### PR TITLE
chore: add editorconfig and VS Code workspace settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# Mirrors .prettierrc.json. Prettier is authoritative; this makes editors agree
+# before Prettier runs, so a file does not visibly reflow on save.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 100
+
+[*.md]
+# Two trailing spaces are a hard line break in markdown.
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "ms-playwright.playwright",
+    "vitest.explorer",
+    "editorconfig.editorconfig",
+    "github.vscode-github-actions",
+    "bierner.markdown-mermaid"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,33 @@
+{
+  // Use the workspace TypeScript, not the editor's bundled copy. A version skew
+  // between the two produces errors that do not reproduce in CI, which is an
+  // expensive kind of confusion in a repository about diagnosing test failures.
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+
+  "eslint.useFlatConfig": true,
+  "eslint.validate": ["javascript", "typescript", "typescriptreact"],
+
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+
+  "search.exclude": {
+    "**/dist": true,
+    "**/coverage": true,
+    "**/node_modules": true,
+    "package-lock.json": true
+  },
+
+  // Generated pipeline output. Visible on disk, never edited by hand.
+  "files.readonlyInclude": {
+    "analysis.json": true,
+    "results.json": true,
+    "otel-spans.json": true
+  }
+}


### PR DESCRIPTION
Closes #10

## What changed

`.editorconfig`, `.vscode/extensions.json`, `.vscode/settings.json`. Both `.vscode` files are already allow-listed in `.gitignore`.

## Why

A contributor opening the repository gets the right formatter, the right TypeScript, and the extension set without configuring anything.

## Decisions worth reviewing

**`typescript.tsdk` is pinned to the workspace copy.** A version skew between the editor's bundled compiler and the repository's produces errors that do not reproduce in CI. In a repository whose entire subject is telling apart real failures from environmental ones, that particular confusion is worth designing out.

**`.editorconfig` mirrors `.prettierrc.json` rather than competing with it.** Prettier remains authoritative; EditorConfig only stops files visibly reflowing on save before Prettier runs. `trim_trailing_whitespace` is off for markdown because two trailing spaces are a hard line break there.

**`files.readonlyInclude` marks the generated pipeline outputs.** `analysis.json`, `results.json` and `otel-spans.json` are regenerated every run; making them read-only in the editor prevents edits that would be silently overwritten.

## How it was verified

`npm run lint && npm run format:check && npm run typecheck && npm run test:unit` clean. Settings were checked against the extension IDs they reference.

## Checklist

- [x] Title is a valid Conventional Commit
- [x] Linked to exactly one issue
- [x] All checks clean
- [x] Under ~400 changed lines