### PR TITLE
chore: add ESLint flat config, Prettier and lint-staged

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-task.yml
+++ b/.github/ISSUE_TEMPLATE/01-task.yml
@@ -1,7 +1,7 @@
-name: "Task"
-description: "A unit of implementation work belonging to a milestone"
-title: "[<area>] <short imperative summary>"
-labels: ["type: task", "status: backlog"]
+name: 'Task'
+description: 'A unit of implementation work belonging to a milestone'
+title: '[<area>] <short imperative summary>'
+labels: ['type: task', 'status: backlog']
 body:
   - type: markdown
     attributes:
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Outcome
       description: What is true after this is done that is not true now? Describe the end state, not the activity.
-      placeholder: "`flakemetry-lib/history.ts` reads, merges and atomically writes `.flakemetry/history.json`, capped at N runs per test."
+      placeholder: '`flakemetry-lib/history.ts` reads, merges and atomically writes `.flakemetry/history.json`, capped at N runs per test.'
     validations:
       required: true
 
@@ -51,17 +51,17 @@ body:
     attributes:
       label: Depends on
       description: Issue numbers that must land first.
-      placeholder: "#12, #14"
+      placeholder: '#12, #14'
 
   - type: dropdown
     id: size
     attributes:
       label: Size
       options:
-        - "XS — under an hour"
-        - "S — a few hours"
-        - "M — about a day"
-        - "L — two or more days, consider splitting"
+        - 'XS — under an hour'
+        - 'S — a few hours'
+        - 'M — about a day'
+        - 'L — two or more days, consider splitting'
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/02-bug.yml
+++ b/.github/ISSUE_TEMPLATE/02-bug.yml
@@ -1,26 +1,26 @@
-name: "Bug"
-description: "Something in the pipeline, the app, or the harness behaves incorrectly"
-title: "[bug] <what is wrong>"
-labels: ["type: bug", "status: backlog"]
+name: 'Bug'
+description: 'Something in the pipeline, the app, or the harness behaves incorrectly'
+title: '[bug] <what is wrong>'
+labels: ['type: bug', 'status: backlog']
 body:
   - type: dropdown
     id: component
     attributes:
       label: Component
       options:
-        - "app / server"
-        - "app / client"
-        - "tests / unit"
-        - "tests / e2e"
-        - "flakemetry-lib"
-        - "agents / triage"
-        - "agents / root-cause"
-        - "agents / fix-suggestion"
-        - "agents / orchestrator"
-        - "eval harness"
-        - "golden dataset"
-        - "CI workflow"
-        - "docs"
+        - 'app / server'
+        - 'app / client'
+        - 'tests / unit'
+        - 'tests / e2e'
+        - 'flakemetry-lib'
+        - 'agents / triage'
+        - 'agents / root-cause'
+        - 'agents / fix-suggestion'
+        - 'agents / orchestrator'
+        - 'eval harness'
+        - 'golden dataset'
+        - 'CI workflow'
+        - 'docs'
     validations:
       required: true
 
@@ -58,16 +58,16 @@ body:
     id: run-link
     attributes:
       label: CI run
-      placeholder: "https://github.com/AKogut/ai-flaky-test-triage/actions/runs/..."
+      placeholder: 'https://github.com/AKogut/ai-flaky-test-triage/actions/runs/...'
 
   - type: dropdown
     id: severity
     attributes:
       label: Severity
       options:
-        - "Blocks the pipeline / CI is red"
-        - "Wrong output, pipeline still completes"
-        - "Cosmetic or docs"
+        - 'Blocks the pipeline / CI is red'
+        - 'Wrong output, pipeline still completes'
+        - 'Cosmetic or docs'
     validations:
       required: true
 
@@ -76,5 +76,5 @@ body:
     attributes:
       label: Before filing
       options:
-        - label: "I checked whether this is the classifier being wrong (expected, see eval/report.md) rather than a defect"
+        - label: 'I checked whether this is the classifier being wrong (expected, see eval/report.md) rather than a defect'
           required: true

--- a/.github/ISSUE_TEMPLATE/03-experiment.yml
+++ b/.github/ISSUE_TEMPLATE/03-experiment.yml
@@ -1,7 +1,7 @@
-name: "Experiment"
-description: "A measured investigation — prompt change, ablation, model swap, heuristic tweak"
-title: "[exp] <hypothesis in one line>"
-labels: ["type: experiment", "area: eval", "status: backlog"]
+name: 'Experiment'
+description: 'A measured investigation — prompt change, ablation, model swap, heuristic tweak'
+title: '[exp] <hypothesis in one line>'
+labels: ['type: experiment', 'area: eval', 'status: backlog']
 body:
   - type: markdown
     attributes:
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Decision metric and threshold
       description: Which number decides this, and what value counts as a win? Set this before running.
-      placeholder: "Joint accuracy on the held-out slice, lower bound of the 95% interval, +3pp or better."
+      placeholder: 'Joint accuracy on the held-out slice, lower bound of the 95% interval, +3pp or better.'
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/04-dataset-fixture.yml
+++ b/.github/ISSUE_TEMPLATE/04-dataset-fixture.yml
@@ -1,7 +1,7 @@
-name: "Golden dataset fixture"
-description: "Add or relabel a fixture in the evaluation dataset"
-title: "[dataset] <failure scenario in one line>"
-labels: ["type: dataset", "area: eval", "status: backlog"]
+name: 'Golden dataset fixture'
+description: 'Add or relabel a fixture in the evaluation dataset'
+title: '[dataset] <failure scenario in one line>'
+labels: ['type: dataset', 'area: eval', 'status: backlog']
 body:
   - type: markdown
     attributes:
@@ -22,7 +22,7 @@ body:
     id: owner
     attributes:
       label: Ground truth — owner
-      options: ["app_code", "test_code", "environment"]
+      options: ['app_code', 'test_code', 'environment']
     validations:
       required: true
 
@@ -30,7 +30,7 @@ body:
     id: determinism
     attributes:
       label: Ground truth — determinism
-      options: ["deterministic", "intermittent"]
+      options: ['deterministic', 'intermittent']
     validations:
       required: true
 
@@ -47,9 +47,9 @@ body:
     attributes:
       label: Provenance
       options:
-        - "synthetic — hand-authored"
-        - "captured — from a real CI run"
-        - "mutated — captured run with an injected defect"
+        - 'synthetic — hand-authored'
+        - 'captured — from a real CI run'
+        - 'mutated — captured run with an injected defect'
     validations:
       required: true
 
@@ -58,12 +58,12 @@ body:
     attributes:
       label: Difficulty bucket
       options:
-        - "Hard quadrant (app_code + intermittent)"
-        - "Misleading history"
-        - "Environment dressed as regression"
-        - "Stale test after refactor"
-        - "Cross-file state leak"
-        - "Straightforward"
+        - 'Hard quadrant (app_code + intermittent)'
+        - 'Misleading history'
+        - 'Environment dressed as regression'
+        - 'Stale test after refactor'
+        - 'Cross-file state leak'
+        - 'Straightforward'
     validations:
       required: true
 
@@ -72,8 +72,8 @@ body:
     attributes:
       label: Fixture hygiene
       options:
-        - label: "No ground-truth term (`app_code`, `flaky`, `race`, …) appears in the fixture payload, filename, or test title"
+        - label: 'No ground-truth term (`app_code`, `flaky`, `race`, …) appears in the fixture payload, filename, or test title'
           required: true
-        - label: "The fixture is realistic — it could plausibly come from a real reporter output"
+        - label: 'The fixture is realistic — it could plausibly come from a real reporter output'
           required: true
-        - label: "Marked `lowConfidenceGroundTruth: true` if the label is genuinely arguable"
+        - label: 'Marked `lowConfidenceGroundTruth: true` if the label is genuinely arguable'

--- a/.github/ISSUE_TEMPLATE/05-adr.yml
+++ b/.github/ISSUE_TEMPLATE/05-adr.yml
@@ -1,7 +1,7 @@
-name: "Architecture decision"
-description: "Propose a decision that needs to be recorded as an ADR"
-title: "[adr] <decision to be made>"
-labels: ["type: adr", "area: docs", "status: backlog"]
+name: 'Architecture decision'
+description: 'Propose a decision that needs to be recorded as an ADR'
+title: '[adr] <decision to be made>'
+labels: ['type: adr', 'area: docs', 'status: backlog']
 body:
   - type: markdown
     attributes:
@@ -41,7 +41,7 @@ body:
     id: supersedes
     attributes:
       label: Supersedes
-      placeholder: "ADR-0004"
+      placeholder: 'ADR-0004'
 
   - type: textarea
     id: reversibility

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,7 @@ Closes #
 <!-- Not "tests pass" — what did you actually check, and how would a reviewer reproduce it? -->
 
 ```bash
+
 ```
 
 ## Eval impact
@@ -22,15 +23,15 @@ Closes #
 <!-- REQUIRED when this PR touches agents/, eval/, prompts/, or the golden dataset.
      Paste the before/after table from eval/report.md. Delete this section otherwise. -->
 
-| Metric | Before | After | Δ |
-|---|---|---|---|
-| Joint accuracy (95% CI lower bound) | | | |
-| `owner` accuracy | | | |
-| `determinism` accuracy | | | |
-| Hard-quadrant recall (`app_code` + `intermittent`) | | | |
-| Self-consistency | | | |
-| Cost per fixture | | | |
-| vs. baseline heuristic | | | |
+| Metric                                             | Before | After | Δ   |
+| -------------------------------------------------- | ------ | ----- | --- |
+| Joint accuracy (95% CI lower bound)                |        |       |     |
+| `owner` accuracy                                   |        |       |     |
+| `determinism` accuracy                             |        |       |     |
+| Hard-quadrant recall (`app_code` + `intermittent`) |        |       |     |
+| Self-consistency                                   |        |       |     |
+| Cost per fixture                                   |        |       |     |
+| vs. baseline heuristic                             |        |       |     |
 
 <!-- Prompt version: -->
 <!-- Dataset revision: -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,30 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: "/"
+    directory: '/'
     schedule:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "chore(deps)"
-      prefix-development: "chore(deps-dev)"
+      prefix: 'chore(deps)'
+      prefix-development: 'chore(deps-dev)'
     groups:
       dev-tooling:
-        patterns: ["eslint*", "prettier*", "@typescript-eslint/*", "husky", "commitlint*", "lint-staged"]
+        patterns:
+          ['eslint*', 'prettier*', '@typescript-eslint/*', 'husky', 'commitlint*', 'lint-staged']
       testing:
-        patterns: ["vitest", "@vitest/*", "@playwright/*", "playwright"]
+        patterns: ['vitest', '@vitest/*', '@playwright/*', 'playwright']
       otel:
-        patterns: ["@opentelemetry/*"]
+        patterns: ['@opentelemetry/*']
     ignore:
       # The SDK version is pinned deliberately — a bump can move classifier behaviour,
       # so it is upgraded manually with an eval run attached to the PR.
-      - dependency-name: "@anthropic-ai/sdk"
+      - dependency-name: '@anthropic-ai/sdk'
 
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: '/'
     schedule:
       interval: monthly
     commit-message:
-      prefix: "ci(deps)"
+      prefix: 'ci(deps)'

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -2,101 +2,101 @@
 # Every issue carries exactly one `type:`, one `area:`, one `priority:`, and one `status:`.
 
 # --- type ---------------------------------------------------------------
-- name: "type: task"
-  color: "1d76db"
-  description: "Implementation work"
-- name: "type: bug"
-  color: "d73a4a"
-  description: "Something behaves incorrectly"
-- name: "type: experiment"
-  color: "8a63d2"
-  description: "Measured investigation; may close as not adopted"
-- name: "type: dataset"
-  color: "0e8a16"
-  description: "Golden-dataset fixture work"
-- name: "type: adr"
-  color: "5319e7"
-  description: "Architecture decision to record"
-- name: "type: docs"
-  color: "0075ca"
-  description: "Documentation"
-- name: "type: chore"
-  color: "cfd3d7"
-  description: "Tooling, dependencies, repository config"
+- name: 'type: task'
+  color: '1d76db'
+  description: 'Implementation work'
+- name: 'type: bug'
+  color: 'd73a4a'
+  description: 'Something behaves incorrectly'
+- name: 'type: experiment'
+  color: '8a63d2'
+  description: 'Measured investigation; may close as not adopted'
+- name: 'type: dataset'
+  color: '0e8a16'
+  description: 'Golden-dataset fixture work'
+- name: 'type: adr'
+  color: '5319e7'
+  description: 'Architecture decision to record'
+- name: 'type: docs'
+  color: '0075ca'
+  description: 'Documentation'
+- name: 'type: chore'
+  color: 'cfd3d7'
+  description: 'Tooling, dependencies, repository config'
 
 # --- area ---------------------------------------------------------------
-- name: "area: app"
-  color: "fbca04"
-  description: "TaskFlow application"
-- name: "area: tests"
-  color: "fbca04"
-  description: "Unit and E2E test suites"
-- name: "area: flakemetry"
-  color: "fbca04"
-  description: "flakemetry-lib analysis and history"
-- name: "area: agents"
-  color: "fbca04"
-  description: "Triage, root-cause, fix-suggestion, orchestration"
-- name: "area: prompts"
-  color: "fbca04"
-  description: "Prompt files and rubric"
-- name: "area: eval"
-  color: "fbca04"
-  description: "Evaluation harness, metrics, dataset"
-- name: "area: ci"
-  color: "fbca04"
-  description: "GitHub Actions workflow"
-- name: "area: observability"
-  color: "fbca04"
-  description: "OpenTelemetry, cost and token tracking"
-- name: "area: docs"
-  color: "fbca04"
-  description: "Documentation and wiki"
+- name: 'area: app'
+  color: 'fbca04'
+  description: 'TaskFlow application'
+- name: 'area: tests'
+  color: 'fbca04'
+  description: 'Unit and E2E test suites'
+- name: 'area: flakemetry'
+  color: 'fbca04'
+  description: 'flakemetry-lib analysis and history'
+- name: 'area: agents'
+  color: 'fbca04'
+  description: 'Triage, root-cause, fix-suggestion, orchestration'
+- name: 'area: prompts'
+  color: 'fbca04'
+  description: 'Prompt files and rubric'
+- name: 'area: eval'
+  color: 'fbca04'
+  description: 'Evaluation harness, metrics, dataset'
+- name: 'area: ci'
+  color: 'fbca04'
+  description: 'GitHub Actions workflow'
+- name: 'area: observability'
+  color: 'fbca04'
+  description: 'OpenTelemetry, cost and token tracking'
+- name: 'area: docs'
+  color: 'fbca04'
+  description: 'Documentation and wiki'
 
 # --- priority -----------------------------------------------------------
-- name: "priority: critical"
-  color: "b60205"
-  description: "Blocks the milestone"
-- name: "priority: high"
-  color: "d93f0b"
-  description: "Next up"
-- name: "priority: medium"
-  color: "fbca04"
-  description: "Planned"
-- name: "priority: low"
-  color: "c2e0c6"
-  description: "Nice to have"
+- name: 'priority: critical'
+  color: 'b60205'
+  description: 'Blocks the milestone'
+- name: 'priority: high'
+  color: 'd93f0b'
+  description: 'Next up'
+- name: 'priority: medium'
+  color: 'fbca04'
+  description: 'Planned'
+- name: 'priority: low'
+  color: 'c2e0c6'
+  description: 'Nice to have'
 
 # --- status -------------------------------------------------------------
-- name: "status: backlog"
-  color: "ededed"
-  description: "Not started, not yet refined"
-- name: "status: ready"
-  color: "c5def5"
-  description: "Refined; acceptance criteria are clear enough to start"
-- name: "status: in progress"
-  color: "0e8a16"
-  description: "Actively being worked on"
-- name: "status: in review"
-  color: "5319e7"
-  description: "PR open"
-- name: "status: blocked"
-  color: "b60205"
-  description: "Waiting on something; the blocker is named in the issue"
+- name: 'status: backlog'
+  color: 'ededed'
+  description: 'Not started, not yet refined'
+- name: 'status: ready'
+  color: 'c5def5'
+  description: 'Refined; acceptance criteria are clear enough to start'
+- name: 'status: in progress'
+  color: '0e8a16'
+  description: 'Actively being worked on'
+- name: 'status: in review'
+  color: '5319e7'
+  description: 'PR open'
+- name: 'status: blocked'
+  color: 'b60205'
+  description: 'Waiting on something; the blocker is named in the issue'
 
 # --- cross-cutting ------------------------------------------------------
-- name: "guardrail"
-  color: "e99695"
-  description: "Touches a safety property; needs the PR guardrail checklist"
-- name: "breaking"
-  color: "b60205"
-  description: "Breaks a committed schema or the script contract"
-- name: "good first issue"
-  color: "7057ff"
-  description: "Self-contained, well specified, low context required"
-- name: "help wanted"
-  color: "008672"
-  description: "Input from others especially welcome"
-- name: "spike"
-  color: "d4c5f9"
-  description: "Time-boxed investigation; output is a decision, not code"
+- name: 'guardrail'
+  color: 'e99695'
+  description: 'Touches a safety property; needs the PR guardrail checklist'
+- name: 'breaking'
+  color: 'b60205'
+  description: 'Breaks a committed schema or the script contract'
+- name: 'good first issue'
+  color: '7057ff'
+  description: 'Self-contained, well specified, low context required'
+- name: 'help wanted'
+  color: '008672'
+  description: 'Input from others especially welcome'
+- name: 'spike'
+  color: 'd4c5f9'
+  description: 'Time-boxed investigation; output is a decision, not code'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: "22"
+  NODE_VERSION: '22'
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -150,6 +150,8 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - run: npm ci
+      - run: npm run lint
+      - run: npm run format:check
       - run: npm run typecheck
 
   # ---------------------------------------------------------------------------
@@ -252,7 +254,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0          # agents need real diff history
+          fetch-depth: 0 # agents need real diff history
 
       - uses: actions/setup-node@v4
         with:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,21 @@
+node_modules/
+dist/
+coverage/
+playwright-report/
+test-results/
+
+package-lock.json
+
+# Pipeline outputs — generated, never hand-edited.
+results.json
+analysis.json
+report.md
+otel-spans.json
+
+# Recorded model responses. Reformatting them would change their content hash
+# and invalidate every cassette.
+agents/replay/cassettes/
+
+# Golden-dataset fixtures are byte-compared against reporter output; formatting
+# them would make them stop resembling the thing they are fixtures of.
+eval/golden-dataset/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/prettierrc",
+  "printWidth": 100,
+  "singleQuote": true,
+  "semi": false,
+  "trailingComma": "all",
+  "arrowParens": "always",
+  "endOfLine": "lf",
+  "overrides": [
+    {
+      "files": ["*.md"],
+      "options": {
+        "printWidth": 100,
+        "proseWrap": "preserve"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 
 ## The problem
 
-Flaky-test detectors tell you *which* tests are unstable. They do not tell you *what to do
-about it*. After every red CI run somebody still has to open the trace, read the stack, look
+Flaky-test detectors tell you _which_ tests are unstable. They do not tell you _what to do
+about it_. After every red CI run somebody still has to open the trace, read the stack, look
 at the diff, and decide: is this a real bug, a badly written test, or the runner having a bad
 day? That decision is repetitive, requires context from several places at once, and is exactly
 the kind of work that gets skipped under deadline pressure — which is how a real regression
@@ -84,16 +84,16 @@ Full detail: [`docs/architecture.md`](docs/architecture.md).
 ## Classification taxonomy
 
 A single flat label list (`real_bug | flaky | stale | race_condition`) collapses under its own
-weight — a race condition in application code *is* a real bug, so the labels overlap and the
+weight — a race condition in application code _is_ a real bug, so the labels overlap and the
 ground truth stops being reproducible. Sentra classifies on **two orthogonal axes** instead:
 
-| | `deterministic` | `intermittent` |
-|---|---|---|
-| **`app_code`** | Genuine regression. Fails every run. | Race / ordering bug in the product. Fails sometimes. **The dangerous quadrant.** |
-| **`test_code`** | Stale test — selector or assertion drifted from the app. | Badly synchronised test — missing wait, shared state, ordering assumption. |
-| **`environment`** | Broken setup — missing dep, bad config, wrong Node version. | Infrastructure noise — runner timeout, port collision, network blip. |
+|                   | `deterministic`                                             | `intermittent`                                                                   |
+| ----------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| **`app_code`**    | Genuine regression. Fails every run.                        | Race / ordering bug in the product. Fails sometimes. **The dangerous quadrant.** |
+| **`test_code`**   | Stale test — selector or assertion drifted from the app.    | Badly synchronised test — missing wait, shared state, ordering assumption.       |
+| **`environment`** | Broken setup — missing dep, bad config, wrong Node version. | Infrastructure noise — runner timeout, port collision, network blip.             |
 
-The first axis answers *who owns the fix*. The second answers *how it will behave on rerun*.
+The first axis answers _who owns the fix_. The second answers _how it will behave on rerun_.
 Neither is derivable from the other, and every failure has exactly one cell.
 
 Rationale, edge cases, and labelling rules: [`docs/taxonomy.md`](docs/taxonomy.md).
@@ -132,18 +132,18 @@ cat eval/report.md
 
 ### Script reference
 
-| Script | Milestone | What it does |
-|---|---|---|
-| `npm run dev` | M4 | Start TaskFlow (API + client) locally |
-| `npm run test:unit` | M5 | Vitest — API, flakemetry-lib, prompt builders |
-| `npm run test:e2e` | M5 | Playwright — TaskFlow UI flows incl. flaky specs |
-| `npm test` | M5 | Both, emits `results.json` |
-| `npm run flakemetry:analyze` | M6 | Test report + history → `analysis.json` |
-| `npm run agents:analyze` | M7 | `analysis.json` → `report.md` |
-| `npm run analyze` | M8 | flakemetry + agents in sequence |
-| `npm run eval` | M2 | Golden-dataset evaluation → `eval/report.md` |
-| `npm run eval:ablation` | M9 | Context-ablation study → `eval/ablation.md` |
-| `npm run demo` | M3 | Full pipeline in replay mode, no credentials |
+| Script                       | Milestone | What it does                                     |
+| ---------------------------- | --------- | ------------------------------------------------ |
+| `npm run dev`                | M4        | Start TaskFlow (API + client) locally            |
+| `npm run test:unit`          | M5        | Vitest — API, flakemetry-lib, prompt builders    |
+| `npm run test:e2e`           | M5        | Playwright — TaskFlow UI flows incl. flaky specs |
+| `npm test`                   | M5        | Both, emits `results.json`                       |
+| `npm run flakemetry:analyze` | M6        | Test report + history → `analysis.json`          |
+| `npm run agents:analyze`     | M7        | `analysis.json` → `report.md`                    |
+| `npm run analyze`            | M8        | flakemetry + agents in sequence                  |
+| `npm run eval`               | M2        | Golden-dataset evaluation → `eval/report.md`     |
+| `npm run eval:ablation`      | M9        | Context-ablation study → `eval/ablation.md`      |
+| `npm run demo`               | M3        | Full pipeline in replay mode, no credentials     |
 
 ---
 
@@ -230,22 +230,22 @@ Full write-up: [`docs/limitations-and-guardrails.md`](docs/limitations-and-guard
 ## Roadmap
 
 Work is tracked as milestones, dataset-first — the evaluation harness and a measurable
-classifier land *before* the demo app, so the core hypothesis is tested before time goes into
+classifier land _before_ the demo app, so the core hypothesis is tested before time goes into
 UI.
 
-| Milestone | Theme |
-|---|---|
-| **M0** | Foundations & repo hygiene |
-| **M1** | Contracts, schemas & taxonomy |
-| **M2** | Golden dataset, baseline & eval harness |
-| **M3** | Triage agent + replay mode |
-| **M4** | TaskFlow application |
-| **M5** | Test suite & emergent flakiness |
-| **M6** | flakemetry-lib integration |
-| **M7** | Root-cause & fix-suggestion agents |
-| **M8** | End-to-end CI & PR comment |
-| **M9** | Observability, ablation & cost |
-| **M10** | Documentation, wiki & v1.0 |
+| Milestone | Theme                                   |
+| --------- | --------------------------------------- |
+| **M0**    | Foundations & repo hygiene              |
+| **M1**    | Contracts, schemas & taxonomy           |
+| **M2**    | Golden dataset, baseline & eval harness |
+| **M3**    | Triage agent + replay mode              |
+| **M4**    | TaskFlow application                    |
+| **M5**    | Test suite & emergent flakiness         |
+| **M6**    | flakemetry-lib integration              |
+| **M7**    | Root-cause & fix-suggestion agents      |
+| **M8**    | End-to-end CI & PR comment              |
+| **M9**    | Observability, ablation & cost          |
+| **M10**   | Documentation, wiki & v1.0              |
 
 [Browse the milestones →](https://github.com/AKogut/ai-flaky-test-triage/milestones)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,7 +52,7 @@ its confidence interval — or the finding that it does not is documented in the
 
 The system under test: React + TypeScript client, Express + SQLite API, task CRUD, status filter,
 drag-to-reorder, optimistic updates. Deliberately small. Includes a seedable nondeterminism layer
-so flakiness can be *emergent* rather than scripted.
+so flakiness can be _emergent_ rather than scripted.
 
 **Exit criterion:** `npm run dev` serves a working task board, and `SENTRA_CHAOS=<seed>` reproduces
 a specific interleaving of the optimistic-update race.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,8 +15,8 @@ rather than a public issue. Expect an initial response within 7 days.
 ## What is in scope
 
 - Anything allowing a pull request to obtain repository secrets or a write-scoped token.
-- Prompt injection that escalates beyond a wrong label — i.e. causes the pipeline to *do*
-  something, rather than *say* something wrong.
+- Prompt injection that escalates beyond a wrong label — i.e. causes the pipeline to _do_
+  something, rather than _say_ something wrong.
 - Paths by which an agent could write to the filesystem, push to git, or approve/merge a PR.
 - Leakage of secrets into prompts, logs, spans, or the posted PR comment.
 - Dependency vulnerabilities reachable from the pipeline's execution path.

--- a/agents/tsconfig.json
+++ b/agents/tsconfig.json
@@ -4,11 +4,6 @@
     "rootDir": ".",
     "outDir": "dist"
   },
-  "include": [
-    "**/*.ts"
-  ],
-  "exclude": [
-    "dist",
-    "node_modules"
-  ]
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "node_modules"]
 }

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -2,7 +2,7 @@
   "name": "@sentra/taskflow-client",
   "version": "0.1.0",
   "private": true,
-  "description": "TaskFlow UI \u2014 the system under test. React and TypeScript, deliberately plain.",
+  "description": "TaskFlow UI — the system under test. React and TypeScript, deliberately plain.",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/app/client/tsconfig.json
+++ b/app/client/tsconfig.json
@@ -3,17 +3,8 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "dist",
-    "lib": [
-      "ES2023",
-      "DOM",
-      "DOM.Iterable"
-    ]
+    "lib": ["ES2023", "DOM", "DOM.Iterable"]
   },
-  "include": [
-    "**/*.ts"
-  ],
-  "exclude": [
-    "dist",
-    "node_modules"
-  ]
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "node_modules"]
 }

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -2,7 +2,7 @@
   "name": "@sentra/taskflow-server",
   "version": "0.1.0",
   "private": true,
-  "description": "TaskFlow API \u2014 the system under test. Express and SQLite, deliberately small.",
+  "description": "TaskFlow API — the system under test. Express and SQLite, deliberately small.",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/app/server/tsconfig.json
+++ b/app/server/tsconfig.json
@@ -4,11 +4,6 @@
     "rootDir": ".",
     "outDir": "dist"
   },
-  "include": [
-    "**/*.ts"
-  ],
-  "exclude": [
-    "dist",
-    "node_modules"
-  ]
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "node_modules"]
 }

--- a/docs/adr/0002-two-axis-classification-taxonomy.md
+++ b/docs/adr/0002-two-axis-classification-taxonomy.md
@@ -13,8 +13,8 @@ The initial specification used a flat enum:
 real_bug | flaky_infra | stale_test | race_condition
 ```
 
-These values are not mutually exclusive. `race_condition` names a *mechanism*; `real_bug` names
-*ownership*. A race in the product's optimistic-update path satisfies both, so the labeller
+These values are not mutually exclusive. `race_condition` names a _mechanism_; `real_bug` names
+_ownership_. A race in the product's optimistic-update path satisfies both, so the labeller
 chooses arbitrarily — and chooses differently on a different day.
 
 This is not a cosmetic problem. The entire evaluation strategy rests on a hand-labelled golden
@@ -72,5 +72,5 @@ between the human labelling process and the agent prompt.
 ### What would make us revisit this
 
 Evidence from the confusion matrices that a third axis is being smuggled into one of the existing
-ones — the most likely candidate being *severity* or *actionability*, currently intentionally
+ones — the most likely candidate being _severity_ or _actionability_, currently intentionally
 absent. A superseding ADR would add it as an axis rather than overloading `owner`.

--- a/docs/adr/0003-dataset-first-milestone-ordering.md
+++ b/docs/adr/0003-dataset-first-milestone-ordering.md
@@ -12,14 +12,14 @@ build the AI layer on top of the traces they produce. It follows the data flow, 
 It has two problems. First, the least differentiated part of the project — a small CRUD app with
 drag-and-drop — is also the most time-consuming, and it sits in front of everything that carries
 the actual value. Second, and worse: it defers the only question that can invalidate the project.
-*Can a model classify these failures better than a thirty-line heuristic?* Learning the answer
+_Can a model classify these failures better than a thirty-line heuristic?_ Learning the answer
 after a week of React work is the expensive way to learn it.
 
 ## Decision
 
 The evaluation harness and a measurable triage agent land **before** the application. Fixtures for
 the golden dataset are hand-authored JSON, which requires no app to exist. The application arrives
-at M4, after the core hypothesis has been tested, and its role is then to *extend* the dataset
+at M4, after the core hypothesis has been tested, and its role is then to _extend_ the dataset
 with captured real-world runs rather than to bootstrap it.
 
 Order: contracts (M1) → dataset + baseline + eval (M2) → triage agent (M3) → app (M4) →

--- a/docs/adr/0005-replay-cassettes-for-credential-free-demo.md
+++ b/docs/adr/0005-replay-cassettes-for-credential-free-demo.md
@@ -19,11 +19,11 @@ every CI run.
 
 All model calls route through one wrapper supporting three modes:
 
-| Mode | Trigger | Behaviour |
-|---|---|---|
-| `live` | default, key present | Real API call |
-| `record` | `SENTRA_RECORD=1` | Real call; request/response written to a cassette |
-| `replay` | `SENTRA_REPLAY=1`, or no key present | Cassette lookup; no network |
+| Mode     | Trigger                              | Behaviour                                         |
+| -------- | ------------------------------------ | ------------------------------------------------- |
+| `live`   | default, key present                 | Real API call                                     |
+| `record` | `SENTRA_RECORD=1`                    | Real call; request/response written to a cassette |
+| `replay` | `SENTRA_REPLAY=1`, or no key present | Cassette lookup; no network                       |
 
 Cassettes live in `agents/replay/cassettes/`, are committed, and are keyed by a stable hash of
 (prompt version, model, normalised request body). A replay miss is a loud error, never a silent

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,15 +6,15 @@ have to reconstruct from the code. Format: [MADR](https://adr.github.io/madr/).
 ADRs are immutable once accepted. A changed decision means a new ADR that supersedes the old one
 and links back to it.
 
-| # | Title | Status |
-|---|---|---|
-| [0001](0001-single-repo-no-persistent-services.md) | Single repository, no persistent services | Accepted |
-| [0002](0002-two-axis-classification-taxonomy.md) | Two-axis classification taxonomy | Accepted |
-| [0003](0003-dataset-first-milestone-ordering.md) | Dataset-first milestone ordering | Accepted |
-| [0004](0004-history-persistence-via-ci-cache.md) | History persistence via CI cache, main-only writes | Accepted |
-| [0005](0005-replay-cassettes-for-credential-free-demo.md) | Replay cassettes for a credential-free demo | Accepted |
-| [0006](0006-single-shot-agents-no-loop.md) | Single-shot agents, no agentic loop | Accepted |
-| [0007](0007-no-github-app-no-pull-request-target.md) | No GitHub App, no `pull_request_target` | Accepted |
+| #                                                         | Title                                              | Status   |
+| --------------------------------------------------------- | -------------------------------------------------- | -------- |
+| [0001](0001-single-repo-no-persistent-services.md)        | Single repository, no persistent services          | Accepted |
+| [0002](0002-two-axis-classification-taxonomy.md)          | Two-axis classification taxonomy                   | Accepted |
+| [0003](0003-dataset-first-milestone-ordering.md)          | Dataset-first milestone ordering                   | Accepted |
+| [0004](0004-history-persistence-via-ci-cache.md)          | History persistence via CI cache, main-only writes | Accepted |
+| [0005](0005-replay-cassettes-for-credential-free-demo.md) | Replay cassettes for a credential-free demo        | Accepted |
+| [0006](0006-single-shot-agents-no-loop.md)                | Single-shot agents, no agentic loop                | Accepted |
+| [0007](0007-no-github-app-no-pull-request-target.md)      | No GitHub App, no `pull_request_target`            | Accepted |
 
 ## When an ADR is required
 

--- a/docs/agent-design.md
+++ b/docs/agent-design.md
@@ -63,11 +63,17 @@ function(s) named in the stack trace.
 
 ```ts
 type RootCause = {
-  hypothesis: string          // <= 600 chars, plain prose
+  hypothesis: string // <= 600 chars, plain prose
   implicatedFiles: string[]
   implicatedSymbols: string[]
-  mechanism: 'race' | 'null_handling' | 'state_leak' | 'logic_error'
-            | 'api_contract' | 'timing' | 'other'
+  mechanism:
+    | 'race'
+    | 'null_handling'
+    | 'state_leak'
+    | 'logic_error'
+    | 'api_contract'
+    | 'timing'
+    | 'other'
   confidence: number
   alternativeHypothesis?: string
 }
@@ -87,11 +93,11 @@ makes uncertainty visible in the report rather than buried in a number.
 
 ```ts
 type FixSuggestion = {
-  summary: string             // one sentence
-  approach: string            // prose, <= 800 chars
-  patch?: string              // unified-diff-style snippet, illustrative only
-  risks: string[]             // what this fix could break
-  testGap?: string            // what test would have caught this earlier
+  summary: string // one sentence
+  approach: string // prose, <= 800 chars
+  patch?: string // unified-diff-style snippet, illustrative only
+  risks: string[] // what this fix could break
+  testGap?: string // what test would have caught this earlier
 }
 ```
 
@@ -150,6 +156,6 @@ hunks — all attacker-controllable in a fork PR. Defences:
    bounded strings.
 3. The report escapes agent output before writing markdown, so injected HTML/markdown cannot
    forge report structure.
-4. Nothing downstream *executes* agent output. The worst achievable outcome is a wrong label and
+4. Nothing downstream _executes_ agent output. The worst achievable outcome is a wrong label and
    a misleading comment — bad, but not an escalation.
 5. Fork PRs have no API key at all, which removes most of the surface by construction.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,7 @@ flowchart LR
 ### 1. Test execution → `results.json`
 
 Playwright's JSON reporter and Vitest's JSON reporter emit different shapes. Both are normalised
-into a single internal `TestRun` type at the boundary. The normaliser is the *only* place that
+into a single internal `TestRun` type at the boundary. The normaliser is the _only_ place that
 knows about reporter-specific fields, so a Playwright major bump breaks one file, loudly, with a
 Zod error — not silently, three stages downstream.
 
@@ -64,13 +64,13 @@ type TestRun = {
   runId: string
   commitSha: string
   branch: string
-  startedAt: string          // ISO 8601
+  startedAt: string // ISO 8601
   durationMs: number
   results: TestResult[]
 }
 
 type TestResult = {
-  testId: string             // stable: file path + full title
+  testId: string // stable: file path + full title
   title: string
   file: string
   status: 'passed' | 'failed' | 'timedOut' | 'skipped'
@@ -89,13 +89,13 @@ signal:
 ```ts
 type FlakySignal = {
   testId: string
-  flakinessScore: number     // 0..1, EWMA of pass/fail alternation
+  flakinessScore: number // 0..1, EWMA of pass/fail alternation
   consecutiveFailures: number
   totalRuns: number
   firstSeenAt: string
   lastPassedAt: string | null
-  statusHistory: string      // e.g. "PPPFPFPPF" — most recent last
-  isNew: boolean             // first run in which this test exists
+  statusHistory: string // e.g. "PPPFPFPPF" — most recent last
+  isNew: boolean // first run in which this test exists
 }
 ```
 
@@ -106,15 +106,15 @@ Writes are atomic (write temp, rename) so an interrupted job cannot leave a trun
 
 For each failing or newly-flaky test the orchestrator assembles a **context bundle**:
 
-| Field | Source | Why the agent needs it |
-|---|---|---|
-| Error message + stack | test report | primary evidence |
-| Code snippet at failure | test report | distinguishes assertion from infrastructure failure |
-| Flakiness score + status history | flakemetry-lib | separates deterministic from intermittent |
-| `isNew`, `consecutiveFailures` | flakemetry-lib | a brand-new always-failing test is a different story |
-| Diff of files touched in this commit | `simple-git` | separates app regression from test drift |
-| Whether the diff touches the file under test | derived | the single strongest heuristic signal |
-| Test source | filesystem | detects missing waits, shared state |
+| Field                                        | Source         | Why the agent needs it                               |
+| -------------------------------------------- | -------------- | ---------------------------------------------------- |
+| Error message + stack                        | test report    | primary evidence                                     |
+| Code snippet at failure                      | test report    | distinguishes assertion from infrastructure failure  |
+| Flakiness score + status history             | flakemetry-lib | separates deterministic from intermittent            |
+| `isNew`, `consecutiveFailures`               | flakemetry-lib | a brand-new always-failing test is a different story |
+| Diff of files touched in this commit         | `simple-git`   | separates app regression from test drift             |
+| Whether the diff touches the file under test | derived        | the single strongest heuristic signal                |
+| Test source                                  | filesystem     | detects missing waits, shared state                  |
 
 Context assembly is a pure function with no I/O of its own (paths are read by callers and passed
 in) so it is unit-testable without a git repo or a network.
@@ -133,13 +133,13 @@ it in place instead of appending a new one on every push.
 
 ## State between runs
 
-| What | Where | Why |
-|---|---|---|
-| Test-run history | `actions/cache` keyed on branch, restore-key falls back to `main` | Survives across runs; cache is keyed, unlike artifacts |
-| Golden dataset | Committed to the repo | It is source, not state |
-| Recorded LLM cassettes | Committed under `agents/replay/cassettes/` | Makes the demo reproducible |
-| Eval baseline scores | Committed to `eval/report.md` | Regressions become visible in the diff |
-| OTel spans | Job artifact | Diagnostic only, disposable |
+| What                   | Where                                                             | Why                                                    |
+| ---------------------- | ----------------------------------------------------------------- | ------------------------------------------------------ |
+| Test-run history       | `actions/cache` keyed on branch, restore-key falls back to `main` | Survives across runs; cache is keyed, unlike artifacts |
+| Golden dataset         | Committed to the repo                                             | It is source, not state                                |
+| Recorded LLM cassettes | Committed under `agents/replay/cassettes/`                        | Makes the demo reproducible                            |
+| Eval baseline scores   | Committed to `eval/report.md`                                     | Regressions become visible in the diff                 |
+| OTel spans             | Job artifact                                                      | Diagnostic only, disposable                            |
 
 **Concurrency hazard:** two PR runs finishing at once both read the same history and both write.
 The loser's update is lost. Mitigations, in order of preference: (a) only the `main` branch job
@@ -150,14 +150,14 @@ document it. Option (a) is the plan — see ADR-0004.
 
 The pipeline never fails the build because of its own problems. It degrades:
 
-| Failure | Behaviour |
-|---|---|
-| No API key (fork PR) | Baseline heuristic only, comment states it |
-| API error / rate limit | Retry with backoff; on exhaustion, that test is reported `unclassified` |
-| Token budget exceeded | Stop fanning out, report what was classified, note the truncation |
-| No history file | Treat every test as `isNew`, reduce confidence in intermittency judgements |
-| Malformed test report | Zod error, pipeline step fails loudly — this one *should* be noisy |
-| Zero failures | Skip the agent stage entirely, post nothing |
+| Failure                | Behaviour                                                                  |
+| ---------------------- | -------------------------------------------------------------------------- |
+| No API key (fork PR)   | Baseline heuristic only, comment states it                                 |
+| API error / rate limit | Retry with backoff; on exhaustion, that test is reported `unclassified`    |
+| Token budget exceeded  | Stop fanning out, report what was classified, note the truncation          |
+| No history file        | Treat every test as `isNew`, reduce confidence in intermittency judgements |
+| Malformed test report  | Zod error, pipeline step fails loudly — this one _should_ be noisy         |
+| Zero failures          | Skip the agent stage entirely, post nothing                                |
 
 ## What is deliberately not here
 

--- a/docs/branching-strategy.md
+++ b/docs/branching-strategy.md
@@ -37,27 +37,27 @@ chore/03-eslint-flat-config
 exp/61-multistep-agent-ablation
 ```
 
-| Prefix | Use for |
-|---|---|
-| `feat/` | New capability |
-| `fix/` | Bug fix |
-| `docs/` | Documentation only |
-| `test/` | Tests only |
-| `chore/` | Tooling, deps, CI config |
-| `refactor/` | Behaviour-preserving change |
-| `perf/` | Performance |
-| `exp/` | Experiments and ablations that may never merge |
+| Prefix      | Use for                                        |
+| ----------- | ---------------------------------------------- |
+| `feat/`     | New capability                                 |
+| `fix/`      | Bug fix                                        |
+| `docs/`     | Documentation only                             |
+| `test/`     | Tests only                                     |
+| `chore/`    | Tooling, deps, CI config                       |
+| `refactor/` | Behaviour-preserving change                    |
+| `perf/`     | Performance                                    |
+| `exp/`      | Experiments and ablations that may never merge |
 
 Including the issue number makes the branch self-linking in the GitHub UI and makes stale
 branches traceable to closed work.
 
 ### Protected and special branches
 
-| Branch | Rule |
-|---|---|
-| `main` | Protected. No direct pushes, no force-push, no deletion. PR + green CI required. |
+| Branch               | Rule                                                                              |
+| -------------------- | --------------------------------------------------------------------------------- |
+| `main`               | Protected. No direct pushes, no force-push, no deletion. PR + green CI required.  |
 | `flakemetry-history` | Orphan branch, machine-written only. Excluded from CI. Humans do not commit here. |
-| `gh-pages` | Reserved for a future published eval dashboard. |
+| `gh-pages`           | Reserved for a future published eval dashboard.                                   |
 
 ## Commit convention
 

--- a/docs/eval-methodology.md
+++ b/docs/eval-methodology.md
@@ -26,7 +26,7 @@ else                                                          → intermittent
 ```
 
 Roughly thirty lines. Every agent number is reported **alongside** the baseline on the same
-fixtures, and the headline metric is the *delta*, not the absolute.
+fixtures, and the headline metric is the _delta_, not the absolute.
 
 This has two good outcomes and no bad one. If the agent wins, there is evidence the LLM earns its
 cost. If the baseline wins, that is a genuinely interesting finding that goes in the README, and
@@ -36,15 +36,15 @@ the project demonstrates something rarer than a working classifier: a willingnes
 
 `eval/golden-dataset/` targets **≥60 fixtures**, hand-labelled, with this composition:
 
-| Bucket | Share | Purpose |
-|---|---|---|
-| Hard quadrant: `app_code` + `intermittent` | ~20% | The case the project exists for |
-| Misleading history (long-flaky test failing for a new reason) | ~10% | Punishes flakiness-score-only reasoning |
-| Environment failures dressed as regressions | ~10% | Punishes diff-only reasoning |
-| Stale tests after refactors | ~15% | Common in practice, easy to over-call as `app_code` |
-| Cross-file state leaks | ~10% | Cause and symptom in different files |
-| Straightforward cases | ~25% | Sanity floor; a classifier that fails these is broken |
-| `lowConfidenceGroundTruth` | ~10% | Genuinely ambiguous; excluded from headline metrics, reported separately |
+| Bucket                                                        | Share | Purpose                                                                  |
+| ------------------------------------------------------------- | ----- | ------------------------------------------------------------------------ |
+| Hard quadrant: `app_code` + `intermittent`                    | ~20%  | The case the project exists for                                          |
+| Misleading history (long-flaky test failing for a new reason) | ~10%  | Punishes flakiness-score-only reasoning                                  |
+| Environment failures dressed as regressions                   | ~10%  | Punishes diff-only reasoning                                             |
+| Stale tests after refactors                                   | ~15%  | Common in practice, easy to over-call as `app_code`                      |
+| Cross-file state leaks                                        | ~10%  | Cause and symptom in different files                                     |
+| Straightforward cases                                         | ~25%  | Sanity floor; a classifier that fails these is broken                    |
+| `lowConfidenceGroundTruth`                                    | ~10%  | Genuinely ambiguous; excluded from headline metrics, reported separately |
 
 Each fixture is a `TestRun`-shaped JSON file plus a sibling `.labels.json` carrying ground truth,
 a prose justification for the label, and the rules from
@@ -106,14 +106,14 @@ bin, producing a reliability curve and an **Expected Calibration Error**. Two co
 
 `npm run eval` runs on every PR that touches `agents/`, `eval/`, or `prompts/`. It fails when:
 
-| Condition | Threshold |
-|---|---|
-| Joint accuracy lower bound drops below the recorded main-branch value | −5pp |
-| Joint accuracy lower bound below absolute floor | 0.65 |
-| Agent fails to beat the baseline on joint accuracy | any regression |
-| Self-consistency below floor | 0.80 |
-| Hard-quadrant recall below floor | 0.50 |
-| Cost per fixture rises sharply | +50% |
+| Condition                                                             | Threshold      |
+| --------------------------------------------------------------------- | -------------- |
+| Joint accuracy lower bound drops below the recorded main-branch value | −5pp           |
+| Joint accuracy lower bound below absolute floor                       | 0.65           |
+| Agent fails to beat the baseline on joint accuracy                    | any regression |
+| Self-consistency below floor                                          | 0.80           |
+| Hard-quadrant recall below floor                                      | 0.50           |
+| Cost per fixture rises sharply                                        | +50%           |
 
 Thresholds start permissive and ratchet as the dataset grows. A gate that blocks on noise gets
 disabled by whoever is on call, so the initial values are chosen to be survivable.
@@ -122,16 +122,16 @@ disabled by whoever is on call, so the initial values are chosen to be survivabl
 
 `npm run eval:ablation` re-runs the dataset with parts of the context removed:
 
-| Variant | Question it answers |
-|---|---|
-| Full context | Reference |
-| No history | How much does the flakiness signal contribute? |
-| No diff | How much does git context contribute? |
-| No test source | Does reading the test matter? |
-| Error message only | How far does the trivial input get? |
-| Baseline heuristic | Is the LLM needed at all? |
+| Variant                  | Question it answers                              |
+| ------------------------ | ------------------------------------------------ |
+| Full context             | Reference                                        |
+| No history               | How much does the flakiness signal contribute?   |
+| No diff                  | How much does git context contribute?            |
+| No test source           | Does reading the test matter?                    |
+| Error message only       | How far does the trivial input get?              |
+| Baseline heuristic       | Is the LLM needed at all?                        |
 | Multi-step agent variant | Does a loop beat one call? (see agent-design.md) |
-| Smaller model | What does the capability tier buy? |
+| Smaller model            | What does the capability tier buy?               |
 
 Results go to `eval/ablation.md`. This is the section that turns "I built an AI classifier" into
 "I measured which parts of it work" — and it is also how the context bundle gets pruned, since a

--- a/docs/limitations-and-guardrails.md
+++ b/docs/limitations-and-guardrails.md
@@ -5,14 +5,14 @@ be wrong. This page is a deliverable, not a disclaimer.
 
 ## Capability guardrails — enforced, not promised
 
-| Guardrail | How it is enforced |
-|---|---|
-| Agents never modify the working tree | No filesystem-write tool is registered on any agent. The orchestrator writes exactly one file (`report.md`) and does so itself. A unit test asserts no agent module imports `fs.write*`. |
-| Agents never push, tag, or open PRs | `simple-git` is wrapped in a read-only facade exposing `diff`, `log`, `show` only. |
-| Agents never approve or merge | The workflow's `GITHUB_TOKEN` is scoped `pull-requests: write, contents: read`. It cannot approve its own PRs or merge. |
-| Fix suggestions are never applied | `patch` is a string rendered inside a fenced code block. No code path reaches an apply step. |
-| Cost cannot run away | Per-run token budget; the orchestrator stops dispatching and reports truncation. |
-| The pipeline cannot fail the build on its own errors | The agent job is `continue-on-error`. Only the test job and the eval gate can fail CI. |
+| Guardrail                                            | How it is enforced                                                                                                                                                                       |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Agents never modify the working tree                 | No filesystem-write tool is registered on any agent. The orchestrator writes exactly one file (`report.md`) and does so itself. A unit test asserts no agent module imports `fs.write*`. |
+| Agents never push, tag, or open PRs                  | `simple-git` is wrapped in a read-only facade exposing `diff`, `log`, `show` only.                                                                                                       |
+| Agents never approve or merge                        | The workflow's `GITHUB_TOKEN` is scoped `pull-requests: write, contents: read`. It cannot approve its own PRs or merge.                                                                  |
+| Fix suggestions are never applied                    | `patch` is a string rendered inside a fenced code block. No code path reaches an apply step.                                                                                             |
+| Cost cannot run away                                 | Per-run token budget; the orchestrator stops dispatching and reports truncation.                                                                                                         |
+| The pipeline cannot fail the build on its own errors | The agent job is `continue-on-error`. Only the test job and the eval gate can fail CI.                                                                                                   |
 
 ## What the system genuinely cannot do
 
@@ -50,16 +50,16 @@ Measured, published in `eval/report.md`, and expected:
 content in test names, assertion messages, source comments, or diff hunks — all of which flow
 into a prompt.
 
-| Concern | Position |
-|---|---|
-| Secrets in fork PRs | GitHub does not expose secrets to fork-triggered workflows. That is correct and is not worked around. `pull_request_target` is **not** used — it would run untrusted code with a write-scoped token. |
-| Degraded mode on forks | With no API key the pipeline runs the baseline heuristic only and the comment says so explicitly. |
-| Prompt injection | Untrusted text is delimited, capped, and introduced as data. Output is schema-constrained, so the model can emit enum values and bounded strings, not instructions. |
-| Injection impact ceiling | Nothing executes agent output. The worst outcome is a wrong label and a misleading comment. |
-| Markdown/HTML injection in the report | Agent output is escaped before rendering, so injected content cannot forge report structure or embed hidden markers. |
-| Data leaving the repository | Source snippets and diff hunks are sent to the Anthropic API. This is stated in the README and is the one genuine data-egress path. Private forks should not enable the agent job without understanding it. |
-| Secret leakage into prompts | Context assembly runs a secret-pattern scrub over diffs and source before they enter a prompt. Best-effort, not a guarantee. |
-| Token scope | Least privilege: `pull-requests: write`, `contents: read`. No `actions: write`, no `packages`, no org scope. |
+| Concern                               | Position                                                                                                                                                                                                    |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Secrets in fork PRs                   | GitHub does not expose secrets to fork-triggered workflows. That is correct and is not worked around. `pull_request_target` is **not** used — it would run untrusted code with a write-scoped token.        |
+| Degraded mode on forks                | With no API key the pipeline runs the baseline heuristic only and the comment says so explicitly.                                                                                                           |
+| Prompt injection                      | Untrusted text is delimited, capped, and introduced as data. Output is schema-constrained, so the model can emit enum values and bounded strings, not instructions.                                         |
+| Injection impact ceiling              | Nothing executes agent output. The worst outcome is a wrong label and a misleading comment.                                                                                                                 |
+| Markdown/HTML injection in the report | Agent output is escaped before rendering, so injected content cannot forge report structure or embed hidden markers.                                                                                        |
+| Data leaving the repository           | Source snippets and diff hunks are sent to the Anthropic API. This is stated in the README and is the one genuine data-egress path. Private forks should not enable the agent job without understanding it. |
+| Secret leakage into prompts           | Context assembly runs a secret-pattern scrub over diffs and source before they enter a prompt. Best-effort, not a guarantee.                                                                                |
+| Token scope                           | Least privilege: `pull-requests: write`, `contents: read`. No `actions: write`, no `packages`, no org scope.                                                                                                |
 
 ## Operational limitations
 

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -8,8 +8,8 @@ The obvious design is one enum:
 real_bug | flaky_infra | stale_test | race_condition
 ```
 
-It does not survive contact with real failures. `race_condition` describes a *mechanism*;
-`real_bug` describes *ownership*. A race in the product's optimistic-update path is both, so the
+It does not survive contact with real failures. `race_condition` describes a _mechanism_;
+`real_bug` describes _ownership_. A race in the product's optimistic-update path is both, so the
 labeller has to pick arbitrarily. Two people labelling the same fixture disagree; the same person
 disagrees with themselves a week later. Once ground truth is unreproducible, accuracy measured
 against it is decoration.
@@ -20,26 +20,26 @@ Every failure gets exactly one value on each axis.
 
 ### Axis 1 — `owner`: where the fix goes
 
-| Value | Meaning | Typical evidence |
-|---|---|---|
-| `app_code` | The product is wrong. The test correctly caught it. | Diff touches the implementation under test; assertion failure on a value, not a locator; error surfaces from application code in the stack |
-| `test_code` | The product is fine. The test is wrong, stale, or badly synchronised. | Locator/timeout error; test asserts immediately after an async action; diff touches only the spec; shared fixture mutated across tests |
-| `environment` | Neither. The run itself was broken. | Port already in use; DNS/network error; missing binary; OOM; runner timeout with no assertion reached; browser launch failure |
+| Value         | Meaning                                                               | Typical evidence                                                                                                                           |
+| ------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `app_code`    | The product is wrong. The test correctly caught it.                   | Diff touches the implementation under test; assertion failure on a value, not a locator; error surfaces from application code in the stack |
+| `test_code`   | The product is fine. The test is wrong, stale, or badly synchronised. | Locator/timeout error; test asserts immediately after an async action; diff touches only the spec; shared fixture mutated across tests     |
+| `environment` | Neither. The run itself was broken.                                   | Port already in use; DNS/network error; missing binary; OOM; runner timeout with no assertion reached; browser launch failure              |
 
 ### Axis 2 — `determinism`: how it behaves on rerun
 
-| Value | Meaning | Typical evidence |
-|---|---|---|
+| Value           | Meaning                                     | Typical evidence                                                                                                                   |
+| --------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | `deterministic` | Fails every time under the same conditions. | `statusHistory` shows an unbroken failure streak; failed on all retry attempts; flakiness score near 0 with current status failing |
-| `intermittent` | Fails some of the time. | Alternating pass/fail history; passed on retry within the same run; high flakiness score |
+| `intermittent`  | Fails some of the time.                     | Alternating pass/fail history; passed on retry within the same run; high flakiness score                                           |
 
 ### The resulting matrix
 
-|                   | `deterministic` | `intermittent` |
-|-------------------|---|---|
-| **`app_code`**     | **Regression.** Ship-blocking. The common, easy case. | **Product race.** The dangerous quadrant — looks like a flaky test, is actually a bug that will hit users. |
-| **`test_code`**    | **Stale test.** Selector or assertion drifted from the app. Fix or delete the test. | **Unsynchronised test.** Missing wait, ordering assumption, shared state. Fix the test. |
-| **`environment`**  | **Broken setup.** Missing dependency, bad config, wrong runtime version. Fix CI. | **Infra noise.** Runner blip, port collision, network flake. Rerun, then track frequency. |
+|                   | `deterministic`                                                                     | `intermittent`                                                                                             |
+| ----------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **`app_code`**    | **Regression.** Ship-blocking. The common, easy case.                               | **Product race.** The dangerous quadrant — looks like a flaky test, is actually a bug that will hit users. |
+| **`test_code`**   | **Stale test.** Selector or assertion drifted from the app. Fix or delete the test. | **Unsynchronised test.** Missing wait, ordering assumption, shared state. Fix the test.                    |
+| **`environment`** | **Broken setup.** Missing dependency, bad config, wrong runtime version. Fix CI.    | **Infra noise.** Runner blip, port collision, network flake. Rerun, then track frequency.                  |
 
 ## Why this is the useful split
 
@@ -69,9 +69,9 @@ harness reports this quadrant separately for that reason.
 type Classification = {
   owner: 'app_code' | 'test_code' | 'environment'
   determinism: 'deterministic' | 'intermittent'
-  confidence: number          // 0..1, calibration measured — see eval-methodology.md
-  reasoning: string           // <= 400 chars, must cite specific evidence
-  evidence: string[]          // quoted fragments from the input the decision rests on
+  confidence: number // 0..1, calibration measured — see eval-methodology.md
+  reasoning: string // <= 400 chars, must cite specific evidence
+  evidence: string[] // quoted fragments from the input the decision rests on
 }
 ```
 
@@ -103,14 +103,14 @@ metrics.
 
 Each of these is represented in the golden dataset on purpose.
 
-| Case | Correct label | Why it is hard |
-|---|---|---|
-| Optimistic UI update races the API response; test is correctly written and waits properly | `app_code` + `intermittent` | Looks identical to a flaky test from the outside |
-| Test passes locally, fails only on CI's slower runner, product is fine | `test_code` + `intermittent` | Tempting to blame `environment`; the test's timeout assumption is the defect |
-| Selector matches two elements only when the list has ≥3 items | `test_code` + `intermittent` | Intermittency comes from data, not timing |
-| Real regression introduced in the same commit that also bumps a dependency | `app_code` + `deterministic` | Diff noise invites an `environment` misclassification |
-| Suite passes, one test times out because a prior test left a modal open | `test_code` + `intermittent` | Failure and cause are in different files |
-| Flaky test that has been flaky for 200 runs and today is failing for a *new* reason | `app_code` + `deterministic` | History actively misleads |
+| Case                                                                                      | Correct label                | Why it is hard                                                               |
+| ----------------------------------------------------------------------------------------- | ---------------------------- | ---------------------------------------------------------------------------- |
+| Optimistic UI update races the API response; test is correctly written and waits properly | `app_code` + `intermittent`  | Looks identical to a flaky test from the outside                             |
+| Test passes locally, fails only on CI's slower runner, product is fine                    | `test_code` + `intermittent` | Tempting to blame `environment`; the test's timeout assumption is the defect |
+| Selector matches two elements only when the list has ≥3 items                             | `test_code` + `intermittent` | Intermittency comes from data, not timing                                    |
+| Real regression introduced in the same commit that also bumps a dependency                | `app_code` + `deterministic` | Diff noise invites an `environment` misclassification                        |
+| Suite passes, one test times out because a prior test left a modal open                   | `test_code` + `intermittent` | Failure and cause are in different files                                     |
+| Flaky test that has been flaky for 200 runs and today is failing for a _new_ reason       | `app_code` + `deterministic` | History actively misleads                                                    |
 
 The last row is the one that punishes over-reliance on flakiness score — the metric a
 history-only baseline is built on.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,118 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
+import prettier from 'eslint-config-prettier'
+
+/**
+ * Flat config. Formatting is Prettier's job entirely — `eslint-config-prettier`
+ * is applied last and turns off every stylistic rule that could disagree with it,
+ * so there is exactly one tool with an opinion about whitespace.
+ */
+
+/** Node's filesystem and process-spawning modules, in both bare and prefixed form. */
+const IO_MODULES = ['fs', 'node:fs', 'fs/promises', 'node:fs/promises']
+const EXEC_MODULES = ['child_process', 'node:child_process']
+
+const restrict = (modules, message) => modules.map((name) => ({ name, message }))
+
+export default tseslint.config(
+  {
+    ignores: [
+      '**/dist/**',
+      '**/node_modules/**',
+      'coverage/**',
+      'playwright-report/**',
+      'test-results/**',
+      '**/*.d.ts',
+    ],
+  },
+
+  js.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  ...tseslint.configs.stylisticTypeChecked,
+
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+      globals: { ...globals.node },
+    },
+    rules: {
+      // The orchestrator fans out asynchronous work. A dropped promise there would
+      // silently swallow one test's entire classification and report success, which
+      // is the worst failure shape this pipeline can have.
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+
+      // verbatimModuleSyntax is on, so the type/value distinction has to be explicit
+      // anyway. Enforcing it here makes the compiler error arrive as a lint fix.
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        { prefer: 'type-imports', fixStyle: 'inline-type-imports' },
+      ],
+
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
+      ],
+
+      // Every entry point here is a CLI. Printing is the interface.
+      'no-console': 'off',
+
+      eqeqeq: ['error', 'always', { null: 'ignore' }],
+      'no-param-reassign': 'error',
+      'prefer-const': ['error', { destructuring: 'all' }],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Guardrail: agents cannot touch the filesystem or spawn processes.
+  //
+  // docs/limitations-and-guardrails.md promises that agents never modify the
+  // working tree. A promise kept by discipline is not a guardrail; this makes it
+  // a build failure.
+  //
+  // The orchestrator and the report writer are deliberately outside this scope —
+  // they are the one component allowed to write, and exactly one file. That is
+  // asserted at runtime instead, by the guardrail suite in #69.
+  // ---------------------------------------------------------------------------
+  {
+    files: [
+      'agents/triage/**/*.ts',
+      'agents/root-cause/**/*.ts',
+      'agents/fix-suggestion/**/*.ts',
+      'agents/context/**/*.ts',
+      'agents/prompts/**/*.ts',
+    ],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            ...restrict(
+              IO_MODULES,
+              'Agents have no filesystem access. Callers read paths and pass the contents in — see docs/limitations-and-guardrails.md.',
+            ),
+            ...restrict(
+              EXEC_MODULES,
+              'Agents cannot spawn processes. Git access goes through the read-only facade — see docs/limitations-and-guardrails.md.',
+            ),
+          ],
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Config and script files are plain JavaScript and are not in any tsconfig,
+  // so type-aware rules cannot run against them.
+  // ---------------------------------------------------------------------------
+  {
+    files: ['**/*.js', '**/*.mjs', '**/*.cjs'],
+    extends: [tseslint.configs.disableTypeChecked],
+  },
+
+  prettier,
+)

--- a/eval/tsconfig.json
+++ b/eval/tsconfig.json
@@ -4,11 +4,6 @@
     "rootDir": ".",
     "outDir": "dist"
   },
-  "include": [
-    "**/*.ts"
-  ],
-  "exclude": [
-    "dist",
-    "node_modules"
-  ]
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "node_modules"]
 }

--- a/flakemetry-lib/tsconfig.json
+++ b/flakemetry-lib/tsconfig.json
@@ -4,11 +4,6 @@
     "rootDir": ".",
     "outDir": "dist"
   },
-  "include": [
-    "**/*.ts"
-  ],
-  "exclude": [
-    "dist",
-    "node_modules"
-  ]
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "node_modules"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,15 @@
         "eval"
       ],
       "devDependencies": {
+        "@eslint/js": "9.39.5",
         "@types/node": "^22.10.2",
-        "typescript": "^5.7.2"
+        "eslint": "9.39.5",
+        "eslint-config-prettier": "9.1.0",
+        "globals": "15.14.0",
+        "lint-staged": "15.5.2",
+        "prettier": "3.4.2",
+        "typescript": "^5.7.2",
+        "typescript-eslint": "8.46.4"
       },
       "engines": {
         "node": ">=22"
@@ -48,6 +55,267 @@
       "version": "0.1.0",
       "license": "MIT"
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@sentra/agents": {
       "resolved": "agents",
       "link": true
@@ -68,6 +336,20 @@
       "resolved": "app/server",
       "link": true
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
@@ -78,10 +360,1883 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.4.tgz",
+      "integrity": "sha512-R48VhmTJqplNyDxCyqqVkFSZIx1qX6PzwqgcXn1olLrzxcSBDlOsbtcnQuQhNtnNiJ4Xe5gREI1foajYaYU2Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.46.4",
+        "@typescript-eslint/type-utils": "8.46.4",
+        "@typescript-eslint/utils": "8.46.4",
+        "@typescript-eslint/visitor-keys": "8.46.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^7.0.0",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.46.4",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.4.tgz",
+      "integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.46.4",
+        "@typescript-eslint/types": "8.46.4",
+        "@typescript-eslint/typescript-estree": "8.46.4",
+        "@typescript-eslint/visitor-keys": "8.46.4",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.4.tgz",
+      "integrity": "sha512-nPiRSKuvtTN+no/2N1kt2tUh/HoFzeEgOm9fQ6XQk4/ApGqjx0zFIIaLJ6wooR1HIoozvj2j6vTi/1fgAz7UYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.46.4",
+        "@typescript-eslint/types": "^8.46.4",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.4.tgz",
+      "integrity": "sha512-tMDbLGXb1wC+McN1M6QeDx7P7c0UWO5z9CXqp7J8E+xGcJuUuevWKxuG8j41FoweS3+L41SkyKKkia16jpX7CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.46.4",
+        "@typescript-eslint/visitor-keys": "8.46.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.4.tgz",
+      "integrity": "sha512-+/XqaZPIAk6Cjg7NWgSGe27X4zMGqrFqZ8atJsX3CWxH/jACqWnrWI68h7nHQld0y+k9eTTjb9r+KU4twLoo9A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.4.tgz",
+      "integrity": "sha512-V4QC8h3fdT5Wro6vANk6eojqfbv5bpwHuMsBcJUJkqs2z5XnYhJzyz9Y02eUmF9u3PgXEUiOt4w4KHR3P+z0PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.46.4",
+        "@typescript-eslint/typescript-estree": "8.46.4",
+        "@typescript-eslint/utils": "8.46.4",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.4.tgz",
+      "integrity": "sha512-USjyxm3gQEePdUwJBFjjGNG18xY9A2grDVGuk7/9AkjIF1L+ZrVnwR5VAU5JXtUnBL/Nwt3H31KlRDaksnM7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.4.tgz",
+      "integrity": "sha512-7oV2qEOr1d4NWNmpXLR35LvCfOkTNymY9oyW+lUHkmCno7aOmIf/hMaydnJBUTBMRCOGZh8YjkFOc8dadEoNGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.46.4",
+        "@typescript-eslint/tsconfig-utils": "8.46.4",
+        "@typescript-eslint/types": "8.46.4",
+        "@typescript-eslint/visitor-keys": "8.46.4",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.4.tgz",
+      "integrity": "sha512-AbSv11fklGXV6T28dp2Me04Uw90R2iJ30g2bgLz529Koehrmkbs1r7paFqr1vPCZi7hHwYxYtxfyQMRC8QaVSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.46.4",
+        "@typescript-eslint/types": "8.46.4",
+        "@typescript-eslint/typescript-estree": "8.46.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.4.tgz",
+      "integrity": "sha512-/++5CYLQqsO9HFGLI7APrxBJYo+5OCMpViuhV8q5/Qa3o5mMrF//eQHks+PXcsAVaLdn817fMuS7zqoXNNZGaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.46.4",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "15.14.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.14.0.tgz",
+      "integrity": "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lint-staged": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
+      "integrity": "sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^13.1.0",
+        "debug": "^4.4.0",
+        "execa": "^8.0.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^8.2.5",
+        "micromatch": "^4.0.8",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.7.0"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.2.5.tgz",
+      "integrity": "sha512-iyAZCeyD+c1gPyE9qpFu8af0Y+MRtmKOncdGoA2S5EY8iFq99dmmvkNnHiWo+pj0s7yH7l3KPIgee77tKpXPWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^4.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.1.tgz",
+      "integrity": "sha512-e0F9AOF1JMrCfBsyJOwU9lNvQ0WtXTq0j/4jk0BQ5JSI9VAybPXmDpPRw/2FQ3e5d3ZFN1mLh7jW99m/jjaptw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -92,12 +2247,132 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-eslint": {
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.4.tgz",
+      "integrity": "sha512-KALyxkpYV5Ix7UhvjTwJXZv76VWsHG+NjNlt/z+a17SOQSiOcBdUXdbJdyXi7RPxrBFECtFOiPwUJQusJuCqrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.46.4",
+        "@typescript-eslint/parser": "8.46.4",
+        "@typescript-eslint/typescript-estree": "8.46.4",
+        "@typescript-eslint/utils": "8.46.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,11 +21,31 @@
     "eval"
   ],
   "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "typecheck": "tsc --build",
     "typecheck:clean": "tsc --build --clean"
   },
   "devDependencies": {
+    "@eslint/js": "9.39.5",
     "@types/node": "^22.10.2",
-    "typescript": "^5.7.2"
+    "eslint": "9.39.5",
+    "eslint-config-prettier": "9.1.0",
+    "globals": "15.14.0",
+    "lint-staged": "15.5.2",
+    "prettier": "3.4.2",
+    "typescript": "^5.7.2",
+    "typescript-eslint": "8.46.4"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,mjs,cjs}": [
+      "eslint --fix --max-warnings=0",
+      "prettier --write"
+    ],
+    "*.{json,md,yml,yaml}": [
+      "prettier --write"
+    ]
   }
 }

--- a/wiki/Agent-Design.md
+++ b/wiki/Agent-Design.md
@@ -5,11 +5,11 @@
 
 ## Three agents, three single calls
 
-| Agent | Runs for | Produces |
-|---|---|---|
-| **Triage** | every failing or newly-flaky test | two-axis classification, confidence, quoted evidence |
-| **Root cause** | `app_code` above the calibrated threshold | a hypothesis, implicated files and symbols, a mechanism, a mandatory alternative when unsure |
-| **Fix suggestion** | root causes above threshold | prose approach, an illustrative patch, **risks**, and the missing test |
+| Agent              | Runs for                                  | Produces                                                                                     |
+| ------------------ | ----------------------------------------- | -------------------------------------------------------------------------------------------- |
+| **Triage**         | every failing or newly-flaky test         | two-axis classification, confidence, quoted evidence                                         |
+| **Root cause**     | `app_code` above the calibrated threshold | a hypothesis, implicated files and symbols, a mechanism, a mandatory alternative when unsure |
+| **Fix suggestion** | root causes above threshold               | prose approach, an illustrative patch, **risks**, and the missing test                       |
 
 No loops. No scratchpads. No self-critique passes. No tools beyond the structured-output schema.
 

--- a/wiki/Architecture-Overview.md
+++ b/wiki/Architecture-Overview.md
@@ -46,7 +46,7 @@ stages later.
 
 **Flakiness analysis.** Merges the current run against the stored history and produces per-test
 signal: an alternation-weighted flakiness score, a failure streak, whether the test is new. The
-scoring measures *alternation*, not failure rate — a test that fails 100% of the time is not flaky,
+scoring measures _alternation_, not failure rate — a test that fails 100% of the time is not flaky,
 it is broken, and conflating those would put every genuine regression in the `intermittent` bucket.
 
 **Context assembly.** The most consequential and least glamorous stage. It turns one entry in
@@ -92,7 +92,7 @@ So every failure mode degrades and announces itself: no API key on a fork PR →
 only; API error → that one test is `unclassified`; budget exhausted → stop dispatching and say how
 many were dropped; no history → reduced confidence, stated.
 
-The one exception is a malformed test report, which fails loudly. That one *should* be noisy — it
+The one exception is a malformed test report, which fails loudly. That one _should_ be noisy — it
 means a contract broke.
 
 ## What is deliberately absent

--- a/wiki/Classification-Taxonomy.md
+++ b/wiki/Classification-Taxonomy.md
@@ -13,7 +13,7 @@ real_bug | flaky_infra | stale_test | race_condition
 ```
 
 It reads fine and it does not survive contact with real failures. `race_condition` names a
-*mechanism*; `real_bug` names *ownership*. A race in a product's optimistic-update path is both, so
+_mechanism_; `real_bug` names _ownership_. A race in a product's optimistic-update path is both, so
 the person labelling has to choose arbitrarily — and chooses differently a week later.
 
 That is not a cosmetic problem. Everything this project claims about itself rests on a hand-labelled
@@ -30,11 +30,11 @@ study, the calibration curve — all of them inherit the noise.
 Every failure gets exactly one value on each. The axes are independent: knowing something is
 intermittent tells you nothing about whether the product or the test is at fault.
 
-|                   | `deterministic` | `intermittent` |
-|-------------------|---|---|
-| **`app_code`**     | Regression | **Product race** |
-| **`test_code`**    | Stale test | Unsynchronised test |
-| **`environment`**  | Broken setup | Infra noise |
+|                   | `deterministic` | `intermittent`      |
+| ----------------- | --------------- | ------------------- |
+| **`app_code`**    | Regression      | **Product race**    |
+| **`test_code`**   | Stale test      | Unsynchronised test |
+| **`environment`** | Broken setup    | Infra noise         |
 
 ## Why these two questions
 
@@ -70,14 +70,14 @@ that out and say so.
 
 Each of these is in the golden dataset on purpose, because each defeats one tempting shortcut:
 
-| Case | Truth | What it defeats |
-|---|---|---|
-| Optimistic update races the API; test is correct and waits properly | `app_code` + `intermittent` | "Intermittent means flaky test" |
-| Test passes locally, fails on a slower CI runner; product is fine | `test_code` + `intermittent` | "Slower runner means environment" |
-| Selector matches two elements only when the list has ≥3 items | `test_code` + `intermittent` | "Intermittent means timing" |
-| Real regression in a commit that also bumps a dependency | `app_code` + `deterministic` | Diff-noise reasoning |
-| Test times out because a prior test left a modal open | `test_code` + `intermittent` | Single-test-in-isolation reasoning |
-| Long-flaky test failing today for a **new** reason | `app_code` + `deterministic` | Flakiness-score reasoning |
+| Case                                                                | Truth                        | What it defeats                    |
+| ------------------------------------------------------------------- | ---------------------------- | ---------------------------------- |
+| Optimistic update races the API; test is correct and waits properly | `app_code` + `intermittent`  | "Intermittent means flaky test"    |
+| Test passes locally, fails on a slower CI runner; product is fine   | `test_code` + `intermittent` | "Slower runner means environment"  |
+| Selector matches two elements only when the list has ≥3 items       | `test_code` + `intermittent` | "Intermittent means timing"        |
+| Real regression in a commit that also bumps a dependency            | `app_code` + `deterministic` | Diff-noise reasoning               |
+| Test times out because a prior test left a modal open               | `test_code` + `intermittent` | Single-test-in-isolation reasoning |
+| Long-flaky test failing today for a **new** reason                  | `app_code` + `deterministic` | Flakiness-score reasoning          |
 
 The last one is the sharpest. It punishes exactly the feature a history-only baseline is built on,
 which is what makes the baseline comparison meaningful rather than a straw man.

--- a/wiki/Evaluation-Methodology.md
+++ b/wiki/Evaluation-Methodology.md
@@ -41,15 +41,15 @@ fair control rather than a straw man.
 
 Roughly 60 fixtures, weighted towards the cases that defeat obvious shortcuts:
 
-| Bucket | Share |
-|---|---|
-| Hard quadrant (`app_code` + `intermittent`) | ~20% |
-| Misleading history | ~10% |
-| Environment dressed as regression | ~10% |
-| Stale tests after refactors | ~15% |
-| Cross-file state leaks | ~10% |
-| Straightforward | ~25% |
-| Genuinely ambiguous (excluded from headline) | ~10% |
+| Bucket                                       | Share |
+| -------------------------------------------- | ----- |
+| Hard quadrant (`app_code` + `intermittent`)  | ~20%  |
+| Misleading history                           | ~10%  |
+| Environment dressed as regression            | ~10%  |
+| Stale tests after refactors                  | ~15%  |
+| Cross-file state leaks                       | ~10%  |
+| Straightforward                              | ~25%  |
+| Genuinely ambiguous (excluded from headline) | ~10%  |
 
 Fixtures carry their **provenance**: `synthetic` (hand-authored), `captured` (from a real CI run,
 labelled after the fact), `mutated` (a real run with an injected defect). Metrics are broken down by

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -11,7 +11,7 @@ study measuring what each piece of context contributes, is the part that is not 
 
 ## How is this different from Flakemetry or similar tools?
 
-Those detect *which* tests are unstable. This decides *what to do about a specific failure* — is it
+Those detect _which_ tests are unstable. This decides _what to do about a specific failure_ — is it
 the product, the test, or the runner, and will rerunning help. Flakemetry-style analysis is consumed
 here as a library; this project is the layer above it.
 
@@ -29,7 +29,7 @@ Once ground truth stops being reproducible, every metric built on it is decorati
 Yes — `npm run demo` runs the whole pipeline against recorded model responses, offline and free. The
 test suite and the evaluation harness also run in replay mode.
 
-You need a key only to classify a *new* failure with a live model.
+You need a key only to classify a _new_ failure with a live model.
 
 ## Why is the accuracy number not higher?
 

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -79,14 +79,14 @@ optimistic-update race is captured for the dataset rather than waited for.
 
 ## Where things end up
 
-| File | Written by | Committed? |
-|---|---|---|
-| `results.json` | the test run | no |
-| `analysis.json` | `flakemetry:analyze` | no |
-| `report.md` | `agents:analyze` | no |
-| `otel-spans.json` | the agents' instrumentation | no |
-| `eval/report.md` | `npm run eval` | **yes** — a regression shows up as a diff |
-| `.flakemetry/history.json` | CI, on `main` only | no — lives in the CI cache |
+| File                       | Written by                  | Committed?                                |
+| -------------------------- | --------------------------- | ----------------------------------------- |
+| `results.json`             | the test run                | no                                        |
+| `analysis.json`            | `flakemetry:analyze`        | no                                        |
+| `report.md`                | `agents:analyze`            | no                                        |
+| `otel-spans.json`          | the agents' instrumentation | no                                        |
+| `eval/report.md`           | `npm run eval`              | **yes** — a regression shows up as a diff |
+| `.flakemetry/history.json` | CI, on `main` only          | no — lives in the CI cache                |
 
 ## Common questions
 

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -55,7 +55,7 @@ flakiness scripted into a test. Only the former produces a classification proble
 **EWMA** — exponentially weighted moving average, used for the flakiness score so that recent runs
 count more than old ones.
 
-**Flakiness score** — a 0..1 measure of how much a test *alternates*, not how often it fails. A test
+**Flakiness score** — a 0..1 measure of how much a test _alternates_, not how often it fails. A test
 that fails every time scores near zero: it is broken, not flaky.
 
 **Golden dataset** — the hand-labelled fixtures every metric in the project is computed against.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -2,7 +2,7 @@
 
 **An AI triage layer for CI test failures — packaged as a pipeline step, not a service.**
 
-Flaky-test detectors tell you *which* tests are unstable. They do not tell you what to do about it.
+Flaky-test detectors tell you _which_ tests are unstable. They do not tell you what to do about it.
 After every red CI run somebody still has to open the trace, read the stack, look at the diff, and
 decide: is this a real bug, a badly written test, or the runner having a bad day? Sentra automates
 that decision and posts the result as a single pull-request comment.
@@ -35,10 +35,10 @@ code, including several where the easy answer was rejected.
 
 Two surfaces, one rule.
 
-| | Holds | Why |
-|---|---|---|
-| **[`docs/`](https://github.com/AKogut/ai-flaky-test-triage/tree/main/docs)** in the repository | Normative specifications: schemas, contracts, labelling rules, ADRs | Versioned with the code, so it must match the code exactly. A PR that changes behaviour changes these in the same commit. |
-| **This wiki** | Orientation and narrative: how the pieces fit, why decisions were made, what to read first | Free to be discursive; nothing here is a contract |
+|                                                                                                | Holds                                                                                      | Why                                                                                                                       |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| **[`docs/`](https://github.com/AKogut/ai-flaky-test-triage/tree/main/docs)** in the repository | Normative specifications: schemas, contracts, labelling rules, ADRs                        | Versioned with the code, so it must match the code exactly. A PR that changes behaviour changes these in the same commit. |
+| **This wiki**                                                                                  | Orientation and narrative: how the pieces fit, why decisions were made, what to read first | Free to be discursive; nothing here is a contract                                                                         |
 
 Nothing is duplicated between them. The wiki links into `docs/` rather than restating it, because
 two copies of a specification means one of them is wrong.
@@ -49,13 +49,13 @@ two copies of a specification means one of them is wrong.
 
 Every test failure is classified on two orthogonal axes rather than a single flat label:
 
-| | `deterministic` | `intermittent` |
-|---|---|---|
-| **`app_code`** | Regression. Ship-blocking. | **Product race — the dangerous quadrant.** |
-| **`test_code`** | Stale test. | Unsynchronised test. |
-| **`environment`** | Broken setup. | Infrastructure noise. |
+|                   | `deterministic`            | `intermittent`                             |
+| ----------------- | -------------------------- | ------------------------------------------ |
+| **`app_code`**    | Regression. Ship-blocking. | **Product race — the dangerous quadrant.** |
+| **`test_code`**   | Stale test.                | Unsynchronised test.                       |
+| **`environment`** | Broken setup.              | Infrastructure noise.                      |
 
-The first axis answers *is this mine?* The second answers *will rerunning help?* Neither is
+The first axis answers _is this mine?_ The second answers _will rerunning help?_ Neither is
 derivable from the other, and that ambiguity is precisely where triage effort goes.
 
 Why not a single flat label: [Classification Taxonomy](Classification-Taxonomy).
@@ -67,7 +67,7 @@ Why not a single flat label: [Classification Taxonomy](Classification-Taxonomy).
 Three things, all of which are measured rather than claimed:
 
 1. **A non-LLM baseline.** A thirty-line heuristic classifies the same dataset. Every reported
-   number is the agent *relative to that*. If the heuristic wins, the README says the heuristic
+   number is the agent _relative to that_. If the heuristic wins, the README says the heuristic
    wins.
 2. **An adversarial dataset.** The fixtures deliberately over-weight cases designed to defeat the
    obvious shortcuts — real races that look like flakes, environment noise inside a suspicious

--- a/wiki/Limitations-and-Guardrails.md
+++ b/wiki/Limitations-and-Guardrails.md
@@ -11,14 +11,14 @@ unusually clear about its own.
 The distinction that matters: these are not promises, they are **absent capabilities**, and an
 executable test suite asserts each one.
 
-| Guarantee | How it holds |
-|---|---|
-| Never modify the working tree | No agent has a filesystem-write tool. The orchestrator writes exactly one file. A static check fails the build if any module under `agents/` imports an `fs` write API. |
-| Never push, tag, or commit | `simple-git` is reachable only through a facade exposing `diff`, `log`, `show`. Importing it elsewhere is a lint error. |
-| Never approve or merge | The workflow token is scoped `pull-requests: write, contents: read`. It cannot approve its own pull requests. |
-| Fix suggestions are never applied | `patch` is a string rendered inside a fenced code block. There is no code path from it to an apply step. |
-| Cost cannot run away | A per-run token budget stops dispatch and reports the truncation. |
-| Cannot fail your build | The analysis job is `continue-on-error`. Only the tests and the eval gate can turn CI red. |
+| Guarantee                         | How it holds                                                                                                                                                            |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Never modify the working tree     | No agent has a filesystem-write tool. The orchestrator writes exactly one file. A static check fails the build if any module under `agents/` imports an `fs` write API. |
+| Never push, tag, or commit        | `simple-git` is reachable only through a facade exposing `diff`, `log`, `show`. Importing it elsewhere is a lint error.                                                 |
+| Never approve or merge            | The workflow token is scoped `pull-requests: write, contents: read`. It cannot approve its own pull requests.                                                           |
+| Fix suggestions are never applied | `patch` is a string rendered inside a fenced code block. There is no code path from it to an apply step.                                                                |
+| Cost cannot run away              | A per-run token budget stops dispatch and reports the truncation.                                                                                                       |
+| Cannot fail your build            | The analysis job is `continue-on-error`. Only the tests and the eval gate can turn CI red.                                                                              |
 
 A promise enforced by discipline is not a guardrail. A promise enforced by the absence of a
 capability holds in six months, in a hurry, when nobody is thinking about it.
@@ -62,7 +62,7 @@ means baseline-heuristic output, and the comment says so.
 
 **Injection has a low ceiling by construction.** Untrusted text is delimited and length-capped;
 output is schema-constrained, so the model can emit enum values and bounded strings but not
-instructions; output is escaped before rendering; and nothing downstream *executes* it. The worst
+instructions; output is escaped before rendering; and nothing downstream _executes_ it. The worst
 achievable outcome is a wrong label and a misleading comment.
 
 **One real egress path.** Source snippets and diff hunks are sent to the model API during the agent

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -14,7 +14,7 @@ npm run wiki:publish        # or: ./scripts/publish-wiki.sh
 ```
 
 The script clones `…/ai-flaky-test-triage.wiki.git`, mirrors this directory into it, and pushes.
-Page names come from filenames: `Getting-Started.md` becomes the *Getting Started* page.
+Page names come from filenames: `Getting-Started.md` becomes the _Getting Started_ page.
 
 `_Sidebar.md` and `_Footer.md` are special — GitHub renders them on every page.
 
@@ -29,10 +29,10 @@ no API for creating that first page. Once, manually:
 
 ## What belongs here, and what does not
 
-| | Holds | Why |
-|---|---|---|
-| [`docs/`](../docs) | Normative specs: schemas, contracts, labelling rules, ADRs | Versioned with the code and must match it exactly |
-| `wiki/` | Orientation and narrative: how things fit, why decisions were made, what to read first | Free to be discursive; nothing here is a contract |
+|                    | Holds                                                                                  | Why                                               |
+| ------------------ | -------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| [`docs/`](../docs) | Normative specs: schemas, contracts, labelling rules, ADRs                             | Versioned with the code and must match it exactly |
+| `wiki/`            | Orientation and narrative: how things fit, why decisions were made, what to read first | Free to be discursive; nothing here is a contract |
 
 Nothing is duplicated. Wiki pages link into `docs/` rather than restating it — two copies of a
 specification means one of them is wrong, and it is never obvious which.

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -11,12 +11,12 @@ output. It follows the data flow and feels right.
 
 It is the wrong order for two reasons. The least differentiated part of the project — a small CRUD
 app with drag-and-drop — is also the most time-consuming, and it sits in front of everything that
-carries value. Worse, it defers the only question that can invalidate the whole thing: *can a model
-classify these failures better than a thirty-line heuristic?* Learning the answer after a week of
+carries value. Worse, it defers the only question that can invalidate the whole thing: _can a model
+classify these failures better than a thirty-line heuristic?_ Learning the answer after a week of
 React work is the expensive way to learn it.
 
 So the evaluation harness and a measurable classifier land first. Fixtures are hand-authored JSON
-and need no application to exist. The app arrives at M4 and its job is then to *extend* the dataset
+and need no application to exist. The app arrives at M4 and its job is then to _extend_ the dataset
 with real captured runs rather than to bootstrap it.
 
 [ADR-0003](https://github.com/AKogut/ai-flaky-test-triage/blob/main/docs/adr/0003-dataset-first-milestone-ordering.md)
@@ -26,19 +26,19 @@ with real captured runs rather than to bootstrap it.
 Each has one exit criterion. A milestone is not done because its issues are closed; it is done when
 the criterion holds.
 
-| | Theme | Exit criterion |
-|---|---|---|
-| **M0** | Foundations & repository hygiene | `npm ci && npm run lint && npm run typecheck` passes on a clean clone, enforced in CI |
-| **M1** | Contracts, schemas & taxonomy | Every pipeline artifact has a Zod schema, an inferred type, and a round-trip test |
-| **M2** | Golden dataset, baseline & eval | `npm run eval` scores the baseline on ≥30 labelled fixtures with intervals and confusion matrices — **no model involved** |
-| **M3** | Triage agent & replay mode | The agent beats the baseline by a margin surviving its interval — or the finding that it does not is in the README. `npm run demo` works with no key. |
-| **M4** | TaskFlow application | `npm run dev` serves a task board; `SENTRA_CHAOS=<seed>` reproduces a specific race interleaving |
-| **M5** | Test suite & emergent flakiness | ≥10 `captured` fixtures from real CI runs; metrics broken down by provenance |
-| **M6** | flakemetry-lib integration | History survives across runs on `main`; a cache miss degrades gracefully; both tested |
-| **M7** | Root-cause & fix-suggestion agents | `npm run agents:analyze` turns a fixture into a report, asserted by an integration test in replay mode |
-| **M8** | End-to-end CI & PR comment | A PR touching a flaky spec produces exactly one comment; pushing again updates it |
-| **M9** | Observability, ablation & cost | `eval/ablation.md` reports every variant; at least one context field is justified by the numbers or removed because of them |
-| **M10** | Documentation, wiki & v1.0 | The Definition of Done holds on a clean clone; `v1.0.0` tagged with eval numbers in the release notes |
+|         | Theme                              | Exit criterion                                                                                                                                        |
+| ------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **M0**  | Foundations & repository hygiene   | `npm ci && npm run lint && npm run typecheck` passes on a clean clone, enforced in CI                                                                 |
+| **M1**  | Contracts, schemas & taxonomy      | Every pipeline artifact has a Zod schema, an inferred type, and a round-trip test                                                                     |
+| **M2**  | Golden dataset, baseline & eval    | `npm run eval` scores the baseline on ≥30 labelled fixtures with intervals and confusion matrices — **no model involved**                             |
+| **M3**  | Triage agent & replay mode         | The agent beats the baseline by a margin surviving its interval — or the finding that it does not is in the README. `npm run demo` works with no key. |
+| **M4**  | TaskFlow application               | `npm run dev` serves a task board; `SENTRA_CHAOS=<seed>` reproduces a specific race interleaving                                                      |
+| **M5**  | Test suite & emergent flakiness    | ≥10 `captured` fixtures from real CI runs; metrics broken down by provenance                                                                          |
+| **M6**  | flakemetry-lib integration         | History survives across runs on `main`; a cache miss degrades gracefully; both tested                                                                 |
+| **M7**  | Root-cause & fix-suggestion agents | `npm run agents:analyze` turns a fixture into a report, asserted by an integration test in replay mode                                                |
+| **M8**  | End-to-end CI & PR comment         | A PR touching a flaky spec produces exactly one comment; pushing again updates it                                                                     |
+| **M9**  | Observability, ablation & cost     | `eval/ablation.md` reports every variant; at least one context field is justified by the numbers or removed because of them                           |
+| **M10** | Documentation, wiki & v1.0         | The Definition of Done holds on a clean clone; `v1.0.0` tagged with eval numbers in the release notes                                                 |
 
 ## The milestone that decides the project
 
@@ -59,7 +59,7 @@ considerably rarer than a working classifier.
 
 ## Open experiments
 
-These may close as *not adopted* — the finding is the deliverable:
+These may close as _not adopted_ — the finding is the deliverable:
 
 - [Does history context earn its place?](https://github.com/AKogut/ai-flaky-test-triage/issues/79)
 - [Does a multi-step agent beat a single call on the hard quadrant?](https://github.com/AKogut/ai-flaky-test-triage/issues/80)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,26 +1,31 @@
 **[Sentra](Home)**
 
 **Start here**
+
 - [Getting Started](Getting-Started)
 - [FAQ](FAQ)
 - [Glossary](Glossary)
 
 **Design**
+
 - [Architecture Overview](Architecture-Overview)
 - [Classification Taxonomy](Classification-Taxonomy)
 - [Agent Design](Agent-Design)
 - [Decision Records](Decision-Records)
 
 **Quality**
+
 - [Evaluation Methodology](Evaluation-Methodology)
 - [Limitations and Guardrails](Limitations-and-Guardrails)
 
 **Working on it**
+
 - [Contributing](Contributing)
 - [Branching and Release](Branching-and-Release)
 - [Roadmap](Roadmap)
 
 ---
+
 [Repository](https://github.com/AKogut/ai-flaky-test-triage) ·
 [Issues](https://github.com/AKogut/ai-flaky-test-triage/issues) ·
 [Milestones](https://github.com/AKogut/ai-flaky-test-triage/milestones)


### PR DESCRIPTION
Closes #7

## What changed

`npm run lint`, `npm run format:check` and `npm run typecheck` all pass and are now enforced by the CI `Static analysis` job. `lint-staged` config is in place; #8 wires it to a commit hook.

## Why

Two of the rules here are load-bearing rather than stylistic, and one of them turns a documented promise into a build failure.

## Decisions worth reviewing

**One tool owns formatting.** `eslint-config-prettier` is applied last, disabling every stylistic ESLint rule. There is no configuration in which the two can disagree and fight over a file.

**`no-floating-promises` and `no-misused-promises` are errors, not warnings.** The orchestrator fans out asynchronous work per failing test. A dropped promise there would silently swallow one test's entire classification and still report success — the worst failure shape this pipeline can have, because the output looks complete.

**The filesystem guardrail is now enforced by lint.** `docs/limitations-and-guardrails.md` promises agents never modify the working tree. `no-restricted-imports` forbids `fs`, `fs/promises` and `child_process` under `agents/triage/`, `agents/root-cause/`, `agents/fix-suggestion/`, `agents/context/` and `agents/prompts/`.

The orchestrator is deliberately **outside** that scope — it is the one component allowed to write, and exactly one file (`report.md`). Scoping the rule to include it would either be a lie or force a suppression comment, and a guardrail with a documented escape hatch is not a guardrail. That case is asserted at runtime instead, by #69.

**`recommendedTypeChecked` + `stylisticTypeChecked`, not `strictTypeChecked`.** Strict adds rules that mostly fire on parsing code handling `unknown` — which is most of this codebase — and the churn would push people toward suppressions. Revisit once there is real code to judge it against.

## How it was verified

Beyond the three scripts passing, the guardrail rule was checked in the failing direction — a probe importing `node:fs` under `agents/triage/`:

```
agents/triage/__guardrail-probe.ts
  1:1  error  'node:fs' import is restricted from being used. Agents have no
              filesystem access. Callers read paths and pass the contents in —
              see docs/limitations-and-guardrails.md
              @typescript-eslint/no-restricted-imports

✖ 1 problem (1 error, 0 warnings)
```

The probe was deleted afterwards; the permanent version of this check is #69.

`npm audit` reports 0 vulnerabilities — `lint-staged` and `eslint` were pinned above the versions carrying the `yaml` and `@eslint/plugin-kit` advisories rather than left on the ranges npm resolved first.

## Checklist

- [x] Title is a valid Conventional Commit
- [x] Linked to exactly one issue with `Closes #N`
- [x] `npm run lint && npm run format:check && npm run typecheck` clean
- [x] Docs unchanged in substance — only formatting
- [ ] Under ~400 changed lines — see below

## Notes for the reviewer

**This PR is large and most of it is not worth reading.** Three groups:

1. **Configuration** — `eslint.config.js`, `.prettierrc.json`, `.prettierignore`, `package.json`, the CI job. This is the actual change, about 180 lines.
2. **One-time formatting normalisation** — 40 files. Quote style, markdown table padding, `*emphasis*` → `_emphasis_`. No prose was rewrapped (`proseWrap: preserve`), and the `.github` YAML diff is quote style only, with block scalars untouched.
3. **Lockfile.**

Splitting the normalisation into its own PR was the alternative. It would have left `main` failing `format:check` between the two merges, which is worse than one noisy diff.

`agents/replay/cassettes/` and `eval/golden-dataset/` are in `.prettierignore`: reformatting a cassette changes its content hash and invalidates it, and fixtures are meant to resemble real reporter output rather than be tidy.