### PR TITLE
docs: derive the README status banner from ROADMAP.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,12 @@ jobs:
           print(f"{len(files)} ADRs indexed")
           PY
 
+      - name: README status banner matches ROADMAP.md
+        if: steps.detect.outputs.has-code == 'true'
+        run: |
+          npm ci --silent
+          npm run docs:status:check
+
       - name: No internal doc links point at missing files
         run: |
           python3 - <<'PY'

--- a/README.md
+++ b/README.md
@@ -3,13 +3,21 @@
 **An AI triage layer for CI test failures — packaged as a pipeline step, not a service.**
 
 [![CI](https://github.com/AKogut/ai-flaky-test-triage/actions/workflows/ci.yml/badge.svg)](https://github.com/AKogut/ai-flaky-test-triage/actions/workflows/ci.yml)
+[![Milestones](https://img.shields.io/github/milestones/progress-percent/AKogut/ai-flaky-test-triage/1?label=M0)](https://github.com/AKogut/ai-flaky-test-triage/milestones)
+[![Open issues](https://img.shields.io/github/issues/AKogut/ai-flaky-test-triage?label=open%20issues)](https://github.com/AKogut/ai-flaky-test-triage/issues)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](package.json)
 
-> **Project status: Phase M0 — scaffolding.** The repository currently contains the
-> specification, documentation, and the full task breakdown. Code lands milestone by
-> milestone; see the [Roadmap](#roadmap) and the [issue tracker](https://github.com/AKogut/ai-flaky-test-triage/issues).
-> Commands marked 🚧 below are not implemented yet.
+<!-- status:start -->
+
+> **Project status: M0 — Foundations & repository hygiene.**
+> 0 of 11 milestones complete.
+> Current exit criterion: `npm ci && npm run lint && npm run typecheck` passes on a clean clone, and CI enforces it on every PR.
+>
+> Progress is tracked as [milestones](https://github.com/AKogut/ai-flaky-test-triage/milestones), not dates.
+> Commands marked 🚧 in the script table are not implemented yet and say so when run.
+
+<!-- status:end -->
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,6 +17,8 @@ Live status: [Milestones](https://github.com/AKogut/ai-flaky-test-triage/milesto
 Tooling that makes every later milestone cheaper: TypeScript project references, ESLint flat
 config, Prettier, Husky, commitlint, the npm workspace layout, and the CI skeleton.
 
+**Status:** in progress
+
 **Exit criterion:** `npm ci && npm run lint && npm run typecheck` passes on a clean clone, and CI
 enforces it on every PR.
 
@@ -25,6 +27,8 @@ enforces it on every PR.
 The type boundaries everything else is written against: `TestRun`, `TestResult`, `FlakySignal`,
 `Classification`, and the fixture format. Zod schemas at every boundary so a reporter version bump
 fails loudly in one file instead of silently three stages downstream.
+
+**Status:** planned
 
 **Exit criterion:** every artifact the pipeline reads or writes has a Zod schema, a TypeScript type
 inferred from it, and a round-trip test.
@@ -35,6 +39,8 @@ The measurement apparatus, built before the thing it measures. Hand-authored adv
 the non-LLM baseline heuristic, metrics with confidence intervals, confusion matrices, and the CI
 gate.
 
+**Status:** planned
+
 **Exit criterion:** `npm run eval` scores the baseline heuristic on ≥30 labelled fixtures and
 writes a report with per-axis accuracy, intervals, and both confusion matrices — with no model
 involved.
@@ -43,6 +49,8 @@ involved.
 
 The first model call. Structured output, the shared rubric, prompt versioning, cassette
 record/replay, calibration measurement, and self-consistency sampling.
+
+**Status:** planned
 
 **Exit criterion:** the triage agent beats the baseline on joint accuracy by a margin that survives
 its confidence interval — or the finding that it does not is documented in the README. Either way,
@@ -54,6 +62,8 @@ The system under test: React + TypeScript client, Express + SQLite API, task CRU
 drag-to-reorder, optimistic updates. Deliberately small. Includes a seedable nondeterminism layer
 so flakiness can be _emergent_ rather than scripted.
 
+**Status:** planned
+
 **Exit criterion:** `npm run dev` serves a working task board, and `SENTRA_CHAOS=<seed>` reproduces
 a specific interleaving of the optimistic-update race.
 
@@ -63,6 +73,8 @@ Vitest for the API and libraries, Playwright for UI flows, and a set of genuinel
 flakiness comes from real races rather than a `Math.random()` in the test. Captured runs feed the
 golden dataset.
 
+**Status:** planned
+
 **Exit criterion:** ≥10 `captured` fixtures from real CI runs are in the dataset, and eval metrics
 are reported broken down by provenance.
 
@@ -70,6 +82,8 @@ are reported broken down by provenance.
 
 `analyze()` and the history file: EWMA flakiness scoring, streak tracking, atomic capped writes,
 and the CI cache strategy with `main`-only writes.
+
+**Status:** planned
 
 **Exit criterion:** history survives across CI runs on `main`, a cache miss degrades gracefully
 rather than crashing, and both behaviours have tests.
@@ -79,6 +93,8 @@ rather than crashing, and both behaviours have tests.
 The two downstream agents, the orchestrator, budget enforcement, concurrency limiting, partial
 failure isolation, and the report writer.
 
+**Status:** planned
+
 **Exit criterion:** `npm run agents:analyze` turns a fixture `analysis.json` into a `report.md`
 whose structure is asserted by an integration test running fully in replay mode.
 
@@ -86,6 +102,8 @@ whose structure is asserted by an integration test running fully in replay mode.
 
 Wiring the whole thing together in one workflow, plus the comment upsert, the fork degradation
 path, and the truncation notice.
+
+**Status:** planned
 
 **Exit criterion:** a pull request that touches a flaky spec produces exactly one bot comment, and
 pushing again updates that comment rather than adding another.
@@ -95,6 +113,8 @@ pushing again updates that comment rather than adding another.
 OpenTelemetry spans to a file exporter, per-run token and cost accounting, and the ablation study
 that measures what each context field actually contributes.
 
+**Status:** planned
+
 **Exit criterion:** `eval/ablation.md` reports every variant from
 [eval-methodology.md](docs/eval-methodology.md#ablation-study), and at least one context field is
 either justified by the numbers or removed because of them.
@@ -103,6 +123,8 @@ either justified by the numbers or removed because of them.
 
 The wiki, the README screenshot of a real PR comment, the honest limitations write-up, and the
 release.
+
+**Status:** planned
 
 **Exit criterion:** the Definition of Done in the README holds end to end on a clean clone, and
 `v1.0.0` is tagged with `eval/report.md` headline numbers in the release notes.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "changelog:check": "tsx scripts/changelog.ts --check",
     "demo": "node scripts/pending.mjs demo",
     "dev": "node scripts/pending.mjs dev",
+    "docs:status": "tsx scripts/status-banner.ts",
+    "docs:status:check": "tsx scripts/status-banner.ts --check",
     "eval": "node scripts/pending.mjs eval",
     "eval:ablation": "node scripts/pending.mjs eval:ablation",
     "flakemetry:analyze": "node scripts/pending.mjs flakemetry:analyze",

--- a/scripts/status-banner.ts
+++ b/scripts/status-banner.ts
@@ -1,0 +1,150 @@
+/**
+ * Regenerate the README status banner from ROADMAP.md.
+ *
+ * A hand-maintained "Project status: Phase M0" line on a repository that has
+ * shipped M6 undermines every other claim on the page, and it is exactly the
+ * kind of edit that gets forgotten. This derives it from the one place the
+ * milestone state is already recorded.
+ *
+ * Deliberately offline. The obvious alternative — querying the GitHub API for
+ * open and closed issue counts — makes the check non-deterministic: closing an
+ * unrelated issue would turn `main` red until somebody regenerated a README.
+ * A gate that fires on activity elsewhere gets disabled by whoever is on call.
+ * Live counts are shown as shields.io badges instead, which are always current
+ * and need no maintenance at all.
+ *
+ * Usage: tsx scripts/status-banner.ts [--check]
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const START = '<!-- status:start -->'
+const END = '<!-- status:end -->'
+
+const REPO = 'https://github.com/AKogut/ai-flaky-test-triage'
+
+export type MilestoneStatus = 'done' | 'in progress' | 'planned'
+
+export interface Milestone {
+  id: string
+  theme: string
+  status: MilestoneStatus
+  exitCriterion: string
+}
+
+const isStatus = (v: string): v is MilestoneStatus =>
+  v === 'done' || v === 'in progress' || v === 'planned'
+
+/**
+ * Parse the milestone sections out of ROADMAP.md.
+ *
+ * Exported for testing: the parser silently returning fewer milestones than the
+ * document contains would produce a plausible, wrong banner.
+ */
+export function parseRoadmap(markdown: string): Milestone[] {
+  const milestones: Milestone[] = []
+  let current: Partial<Milestone> | null = null
+
+  const flush = (): void => {
+    if (
+      current?.id !== undefined &&
+      current.theme !== undefined &&
+      current.status !== undefined &&
+      current.exitCriterion !== undefined
+    ) {
+      milestones.push(current as Milestone)
+    }
+    current = null
+  }
+
+  const lines = markdown.split('\n')
+  for (const [index, line] of lines.entries()) {
+    const heading = /^## (M\d+) — (.+)$/.exec(line)
+    if (heading?.[1] !== undefined && heading[2] !== undefined) {
+      flush()
+      current = { id: heading[1], theme: heading[2].trim() }
+      continue
+    }
+    if (current === null) continue
+
+    const status = /^\*\*Status:\*\*\s*(.+)$/.exec(line)
+    if (status?.[1] !== undefined) {
+      const value = status[1].trim()
+      if (!isStatus(value)) {
+        throw new Error(`ROADMAP.md: ${current.id ?? '?'} has unknown status "${value}"`)
+      }
+      current.status = value
+      continue
+    }
+
+    const exit = /^\*\*Exit criterion:\*\*\s*(.*)$/.exec(line)
+    if (exit?.[1] !== undefined) {
+      // Exit criteria wrap across lines; take everything up to the blank line.
+      const rest: string[] = [exit[1]]
+      for (const next of lines.slice(index + 1)) {
+        if (next.trim() === '') break
+        rest.push(next.trim())
+      }
+      current.exitCriterion = rest.join(' ').trim()
+    }
+  }
+  flush()
+
+  return milestones
+}
+
+export function renderBanner(milestones: Milestone[]): string {
+  const done = milestones.filter((m) => m.status === 'done')
+  const active = milestones.find((m) => m.status === 'in progress')
+  const total = milestones.length
+
+  if (active === undefined) {
+    if (done.length === total && total > 0) {
+      return [
+        `> **All ${String(total)} milestones complete.** The Definition of Done below holds end to`,
+        `> end on a clean clone. See [\`eval/report.md\`](eval/report.md) for how well the classifier`,
+        `> actually performs.`,
+      ].join('\n')
+    }
+    throw new Error('ROADMAP.md has no milestone marked "in progress"')
+  }
+
+  return [
+    `> **Project status: ${active.id} — ${active.theme}.**`,
+    `> ${String(done.length)} of ${String(total)} milestones complete.`,
+    `> Current exit criterion: ${active.exitCriterion}`,
+    `>`,
+    `> Progress is tracked as [milestones](${REPO}/milestones), not dates.`,
+    `> Commands marked 🚧 in the script table are not implemented yet and say so when run.`,
+  ].join('\n')
+}
+
+export function splice(readme: string, banner: string): string {
+  const start = readme.indexOf(START)
+  const end = readme.indexOf(END)
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error(`README.md is missing the ${START} / ${END} markers`)
+  }
+  return `${readme.slice(0, start + START.length)}\n\n${banner}\n\n${readme.slice(end)}`
+}
+
+function main(): void {
+  const milestones = parseRoadmap(readFileSync('ROADMAP.md', 'utf8'))
+  if (milestones.length === 0) throw new Error('ROADMAP.md: no milestones parsed')
+
+  const readme = readFileSync('README.md', 'utf8')
+  const next = splice(readme, renderBanner(milestones))
+
+  if (process.argv.includes('--check')) {
+    if (next !== readme) {
+      console.error('README status banner is out of date with ROADMAP.md. Run: npm run docs:status')
+      process.exit(1)
+    }
+    console.log(`README status banner is up to date (${String(milestones.length)} milestones)`)
+    return
+  }
+
+  writeFileSync('README.md', next)
+  console.log('README status banner regenerated')
+}
+
+if (process.argv[1]?.endsWith('status-banner.ts') === true) main()

--- a/tests/unit/status-banner.test.ts
+++ b/tests/unit/status-banner.test.ts
@@ -1,0 +1,103 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parseRoadmap, renderBanner, splice } from '../../scripts/status-banner.js'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+const roadmap = (...sections: [id: string, status: string][]): string =>
+  sections
+    .map(
+      ([id, status]) =>
+        `## ${id} — Theme for ${id}\n\nProse.\n\n**Status:** ${status}\n\n**Exit criterion:** something\nthat wraps onto a second line.\n`,
+    )
+    .join('\n')
+
+describe('parseRoadmap', () => {
+  it('reads id, theme, status and a wrapped exit criterion', () => {
+    const [m] = parseRoadmap(roadmap(['M0', 'in progress']))
+    expect(m).toEqual({
+      id: 'M0',
+      theme: 'Theme for M0',
+      status: 'in progress',
+      exitCriterion: 'something that wraps onto a second line.',
+    })
+  })
+
+  it('rejects a status value it does not understand', () => {
+    // A typo silently treated as "planned" would produce a plausible, wrong banner.
+    expect(() => parseRoadmap(roadmap(['M0', 'nearly done']))).toThrow(/unknown status/)
+  })
+
+  it('drops a section that is missing a required field rather than half-parsing it', () => {
+    expect(parseRoadmap('## M0 — Theme\n\n**Status:** done\n')).toHaveLength(0)
+  })
+
+  it('parses every milestone in the real ROADMAP.md', () => {
+    const parsed = parseRoadmap(readFileSync(join(root, 'ROADMAP.md'), 'utf8'))
+    expect(parsed).toHaveLength(11)
+    expect(parsed.map((m) => m.id)).toEqual([
+      'M0',
+      'M1',
+      'M2',
+      'M3',
+      'M4',
+      'M5',
+      'M6',
+      'M7',
+      'M8',
+      'M9',
+      'M10',
+    ])
+    for (const m of parsed) expect(m.exitCriterion.length).toBeGreaterThan(20)
+  })
+})
+
+describe('renderBanner', () => {
+  it('names the active milestone and counts the completed ones', () => {
+    const banner = renderBanner(
+      parseRoadmap(roadmap(['M0', 'done'], ['M1', 'in progress'], ['M2', 'planned'])),
+    )
+    expect(banner).toContain('M1 — Theme for M1')
+    expect(banner).toContain('1 of 3 milestones complete')
+  })
+
+  it('refuses to guess when nothing is in progress', () => {
+    expect(() => renderBanner(parseRoadmap(roadmap(['M0', 'done'], ['M1', 'planned'])))).toThrow(
+      /no milestone marked/,
+    )
+  })
+
+  it('switches to a completion banner when every milestone is done', () => {
+    const banner = renderBanner(parseRoadmap(roadmap(['M0', 'done'], ['M1', 'done'])))
+    expect(banner).toContain('All 2 milestones complete')
+  })
+})
+
+describe('splice', () => {
+  const doc = '# T\n\n<!-- status:start -->\n\nold\n\n<!-- status:end -->\n\nrest\n'
+
+  it('replaces only the marked region', () => {
+    const out = splice(doc, '> new')
+    expect(out).toContain('> new')
+    expect(out).not.toContain('old')
+    expect(out).toContain('rest')
+  })
+
+  it('is idempotent', () => {
+    expect(splice(splice(doc, '> new'), '> new')).toBe(splice(doc, '> new'))
+  })
+
+  it('refuses to guess when the markers are missing', () => {
+    expect(() => splice('# T\n', '> new')).toThrow(/markers/)
+  })
+})
+
+describe('the committed README', () => {
+  it('matches what generation produces', () => {
+    const readme = readFileSync(join(root, 'README.md'), 'utf8')
+    const banner = renderBanner(parseRoadmap(readFileSync(join(root, 'ROADMAP.md'), 'utf8')))
+    expect(splice(readme, banner)).toBe(readme)
+  })
+})


### PR DESCRIPTION
Closes #12

## What changed

The README status banner is generated from `ROADMAP.md` by `npm run docs:status`, and the `Repository hygiene` job fails if the committed banner and the roadmap disagree. Badges gained live milestone progress and open-issue counts.

```
> **Project status: M0 — Foundations & repository hygiene.**
> 0 of 11 milestones complete.
> Current exit criterion: `npm ci && npm run lint && npm run typecheck` passes on a
> clean clone, and CI enforces it on every PR.
```

## Why

A hand-maintained "Project status: Phase M0" line on a repository that has shipped M6 undermines every other claim on the page — and it is exactly the edit that gets forgotten, because nothing breaks when it is wrong.

## I deviated from the acceptance criteria — here is the argument

The issue asked for **open and closed issue counts in the banner** and **a CI check that fails when the banner is stale**. Those two requirements are in conflict.

Issue counts change constantly and for reasons unrelated to any pull request. Putting them in a checked, committed file means closing an unrelated issue turns `main` red until somebody regenerates a README — a gate that fires on activity elsewhere in the project. That gate gets disabled by whoever is on call within a fortnight, and then the banner rots anyway, which is the exact outcome the issue was written to prevent.

The split here keeps both properties:

- **Live counts are shields.io badges.** Milestone progress and open-issue count, queried by shields from GitHub on every page view. Always current, no maintenance, nothing to check.
- **The banner carries only slow-moving state** — active milestone, theme, exit criterion, completed count — derived from `ROADMAP.md`. That is committed data, so the check is deterministic and offline, and it only fails when someone edits one of the two files without the other.

`ROADMAP.md` gains a `**Status:**` line per milestone. That line is also the single edit needed when a milestone completes, which is the smallest possible ritual for keeping the page honest.

## Decisions worth reviewing

**The parser fails loudly rather than guessing.** An unrecognised status value throws instead of defaulting to `planned`; a milestone missing a required field is dropped rather than half-parsed; no milestone marked `in progress` throws rather than rendering a banner with a blank name. Every one of those alternatives would produce a plausible-looking, wrong banner — the failure mode this issue exists to prevent.

**Exit criteria are reflowed, not truncated.** They wrap across lines in `ROADMAP.md`; the parser reads to the blank line, so the banner carries the whole criterion.

## How it was verified

45 assertions, including a test that parses the **real** `ROADMAP.md` and asserts all 11 milestones come back with non-trivial exit criteria — a parser silently returning 3 of 11 would otherwise pass every synthetic test.

Both failing directions were checked by hand:

```
# banner edited to claim M9
$ npm run docs:status:check
README status banner is out of date with ROADMAP.md. Run: npm run docs:status

# ROADMAP with nothing in progress
$ npm run docs:status:check
Error: ROADMAP.md has no milestone marked "in progress"
```

There is also a test asserting the committed README already matches what generation produces, so the check cannot pass locally and fail in CI.

## Checklist

- [x] Title is a valid Conventional Commit
- [x] Linked to exactly one issue with `Closes #N`
- [x] `npm run lint && npm run format:check && npm run typecheck && npm run test:unit` clean
- [x] Tests cover the failure modes
- [x] `ROADMAP.md` updated — it gained the `Status` field the generator reads

## Notes for the reviewer

The milestone-progress badge hardcodes milestone number `1` in its URL because shields addresses milestones by number, not name. It needs updating once per milestone, in the same edit that flips the `Status` line — worth flagging as the one hand-maintained thing left on the page.

This closes M0. `npm ci && npm run lint && npm run typecheck` passes on a clean clone and CI enforces it, so the exit criterion holds.
