### PR TITLE
feat(eval): add TestRun domain types and Zod schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@
 **An AI triage layer for CI test failures — packaged as a pipeline step, not a service.**
 
 [![CI](https://github.com/AKogut/ai-flaky-test-triage/actions/workflows/ci.yml/badge.svg)](https://github.com/AKogut/ai-flaky-test-triage/actions/workflows/ci.yml)
-[![Milestones](https://img.shields.io/github/milestones/progress-percent/AKogut/ai-flaky-test-triage/1?label=M0)](https://github.com/AKogut/ai-flaky-test-triage/milestones)
+[![Milestones](https://img.shields.io/github/milestones/progress-percent/AKogut/ai-flaky-test-triage/2?label=M1)](https://github.com/AKogut/ai-flaky-test-triage/milestones)
 [![Open issues](https://img.shields.io/github/issues/AKogut/ai-flaky-test-triage?label=open%20issues)](https://github.com/AKogut/ai-flaky-test-triage/issues)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](package.json)
 
 <!-- status:start -->
 
-> **Project status: M0 — Foundations & repository hygiene.**
-> 0 of 11 milestones complete.
-> Current exit criterion: `npm ci && npm run lint && npm run typecheck` passes on a clean clone, and CI enforces it on every PR.
+> **Project status: M1 — Contracts, schemas & taxonomy.**
+> 1 of 11 milestones complete.
+> Current exit criterion: every artifact the pipeline reads or writes has a Zod schema, a TypeScript type inferred from it, and a round-trip test.
 >
 > Progress is tracked as [milestones](https://github.com/AKogut/ai-flaky-test-triage/milestones), not dates.
 > Commands marked 🚧 in the script table are not implemented yet and say so when run.
@@ -168,6 +168,8 @@ Everything else runs today. `npm run help` prints this table from the terminal.
 │   ├── workflows/ci.yml         # the entire pipeline, one workflow
 │   ├── ISSUE_TEMPLATE/          # task / bug / experiment / ADR forms
 │   └── CODEOWNERS
+├── contracts/                   # Zod schemas + inferred types for every artifact
+│                                #   the pipeline reads or writes
 ├── app/                         # TaskFlow — the system under test
 │   ├── client/                  # React + TypeScript
 │   └── server/                  # Express + SQLite

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,7 @@ Live status: [Milestones](https://github.com/AKogut/ai-flaky-test-triage/milesto
 Tooling that makes every later milestone cheaper: TypeScript project references, ESLint flat
 config, Prettier, Husky, commitlint, the npm workspace layout, and the CI skeleton.
 
-**Status:** in progress
+**Status:** done
 
 **Exit criterion:** `npm ci && npm run lint && npm run typecheck` passes on a clean clone, and CI
 enforces it on every PR.
@@ -28,7 +28,7 @@ The type boundaries everything else is written against: `TestRun`, `TestResult`,
 `Classification`, and the fixture format. Zod schemas at every boundary so a reporter version bump
 fails loudly in one file instead of silently three stages downstream.
 
-**Status:** planned
+**Status:** in progress
 
 **Exit criterion:** every artifact the pipeline reads or writes has a Zod schema, a TypeScript type
 inferred from it, and a round-trip test.

--- a/contracts/index.ts
+++ b/contracts/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @sentra/contracts
+ *
+ * Zod schemas and inferred types for every artifact the pipeline reads or
+ * writes. Importing from here rather than from a sibling file keeps the set of
+ * things that count as a contract visible in one place.
+ */
+
+export * from './test-run.js'

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@sentra/contracts",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Zod schemas and inferred types for every artifact the pipeline reads or writes. The narrow waist: nothing downstream of a boundary knows which tool produced the data.",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./index.ts"
+    }
+  },
+  "dependencies": {
+    "zod": "4.4.3"
+  }
+}

--- a/contracts/test-run.test.ts
+++ b/contracts/test-run.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import {
+  deriveTestId,
+  normaliseFilePath,
+  parseTestRun,
+  TestResultSchema,
+  TestRunSchema,
+} from './test-run.js'
+
+const result = {
+  testId: 'tests/e2e/board.spec.ts›reorder › moves a task up',
+  title: 'reorder › moves a task up',
+  file: 'tests/e2e/board.spec.ts',
+  status: 'failed',
+  attempts: 1,
+  flakyWithinRun: false,
+  durationMs: 1234,
+  error: { message: 'expected 2 to be 1' },
+}
+
+const run = {
+  runId: 'run-1',
+  commitSha: 'abc1234',
+  branch: 'main',
+  startedAt: '2026-08-10T12:00:00.000Z',
+  durationMs: 5000,
+  source: 'playwright',
+  results: [result],
+}
+
+describe('deriveTestId', () => {
+  it('combines file and title', () => {
+    expect(deriveTestId('tests/a.spec.ts', 'does a thing')).toBe('tests/a.spec.ts›does a thing')
+  })
+
+  it('gives the same id for paths that differ only by normalisation', () => {
+    // Two implementations disagreeing here would split one test's history in
+    // two and make every intermittent test look new.
+    const canonical = deriveTestId('tests/a.spec.ts', 'x')
+    expect(deriveTestId('./tests/a.spec.ts', 'x')).toBe(canonical)
+    expect(deriveTestId('tests\\a.spec.ts', 'x')).toBe(canonical)
+    expect(deriveTestId('/tests/a.spec.ts', 'x')).toBe(canonical)
+    expect(deriveTestId('tests/a.spec.ts', '  x  ')).toBe(canonical)
+  })
+
+  it('separates tests with the same title in different files', () => {
+    expect(deriveTestId('a.spec.ts', 'works')).not.toBe(deriveTestId('b.spec.ts', 'works'))
+  })
+
+  it('separates different titles in the same file', () => {
+    expect(deriveTestId('a.spec.ts', 'x')).not.toBe(deriveTestId('a.spec.ts', 'y'))
+  })
+})
+
+describe('normaliseFilePath', () => {
+  it.each([
+    ['./a/b.ts', 'a/b.ts'],
+    ['/a/b.ts', 'a/b.ts'],
+    ['a\\b.ts', 'a/b.ts'],
+    ['a/b.ts', 'a/b.ts'],
+  ])('%s -> %s', (input, expected) => {
+    expect(normaliseFilePath(input)).toBe(expected)
+  })
+})
+
+describe('TestRunSchema', () => {
+  it('accepts a well-formed run', () => {
+    expect(TestRunSchema.parse(run).results).toHaveLength(1)
+  })
+
+  it('round-trips through JSON unchanged', () => {
+    const once = TestRunSchema.parse(run)
+    expect(TestRunSchema.parse(JSON.parse(JSON.stringify(once)))).toEqual(once)
+  })
+
+  it('defaults annotations rather than leaving them undefined', () => {
+    expect(TestResultSchema.parse(result).annotations).toEqual([])
+  })
+
+  it('rejects an unknown field instead of passing it through', () => {
+    // A reporter that renames a field must fail here, not three stages later
+    // with an undefined that looks like "this test has no error".
+    expect(() => TestRunSchema.parse({ ...run, unexpected: true })).toThrow()
+  })
+
+  it.each([
+    ['attempts below 1', { ...result, attempts: 0 }],
+    ['a negative duration', { ...result, durationMs: -1 }],
+    ['an unknown status', { ...result, status: 'exploded' }],
+    ['an empty file path', { ...result, file: '' }],
+  ])('rejects %s', (_label, bad) => {
+    expect(() => TestResultSchema.parse(bad)).toThrow()
+  })
+
+  it('rejects a non-ISO timestamp', () => {
+    expect(() => TestRunSchema.parse({ ...run, startedAt: '10 August 2026' })).toThrow()
+  })
+
+  it('rejects a truncated commit sha', () => {
+    expect(() => TestRunSchema.parse({ ...run, commitSha: 'abc' })).toThrow()
+  })
+
+  it('accepts a run with no results — a green run is valid input', () => {
+    expect(TestRunSchema.parse({ ...run, results: [] }).results).toEqual([])
+  })
+})
+
+describe('parseTestRun', () => {
+  it('names the source and the failing path', () => {
+    expect(() => parseTestRun({ ...run, commitSha: 'abc' }, 'results.json')).toThrow(
+      /results\.json is not a valid TestRun:[\s\S]*commitSha/,
+    )
+  })
+
+  it('caps how many issues it prints', () => {
+    let message = ''
+    try {
+      parseTestRun({}, 'results.json')
+    } catch (error) {
+      message = (error as Error).message
+    }
+    expect(message.split('\n').length).toBeLessThanOrEqual(7)
+  })
+})

--- a/contracts/test-run.ts
+++ b/contracts/test-run.ts
@@ -1,0 +1,120 @@
+import { z } from 'zod'
+
+/**
+ * The narrow waist of the pipeline.
+ *
+ * Playwright and Vitest emit different shapes. Both are normalised into these
+ * types at the boundary, and nothing downstream knows which tool produced a run.
+ * That is what makes a reporter upgrade break exactly one file, loudly, instead
+ * of silently degrading the flakiness signal three stages later.
+ *
+ * Schema-first, with types inferred. Keeping a hand-written type in step with a
+ * hand-written validator is a guaranteed source of drift, and the drift is
+ * invisible: the validator accepts a payload the type says cannot exist.
+ *
+ * Specified in docs/architecture.md.
+ */
+
+/**
+ * `timedOut` is deliberately distinct from `failed`.
+ *
+ * A timeout means the assertion was never reached, which is strong evidence for
+ * `environment` or for an unsynchronised test — quite different from an assertion
+ * that ran and disagreed. Collapsing the two would erase that signal before the
+ * classifier ever sees it.
+ */
+export const TestStatusSchema = z.enum(['passed', 'failed', 'timedOut', 'skipped'])
+export type TestStatus = z.infer<typeof TestStatusSchema>
+
+export const TestErrorSchema = z
+  .object({
+    message: z.string(),
+    stack: z.string().optional(),
+    /** Source around the failing line, when the reporter captured it. */
+    snippet: z.string().optional(),
+    /** Present when the reporter distinguishes expected from actual. */
+    expected: z.string().optional(),
+    actual: z.string().optional(),
+  })
+  .strict()
+export type TestError = z.infer<typeof TestErrorSchema>
+
+export const TestResultSchema = z
+  .object({
+    /** Stable across runs: see {@link deriveTestId}. */
+    testId: z.string().min(1),
+    title: z.string().min(1),
+    /** Repository-relative, forward slashes, no leading `./`. */
+    file: z.string().min(1),
+    status: TestStatusSchema,
+    /**
+     * Attempts within this run, counting the first. A test that failed and then
+     * passed on attempt 2 is intermittency evidence that exists nowhere else, so
+     * it must survive normalisation.
+     */
+    attempts: z.int().min(1),
+    /** True when an earlier attempt failed and a later one passed. */
+    flakyWithinRun: z.boolean(),
+    durationMs: z.number().min(0),
+    error: TestErrorSchema.optional(),
+    annotations: z.array(z.string()).default([]),
+  })
+  .strict()
+export type TestResult = z.infer<typeof TestResultSchema>
+
+export const TestRunSchema = z
+  .object({
+    runId: z.string().min(1),
+    commitSha: z.string().min(7),
+    branch: z.string().min(1),
+    startedAt: z.iso.datetime(),
+    durationMs: z.number().min(0),
+    /** Which reporter produced this run. Diagnostic only — no logic branches on it. */
+    source: z.enum(['playwright', 'vitest', 'synthetic']),
+    results: z.array(TestResultSchema),
+  })
+  .strict()
+export type TestRun = z.infer<typeof TestRunSchema>
+
+/**
+ * Derive the identity a test keeps across runs.
+ *
+ * File path plus full title, because neither alone is stable: titles repeat
+ * across files, and a file can be renamed while its tests stay the same. The
+ * separator is a character that cannot occur in either part.
+ *
+ * This is the single definition. History, flakiness scoring, and the golden
+ * dataset all key on it, so two implementations that disagree by a normalisation
+ * detail — a leading `./`, a backslash on Windows — would silently split one
+ * test's history in two and make every intermittent test look new.
+ */
+export function deriveTestId(file: string, title: string): string {
+  return `${normaliseFilePath(file)}›${title.trim()}`
+}
+
+/** Repository-relative, forward slashes, no leading `./` or `/`. */
+export function normaliseFilePath(file: string): string {
+  return file.replaceAll('\\', '/').replace(/^\.\//, '').replace(/^\/+/, '')
+}
+
+/**
+ * Parse a `TestRun`, throwing a message that names the failing path.
+ *
+ * Callers at a boundary should use this rather than `TestRunSchema.parse`, so a
+ * malformed payload produces one legible error instead of a Zod issue tree.
+ */
+export function parseTestRun(value: unknown, sourceLabel: string): TestRun {
+  const result = TestRunSchema.safeParse(value)
+  if (!result.success) {
+    const issues = result.error.issues
+      .slice(0, 5)
+      .map((i) => `  ${i.path.join('.') || '<root>'}: ${i.message}`)
+      .join('\n')
+    const more =
+      result.error.issues.length > 5
+        ? `\n  … and ${String(result.error.issues.length - 5)} more`
+        : ''
+    throw new Error(`${sourceLabel} is not a valid TestRun:\n${issues}${more}`)
+  }
+  return result.data
+}

--- a/contracts/tsconfig.json
+++ b/contracts/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["dist"]
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,7 @@ flowchart LR
 ### 1. Test execution → `results.json`
 
 Playwright's JSON reporter and Vitest's JSON reporter emit different shapes. Both are normalised
-into a single internal `TestRun` type at the boundary. The normaliser is the _only_ place that
+into a single internal `TestRun` type at the boundary, defined in the `contracts/` workspace. The normaliser is the _only_ place that
 knows about reporter-specific fields, so a Playwright major bump breaks one file, loudly, with a
 Zod error — not silently, three stages downstream.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,16 @@
       "version": "0.1.0",
       "license": "MIT",
       "workspaces": [
+        "contracts",
         "app/client",
         "app/server",
         "flakemetry-lib",
         "agents",
         "eval"
       ],
+      "dependencies": {
+        "zod": "4.4.3"
+      },
       "devDependencies": {
         "@commitlint/cli": "19.6.1",
         "@commitlint/config-conventional": "19.6.0",
@@ -50,6 +54,14 @@
       "name": "@sentra/taskflow-server",
       "version": "0.1.0",
       "license": "MIT"
+    },
+    "contracts": {
+      "name": "@sentra/contracts",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "4.4.3"
+      }
     },
     "eval": {
       "name": "@sentra/eval",
@@ -1553,6 +1565,10 @@
     },
     "node_modules/@sentra/agents": {
       "resolved": "agents",
+      "link": true
+    },
+    "node_modules/@sentra/contracts": {
+      "resolved": "contracts",
       "link": true
     },
     "node_modules/@sentra/eval": {
@@ -5417,6 +5433,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "node": ">=22"
   },
   "workspaces": [
+    "contracts",
     "app/client",
     "app/server",
     "flakemetry-lib",
@@ -71,5 +72,8 @@
     "*.{json,md,yml,yaml}": [
       "prettier --write"
     ]
+  },
+  "dependencies": {
+    "zod": "4.4.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
       "path": "./scripts"
     },
     {
+      "path": "./contracts"
+    },
+    {
       "path": "./flakemetry-lib"
     },
     {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     include: [
       'tests/unit/**/*.test.ts',
+      'contracts/**/*.test.ts',
       'flakemetry-lib/**/*.test.ts',
       'agents/**/*.test.ts',
       'eval/**/*.test.ts',


### PR DESCRIPTION
Closes #13

## What changed

`TestRun` and `TestResult` exist as Zod schemas with types inferred from them, in a new `contracts/` workspace. Plus `deriveTestId`, the single definition of what identity a test keeps across runs.

## Why

This is the narrow waist of the pipeline. Playwright and Vitest emit different shapes; both are normalised into these types at the boundary, and nothing downstream knows which tool produced a run. That is what makes a reporter upgrade break exactly one file, loudly, instead of silently degrading the flakiness signal three stages later.

## Decisions worth reviewing

**A new `contracts/` workspace, not a file inside an existing package.** The issue said "a shared package" without naming one. Putting the schemas in `flakemetry-lib` would mean `agents` and `eval` depend on the flakiness library to read a type, and that is the shape dependency graphs rot into. The README layout and `docs/architecture.md` are updated to match.

**Schema-first, types inferred — never declared separately.** A hand-written type next to a hand-written validator drifts, and the drift is invisible in the worst direction: the validator accepts a payload the type says cannot exist, so the compiler stops helping exactly where the data is untrusted.

**`.strict()` everywhere.** An unknown field is an error, not something to strip quietly. The failure this prevents is the quiet one: a reporter renames a field, the normaliser reads `undefined`, every test looks like it passed once, and the flakiness signal degrades with no error anywhere. That is much worse than a crash and far harder to notice.

**`timedOut` is a separate status from `failed`.** A timeout means the assertion was never reached — strong evidence for `environment` or an unsynchronised test, and quite different from an assertion that ran and disagreed. Collapsing them would erase the distinction before the classifier ever sees it.

**`flakyWithinRun` is stored, not derived later.** A test that failed and then passed on attempt 2 is intermittency evidence that exists nowhere else in the pipeline — the history file records one status per run, not per attempt. If it does not survive normalisation it is gone.

**`parseTestRun` exists alongside `TestRunSchema.parse`.** Boundary callers get one legible error naming the source file and the failing path, capped at five issues, instead of a Zod issue tree. A stack of nested validation objects in a CI log is technically complete and practically unreadable.

## How it was verified

66 assertions total, 21 of them new here. The ones that matter are not the happy path:

- **Test-id stability under path normalisation.** `./tests/a.spec.ts`, `tests\a.spec.ts`, `/tests/a.spec.ts` and `tests/a.spec.ts` must all produce the same id. Two implementations disagreeing by a leading `./` would silently split one test's history in two and make every intermittent test look new — the exact signal this project consumes.
- **Unknown fields rejected**, per the reasoning above.
- **A run with no results is valid** — a green run is legitimate input and the pipeline must not treat it as malformed.
- **Error-message shape**, including the issue cap, because the diagnostic is the feature.

```bash
npm run lint && npm run format:check && npm run typecheck && npm run test:unit   # all clean
```

## Checklist

- [x] Title is a valid Conventional Commit
- [x] Linked to exactly one issue with `Closes #N`
- [x] All checks clean
- [x] Round-trip test present, per the milestone exit criterion
- [x] Docs updated — README layout, `docs/architecture.md`, `ROADMAP.md` statuses

## Notes for the reviewer

M0 is closed; `ROADMAP.md` and the status banner now show M1 in progress, and the milestone badge points at milestone 2.

`zod@4` is pinned exactly. The schemas are a committed data contract, and a minor-version change to validation behaviour would be a change to what the pipeline accepts — that should be a deliberate upgrade with tests, not a lockfile refresh.
