### PR TITLE
feat(eval): normalise Playwright JSON reporter output

### DIFF
--- a/contracts/index.ts
+++ b/contracts/index.ts
@@ -7,3 +7,4 @@
  */
 
 export * from './test-run.js'
+export * from './reporters/playwright.js'

--- a/contracts/reporters/playwright.test.ts
+++ b/contracts/reporters/playwright.test.ts
@@ -1,0 +1,182 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { normalisePlaywrightReport } from './playwright.js'
+import { TestRunSchema } from '../test-run.js'
+
+/**
+ * Driven by real reporter output, not a hand-written approximation. A fixture
+ * written to match what the documentation says encodes the author's belief about
+ * the format, and that belief is exactly what an upgrade invalidates.
+ *
+ * The committed run contains, on purpose: nested suites, a pass, an assertion
+ * failure retried to exhaustion, a test that failed and then passed on retry, a
+ * skip with an annotation, and a timeout.
+ */
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const report: unknown = JSON.parse(
+  readFileSync(join(root, 'tests/fixtures/reporters/playwright-1.62.1.json'), 'utf8'),
+)
+
+const meta = { runId: 'run-1', commitSha: 'abc1234', branch: 'main' }
+const run = normalisePlaywrightReport(report, meta)
+const byTitle = (needle: string) => run.results.find((r) => r.title.includes(needle))
+
+describe('normalisePlaywrightReport', () => {
+  it('produces a valid TestRun', () => {
+    expect(() => TestRunSchema.parse(run)).not.toThrow()
+  })
+
+  it('flattens nested suites without losing any test', () => {
+    expect(run.results).toHaveLength(5)
+  })
+
+  it('builds the full title from the suite path, excluding the file suite', () => {
+    // 'sample.spec.ts › task board › reorder › …' would duplicate `file`;
+    // dropping 'reorder' would merge this with any other 'moves a task…'.
+    expect(byTitle('moves a task')?.title).toBe(
+      'task board › reorder › moves a task above its neighbour',
+    )
+  })
+
+  it('gives every test a unique, file-qualified id', () => {
+    const ids = run.results.map((r) => r.testId)
+    expect(new Set(ids).size).toBe(ids.length)
+    for (const id of ids) expect(id.startsWith('sample.spec.ts')).toBe(true)
+  })
+
+  describe('a test that failed and then passed on retry', () => {
+    const flaky = byTitle('completion toggle')
+
+    it('is recorded as passed', () => {
+      expect(flaky?.status).toBe('passed')
+    })
+
+    it('keeps the attempt count', () => {
+      expect(flaky?.attempts).toBe(2)
+    })
+
+    it('is marked flaky within the run', () => {
+      // The single strongest piece of within-run intermittency evidence, and it
+      // exists nowhere else once the run is over.
+      expect(flaky?.flakyWithinRun).toBe(true)
+    })
+
+    it('reports the error from the attempt that failed, not the one that passed', () => {
+      expect(flaky?.error?.message).toBeTruthy()
+    })
+  })
+
+  describe('a test that failed on every attempt', () => {
+    const failed = byTitle('moves a task')
+
+    it('is recorded as failed and not flaky', () => {
+      expect(failed?.status).toBe('failed')
+      expect(failed?.flakyWithinRun).toBe(false)
+    })
+
+    it('counts all three attempts', () => {
+      expect(failed?.attempts).toBe(3)
+    })
+
+    it('carries message, stack and snippet', () => {
+      expect(failed?.error?.message).toContain('toEqual')
+      expect(failed?.error?.stack).toBeTruthy()
+      expect(failed?.error?.snippet).toBeTruthy()
+    })
+  })
+
+  it('keeps timedOut distinct from failed', () => {
+    // A timeout means the assertion was never reached, which is evidence for a
+    // different quadrant than an assertion that ran and disagreed.
+    expect(byTitle('slow operation')?.status).toBe('timedOut')
+  })
+
+  it('preserves skip annotations', () => {
+    const skipped = byTitle('drag handle')
+    expect(skipped?.status).toBe('skipped')
+    expect(skipped?.annotations).toContain('skip: covered by keyboard reorder')
+  })
+
+  it('sums duration across attempts', () => {
+    const failed = byTitle('moves a task')
+    expect(failed?.durationMs).toBeGreaterThan(0)
+  })
+
+  it('takes run identity from the caller, since the reporter records none', () => {
+    expect(run).toMatchObject({ runId: 'run-1', commitSha: 'abc1234', branch: 'main' })
+    expect(run.source).toBe('playwright')
+  })
+
+  it('normalises the start time to ISO 8601', () => {
+    expect(run.startedAt).toMatch(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/)
+  })
+
+  it('leaves no required field undefined', () => {
+    for (const result of run.results) {
+      for (const [key, value] of Object.entries(result)) {
+        expect(value, `${result.title}.${key}`).toBeDefined()
+      }
+    }
+  })
+})
+
+describe('when the reporter format changes', () => {
+  it('fails loudly and says where to look', () => {
+    // The alternative is reading undefined and reporting that every test passed
+    // once — worse than a crash, and much harder to notice.
+    expect(() => normalisePlaywrightReport({ suites: [], stats: {} }, meta)).toThrow(
+      /reporter format may have changed[\s\S]*contracts\/reporters\/playwright\.ts/,
+    )
+  })
+
+  it('rejects a renamed status field rather than guessing', () => {
+    const broken = {
+      suites: [
+        {
+          title: 'a.spec.ts',
+          specs: [
+            {
+              title: 't',
+              file: 'a.spec.ts',
+              tests: [
+                { status: 'unexpected', results: [{ outcome: 'failed', duration: 1, retry: 0 }] },
+              ],
+            },
+          ],
+        },
+      ],
+      stats: { startTime: '2026-01-01T00:00:00.000Z', duration: 1 },
+    }
+    expect(() => normalisePlaywrightReport(broken, meta)).toThrow()
+  })
+
+  it('tolerates fields Playwright adds that this module does not read', () => {
+    const withExtras = {
+      suites: [
+        {
+          title: 'a.spec.ts',
+          somethingNew: true,
+          specs: [
+            {
+              title: 't',
+              file: 'a.spec.ts',
+              futureField: 1,
+              tests: [
+                {
+                  status: 'expected',
+                  annotations: [],
+                  results: [{ status: 'passed', duration: 1, retry: 0, newThing: 'x' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      stats: { startTime: '2026-01-01T00:00:00.000Z', duration: 1, newStat: 2 },
+    }
+    expect(normalisePlaywrightReport(withExtras, meta).results).toHaveLength(1)
+  })
+})

--- a/contracts/reporters/playwright.ts
+++ b/contracts/reporters/playwright.ts
@@ -1,0 +1,221 @@
+import { z } from 'zod'
+import {
+  deriveTestId,
+  normaliseFilePath,
+  type TestError,
+  type TestResult,
+  type TestRun,
+  type TestStatus,
+} from '../test-run.js'
+
+/**
+ * Playwright JSON reporter → `TestRun`.
+ *
+ * Everything Playwright-specific lives in this file. That is the whole point: a
+ * major version bump breaks one module with a legible error, rather than
+ * corrupting `analysis.json` three stages downstream where the symptom is
+ * "every test suddenly looks new".
+ *
+ * Three things in the source format carry signal that is easy to lose:
+ *
+ *  - Suites nest recursively, and a test's identity is its **full** title. Taking
+ *    only the leaf would merge `reorder › moves up` with any other `moves up`.
+ *  - Retries are separate entries in `results[]`. A test that failed and then
+ *    passed is the strongest within-run intermittency evidence there is, and it
+ *    exists nowhere else once the run is over.
+ *  - The final result of a flaky test is the *passing* one, so its error is
+ *    absent. The error worth reporting comes from the attempt that failed.
+ */
+
+// ---------------------------------------------------------------------------
+// Source format
+//
+// Loose objects, not strict: Playwright adds fields between minor versions and
+// failing on an addition would be noise. What must fail is a change to a field
+// this module reads — those are required below.
+// ---------------------------------------------------------------------------
+
+const PlaywrightErrorSchema = z.looseObject({
+  message: z.string().optional(),
+  stack: z.string().optional(),
+  snippet: z.string().optional(),
+})
+
+const PlaywrightResultSchema = z.looseObject({
+  status: z.enum(['passed', 'failed', 'timedOut', 'skipped', 'interrupted']),
+  duration: z.number(),
+  retry: z.number(),
+  error: PlaywrightErrorSchema.optional(),
+})
+
+const PlaywrightAnnotationSchema = z.looseObject({
+  type: z.string(),
+  description: z.string().optional(),
+})
+
+const PlaywrightTestSchema = z.looseObject({
+  status: z.enum(['expected', 'unexpected', 'flaky', 'skipped']),
+  annotations: z.array(PlaywrightAnnotationSchema).default([]),
+  results: z.array(PlaywrightResultSchema),
+})
+
+const PlaywrightSpecSchema = z.looseObject({
+  title: z.string(),
+  file: z.string(),
+  tests: z.array(PlaywrightTestSchema),
+})
+
+/** Suites nest arbitrarily deep; the recursion has to be explicit for Zod. */
+export interface PlaywrightSuite {
+  title: string
+  // Explicit `| undefined` because exactOptionalPropertyTypes is on and Zod's
+  // inferred optionals include it; without this the recursive type does not
+  // match the schema it describes.
+  file?: string | undefined
+  specs: z.infer<typeof PlaywrightSpecSchema>[]
+  suites?: PlaywrightSuite[] | undefined
+}
+
+const PlaywrightSuiteSchema: z.ZodType<PlaywrightSuite> = z.lazy(() =>
+  z.looseObject({
+    title: z.string(),
+    file: z.string().optional(),
+    specs: z.array(PlaywrightSpecSchema),
+    suites: z.array(PlaywrightSuiteSchema).optional(),
+  }),
+)
+
+export const PlaywrightReportSchema = z.looseObject({
+  suites: z.array(PlaywrightSuiteSchema),
+  stats: z.looseObject({
+    startTime: z.string(),
+    duration: z.number(),
+  }),
+})
+
+export type PlaywrightReport = z.infer<typeof PlaywrightReportSchema>
+
+// ---------------------------------------------------------------------------
+// Normalisation
+// ---------------------------------------------------------------------------
+
+/**
+ * `interrupted` maps to `timedOut` rather than `failed`.
+ *
+ * Both mean the assertion was never reached, which is the distinction the
+ * `TestStatus` enum exists to preserve. Mapping it to `failed` would tell the
+ * classifier an assertion ran and disagreed, which is not what happened.
+ */
+const STATUS: Record<z.infer<typeof PlaywrightResultSchema>['status'], TestStatus> = {
+  passed: 'passed',
+  failed: 'failed',
+  timedOut: 'timedOut',
+  skipped: 'skipped',
+  interrupted: 'timedOut',
+}
+
+export interface RunMetadata {
+  runId: string
+  commitSha: string
+  branch: string
+}
+
+/** The title Playwright itself displays: suite path below the file, then the spec. */
+const TITLE_SEPARATOR = ' › '
+
+function toError(raw: z.infer<typeof PlaywrightErrorSchema> | undefined): TestError | undefined {
+  if (raw === undefined) return undefined
+  const error: TestError = {
+    message: raw.message ?? 'Playwright reported a failure with no message',
+  }
+  if (raw.stack !== undefined) error.stack = raw.stack
+  if (raw.snippet !== undefined) error.snippet = raw.snippet
+  return error
+}
+
+function toResult(
+  spec: z.infer<typeof PlaywrightSpecSchema>,
+  test: z.infer<typeof PlaywrightTestSchema>,
+  suitePath: string[],
+): TestResult {
+  const title = [...suitePath, spec.title].join(TITLE_SEPARATOR)
+  const file = normaliseFilePath(spec.file)
+
+  const attempts = test.results
+  const last = attempts.at(-1)
+  const status: TestStatus = last === undefined ? 'skipped' : STATUS[last.status]
+
+  // A flaky test's final attempt passed, so its error is gone. Report the
+  // failure that actually happened.
+  const failing = [...attempts].reverse().find((r) => r.error !== undefined)
+
+  const passedAfterFailing =
+    status === 'passed' && attempts.some((r) => r.status === 'failed' || r.status === 'timedOut')
+
+  const normalised: TestResult = {
+    testId: deriveTestId(file, title),
+    title,
+    file,
+    status,
+    attempts: Math.max(attempts.length, 1),
+    flakyWithinRun: test.status === 'flaky' || passedAfterFailing,
+    durationMs: attempts.reduce((total, r) => total + r.duration, 0),
+    annotations: test.annotations.map((a) =>
+      a.description === undefined ? a.type : `${a.type}: ${a.description}`,
+    ),
+  }
+
+  const error = toError(failing?.error)
+  if (error !== undefined) normalised.error = error
+
+  return normalised
+}
+
+function collect(
+  suite: PlaywrightSuite,
+  suitePath: string[],
+  out: TestResult[],
+  depth: number,
+): void {
+  // The outermost suite is the file itself; its title is the filename and would
+  // duplicate `file` in every test title.
+  const path = depth === 0 ? [] : [...suitePath, suite.title]
+
+  for (const spec of suite.specs) {
+    for (const test of spec.tests) out.push(toResult(spec, test, path))
+  }
+  for (const child of suite.suites ?? []) collect(child, path, out, depth + 1)
+}
+
+/**
+ * Validate a Playwright JSON report and normalise it.
+ *
+ * `meta` is supplied by the caller because the reporter records none of it — the
+ * run identity comes from CI, not from the test tool.
+ */
+export function normalisePlaywrightReport(raw: unknown, meta: RunMetadata): TestRun {
+  const parsed = PlaywrightReportSchema.safeParse(raw)
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .slice(0, 5)
+      .map((i) => `  ${i.path.join('.') || '<root>'}: ${i.message}`)
+      .join('\n')
+    throw new Error(
+      `Not a Playwright JSON report. The reporter format may have changed:\n${issues}\n` +
+        `Update contracts/reporters/playwright.ts and the fixture in tests/fixtures/reporters/.`,
+    )
+  }
+
+  const results: TestResult[] = []
+  for (const suite of parsed.data.suites) collect(suite, [], results, 0)
+
+  return {
+    runId: meta.runId,
+    commitSha: meta.commitSha,
+    branch: meta.branch,
+    startedAt: new Date(parsed.data.stats.startTime).toISOString(),
+    durationMs: parsed.data.stats.duration,
+    source: 'playwright',
+    results,
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@commitlint/cli": "19.6.1",
         "@commitlint/config-conventional": "19.6.0",
         "@eslint/js": "9.39.5",
+        "@playwright/test": "1.62.1",
         "@types/node": "^22.10.2",
         "@vitest/coverage-v8": "4.1.10",
         "eslint": "9.39.5",
@@ -1316,6 +1317,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -4387,6 +4404,53 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@commitlint/cli": "19.6.1",
     "@commitlint/config-conventional": "19.6.0",
     "@eslint/js": "9.39.5",
+    "@playwright/test": "1.62.1",
     "@types/node": "^22.10.2",
     "@vitest/coverage-v8": "4.1.10",
     "eslint": "9.39.5",

--- a/tests/fixtures/reporters/README.md
+++ b/tests/fixtures/reporters/README.md
@@ -1,0 +1,16 @@
+# Reporter fixtures
+
+Real output from the pinned reporter versions, produced by running the tool — not hand-written to
+match what its documentation says. Hand-written fixtures encode the author's belief about a format,
+and that belief is exactly what breaks on an upgrade.
+
+| File                     | Produced by                                    | Contains                                                                                                                                                    |
+| ------------------------ | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `playwright-1.62.1.json` | `@playwright/test` JSON reporter, `retries: 2` | nested suites, a pass, an assertion failure retried to exhaustion, a test that failed then passed on retry, a `test.skip` with an annotation, and a timeout |
+
+Absolute paths from the machine that produced them are rewritten to `/repo`, and the node binary
+path to `/usr/local/bin/node`. Nothing else is edited: the point is that the shape is genuine.
+
+Regenerating these is deliberately manual — see the pinned versions asserted in
+`tests/unit/reporter-contract.test.ts`. A version bump should be a conscious update with the new
+output committed, not a silent refresh.

--- a/tests/fixtures/reporters/playwright-1.62.1.json
+++ b/tests/fixtures/reporters/playwright-1.62.1.json
@@ -1,0 +1,512 @@
+{
+  "config": {
+    "argv": ["/usr/local/bin/node", "/repo/node_modules/.bin/playwright", "test"],
+    "configFile": "/repo/playwright.config.ts",
+    "rootDir": "/repo/specs",
+    "failOnFlakyTests": false,
+    "forbidOnly": false,
+    "fullyParallel": false,
+    "globalSetup": null,
+    "globalTeardown": null,
+    "globalTimeout": 0,
+    "grep": {},
+    "grepInvert": null,
+    "maxFailures": 0,
+    "metadata": {
+      "actualWorkers": 1
+    },
+    "preserveOutput": "always",
+    "projects": [
+      {
+        "outputDir": "/repo/test-results",
+        "repeatEach": 1,
+        "retries": 2,
+        "metadata": {
+          "actualWorkers": 1
+        },
+        "id": "chromium",
+        "name": "chromium",
+        "testDir": "/repo/specs",
+        "testIgnore": [],
+        "testMatch": ["**/*.@(spec|test).?(c|m)[jt]s?(x)"],
+        "timeout": 30000
+      }
+    ],
+    "quiet": false,
+    "reporter": [
+      [
+        "json",
+        {
+          "outputFile": "report.json"
+        }
+      ]
+    ],
+    "reportSlowTests": {
+      "max": 5,
+      "threshold": 300000
+    },
+    "shard": null,
+    "tags": [],
+    "updateSnapshots": "missing",
+    "updateSourceMethod": "patch",
+    "version": "1.62.1",
+    "workers": 14,
+    "webServer": null
+  },
+  "suites": [
+    {
+      "title": "sample.spec.ts",
+      "file": "sample.spec.ts",
+      "column": 0,
+      "line": 0,
+      "specs": [
+        {
+          "title": "completion toggle settles before assertion",
+          "ok": true,
+          "tags": [],
+          "tests": [
+            {
+              "timeout": 30000,
+              "annotations": [],
+              "expectedStatus": "passed",
+              "projectId": "chromium",
+              "projectName": "chromium",
+              "results": [
+                {
+                  "workerIndex": 3,
+                  "parallelIndex": 0,
+                  "status": "failed",
+                  "duration": 3,
+                  "error": {
+                    "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeGreaterThan\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected: > \u001b[32m0\u001b[39m\nReceived:   \u001b[31m0\u001b[39m",
+                    "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeGreaterThan\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected: > \u001b[32m0\u001b[39m\nReceived:   \u001b[31m0\u001b[39m\n    at /repo/specs/sample.spec.ts:21:13",
+                    "location": {
+                      "file": "/repo/specs/sample.spec.ts",
+                      "column": 13,
+                      "line": 21
+                    },
+                    "snippet": "  19 |   const n = existsSync(COUNTER) ? Number(readFileSync(COUNTER, 'utf8')) : 0\n  20 |   writeFileSync(COUNTER, String(n + 1))\n> 21 |   expect(n).toBeGreaterThan(0)\n     |             ^\n  22 | })\n  23 |\n  24 | test('drag handle is present', async () => {"
+                  },
+                  "errors": [
+                    {
+                      "location": {
+                        "file": "/repo/specs/sample.spec.ts",
+                        "column": 13,
+                        "line": 21
+                      },
+                      "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBeGreaterThan\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected: > \u001b[32m0\u001b[39m\nReceived:   \u001b[31m0\u001b[39m\n\n  19 |   const n = existsSync(COUNTER) ? Number(readFileSync(COUNTER, 'utf8')) : 0\n  20 |   writeFileSync(COUNTER, String(n + 1))\n> 21 |   expect(n).toBeGreaterThan(0)\n     |             ^\n  22 | })\n  23 |\n  24 | test('drag handle is present', async () => {\n    at /repo/specs/sample.spec.ts:21:13"
+                    }
+                  ],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 0,
+                  "startTime": "2026-08-10T10:31:10.849Z",
+                  "annotations": [],
+                  "attachments": [
+                    {
+                      "name": "error-context",
+                      "contentType": "text/markdown",
+                      "path": "/repo/test-results/sample-completion-toggle-settles-before-assertion-chromium/error-context.md"
+                    }
+                  ],
+                  "errorLocation": {
+                    "file": "/repo/specs/sample.spec.ts",
+                    "column": 13,
+                    "line": 21
+                  }
+                },
+                {
+                  "workerIndex": 4,
+                  "parallelIndex": 0,
+                  "status": "passed",
+                  "duration": 2,
+                  "errors": [],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 1,
+                  "startTime": "2026-08-10T10:31:11.038Z",
+                  "annotations": [],
+                  "attachments": []
+                }
+              ],
+              "status": "flaky"
+            }
+          ],
+          "id": "b92766bcf73bd5c029a8-c0e8f226384405cbfe68",
+          "file": "sample.spec.ts",
+          "line": 18,
+          "column": 5
+        },
+        {
+          "title": "drag handle is present",
+          "ok": true,
+          "tags": [],
+          "tests": [
+            {
+              "timeout": 30000,
+              "annotations": [
+                {
+                  "type": "skip",
+                  "description": "covered by keyboard reorder",
+                  "location": {
+                    "file": "/repo/specs/sample.spec.ts",
+                    "line": 25,
+                    "column": 8
+                  }
+                }
+              ],
+              "expectedStatus": "skipped",
+              "projectId": "chromium",
+              "projectName": "chromium",
+              "results": [
+                {
+                  "workerIndex": 4,
+                  "parallelIndex": 0,
+                  "status": "skipped",
+                  "duration": 0,
+                  "errors": [],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 0,
+                  "startTime": "2026-08-10T10:31:11.054Z",
+                  "annotations": [
+                    {
+                      "type": "skip",
+                      "description": "covered by keyboard reorder",
+                      "location": {
+                        "file": "/repo/specs/sample.spec.ts",
+                        "line": 25,
+                        "column": 8
+                      }
+                    }
+                  ],
+                  "attachments": []
+                }
+              ],
+              "status": "skipped"
+            }
+          ],
+          "id": "b92766bcf73bd5c029a8-02d9b1baa6be5b11dbb7",
+          "file": "sample.spec.ts",
+          "line": 24,
+          "column": 5
+        },
+        {
+          "title": "slow operation finishes in time",
+          "ok": false,
+          "tags": [],
+          "tests": [
+            {
+              "timeout": 150,
+              "annotations": [],
+              "expectedStatus": "passed",
+              "projectId": "chromium",
+              "projectName": "chromium",
+              "results": [
+                {
+                  "workerIndex": 4,
+                  "parallelIndex": 0,
+                  "status": "timedOut",
+                  "duration": 151,
+                  "error": {
+                    "message": "\u001b[31mTest timeout of 150ms exceeded.\u001b[39m",
+                    "stack": "\u001b[31mTest timeout of 150ms exceeded.\u001b[39m"
+                  },
+                  "errors": [
+                    {
+                      "message": "\u001b[31mTest timeout of 150ms exceeded.\u001b[39m"
+                    }
+                  ],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 0,
+                  "startTime": "2026-08-10T10:31:11.060Z",
+                  "annotations": [],
+                  "attachments": [
+                    {
+                      "name": "error-context",
+                      "contentType": "text/markdown",
+                      "path": "/repo/test-results/sample-slow-operation-finishes-in-time-chromium/error-context.md"
+                    }
+                  ]
+                },
+                {
+                  "workerIndex": 5,
+                  "parallelIndex": 0,
+                  "status": "timedOut",
+                  "duration": 152,
+                  "error": {
+                    "message": "\u001b[31mTest timeout of 150ms exceeded.\u001b[39m",
+                    "stack": "\u001b[31mTest timeout of 150ms exceeded.\u001b[39m"
+                  },
+                  "errors": [
+                    {
+                      "message": "\u001b[31mTest timeout of 150ms exceeded.\u001b[39m"
+                    }
+                  ],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 1,
+                  "startTime": "2026-08-10T10:31:11.400Z",
+                  "annotations": [],
+                  "attachments": [
+                    {
+                      "name": "error-context",
+                      "contentType": "text/markdown",
+                      "path": "/repo/test-results/sample-slow-operation-finishes-in-time-chromium-retry1/error-context.md"
+                    }
+                  ]
+                },
+                {
+                  "workerIndex": 6,
+                  "parallelIndex": 0,
+                  "status": "timedOut",
+                  "duration": 152,
+                  "error": {
+                    "message": "\u001b[31mTest timeout of 150ms exceeded.\u001b[39m",
+                    "stack": "\u001b[31mTest timeout of 150ms exceeded.\u001b[39m"
+                  },
+                  "errors": [
+                    {
+                      "message": "\u001b[31mTest timeout of 150ms exceeded.\u001b[39m"
+                    }
+                  ],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 2,
+                  "startTime": "2026-08-10T10:31:11.749Z",
+                  "annotations": [],
+                  "attachments": [
+                    {
+                      "name": "error-context",
+                      "contentType": "text/markdown",
+                      "path": "/repo/test-results/sample-slow-operation-finishes-in-time-chromium-retry2/error-context.md"
+                    }
+                  ]
+                }
+              ],
+              "status": "unexpected"
+            }
+          ],
+          "id": "b92766bcf73bd5c029a8-a30fc39ecd98ffbb09af",
+          "file": "sample.spec.ts",
+          "line": 28,
+          "column": 5
+        }
+      ],
+      "suites": [
+        {
+          "title": "task board",
+          "file": "sample.spec.ts",
+          "line": 6,
+          "column": 6,
+          "specs": [
+            {
+              "title": "lists tasks after load",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 0,
+                      "parallelIndex": 0,
+                      "status": "passed",
+                      "duration": 2,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-08-10T10:31:10.248Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "b92766bcf73bd5c029a8-75946ab33b639189b73d",
+              "file": "sample.spec.ts",
+              "line": 7,
+              "column": 7
+            }
+          ],
+          "suites": [
+            {
+              "title": "reorder",
+              "file": "sample.spec.ts",
+              "line": 11,
+              "column": 8,
+              "specs": [
+                {
+                  "title": "moves a task above its neighbour",
+                  "ok": false,
+                  "tags": [],
+                  "tests": [
+                    {
+                      "timeout": 30000,
+                      "annotations": [],
+                      "expectedStatus": "passed",
+                      "projectId": "chromium",
+                      "projectName": "chromium",
+                      "results": [
+                        {
+                          "workerIndex": 0,
+                          "parallelIndex": 0,
+                          "status": "failed",
+                          "duration": 2,
+                          "error": {
+                            "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoEqual\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // deep equality\u001b[22m\n\n\u001b[32m- Expected  - 1\u001b[39m\n\u001b[31m+ Received  + 1\u001b[39m\n\n\u001b[2m  Array [\u001b[22m\n\u001b[32m-   \"a\",\u001b[39m\n\u001b[2m    \"b\",\u001b[22m\n\u001b[31m+   \"a\",\u001b[39m\n\u001b[2m  ]\u001b[22m",
+                            "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoEqual\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // deep equality\u001b[22m\n\n\u001b[32m- Expected  - 1\u001b[39m\n\u001b[31m+ Received  + 1\u001b[39m\n\n\u001b[2m  Array [\u001b[22m\n\u001b[32m-   \"a\",\u001b[39m\n\u001b[2m    \"b\",\u001b[22m\n\u001b[31m+   \"a\",\u001b[39m\n\u001b[2m  ]\u001b[22m\n    at /repo/specs/sample.spec.ts:13:26",
+                            "location": {
+                              "file": "/repo/specs/sample.spec.ts",
+                              "column": 26,
+                              "line": 13
+                            },
+                            "snippet": "  11 |   test.describe('reorder', () => {\n  12 |     test('moves a task above its neighbour', async () => {\n> 13 |       expect(['b', 'a']).toEqual(['a', 'b'])\n     |                          ^\n  14 |     })\n  15 |   })\n  16 | })"
+                          },
+                          "errors": [
+                            {
+                              "location": {
+                                "file": "/repo/specs/sample.spec.ts",
+                                "column": 26,
+                                "line": 13
+                              },
+                              "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoEqual\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // deep equality\u001b[22m\n\n\u001b[32m- Expected  - 1\u001b[39m\n\u001b[31m+ Received  + 1\u001b[39m\n\n\u001b[2m  Array [\u001b[22m\n\u001b[32m-   \"a\",\u001b[39m\n\u001b[2m    \"b\",\u001b[22m\n\u001b[31m+   \"a\",\u001b[39m\n\u001b[2m  ]\u001b[22m\n\n  11 |   test.describe('reorder', () => {\n  12 |     test('moves a task above its neighbour', async () => {\n> 13 |       expect(['b', 'a']).toEqual(['a', 'b'])\n     |                          ^\n  14 |     })\n  15 |   })\n  16 | })\n    at /repo/specs/sample.spec.ts:13:26"
+                            }
+                          ],
+                          "stdout": [],
+                          "stderr": [],
+                          "retry": 0,
+                          "startTime": "2026-08-10T10:31:10.265Z",
+                          "annotations": [],
+                          "attachments": [
+                            {
+                              "name": "error-context",
+                              "contentType": "text/markdown",
+                              "path": "/repo/test-results/sample-task-board-reorder-moves-a-task-above-its-neighbour-chromium/error-context.md"
+                            }
+                          ],
+                          "errorLocation": {
+                            "file": "/repo/specs/sample.spec.ts",
+                            "column": 26,
+                            "line": 13
+                          }
+                        },
+                        {
+                          "workerIndex": 1,
+                          "parallelIndex": 0,
+                          "status": "failed",
+                          "duration": 4,
+                          "error": {
+                            "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoEqual\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // deep equality\u001b[22m\n\n\u001b[32m- Expected  - 1\u001b[39m\n\u001b[31m+ Received  + 1\u001b[39m\n\n\u001b[2m  Array [\u001b[22m\n\u001b[32m-   \"a\",\u001b[39m\n\u001b[2m    \"b\",\u001b[22m\n\u001b[31m+   \"a\",\u001b[39m\n\u001b[2m  ]\u001b[22m",
+                            "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoEqual\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // deep equality\u001b[22m\n\n\u001b[32m- Expected  - 1\u001b[39m\n\u001b[31m+ Received  + 1\u001b[39m\n\n\u001b[2m  Array [\u001b[22m\n\u001b[32m-   \"a\",\u001b[39m\n\u001b[2m    \"b\",\u001b[22m\n\u001b[31m+   \"a\",\u001b[39m\n\u001b[2m  ]\u001b[22m\n    at /repo/specs/sample.spec.ts:13:26",
+                            "location": {
+                              "file": "/repo/specs/sample.spec.ts",
+                              "column": 26,
+                              "line": 13
+                            },
+                            "snippet": "  11 |   test.describe('reorder', () => {\n  12 |     test('moves a task above its neighbour', async () => {\n> 13 |       expect(['b', 'a']).toEqual(['a', 'b'])\n     |                          ^\n  14 |     })\n  15 |   })\n  16 | })"
+                          },
+                          "errors": [
+                            {
+                              "location": {
+                                "file": "/repo/specs/sample.spec.ts",
+                                "column": 26,
+                                "line": 13
+                              },
+                              "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoEqual\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // deep equality\u001b[22m\n\n\u001b[32m- Expected  - 1\u001b[39m\n\u001b[31m+ Received  + 1\u001b[39m\n\n\u001b[2m  Array [\u001b[22m\n\u001b[32m-   \"a\",\u001b[39m\n\u001b[2m    \"b\",\u001b[22m\n\u001b[31m+   \"a\",\u001b[39m\n\u001b[2m  ]\u001b[22m\n\n  11 |   test.describe('reorder', () => {\n  12 |     test('moves a task above its neighbour', async () => {\n> 13 |       expect(['b', 'a']).toEqual(['a', 'b'])\n     |                          ^\n  14 |     })\n  15 |   })\n  16 | })\n    at /repo/specs/sample.spec.ts:13:26"
+                            }
+                          ],
+                          "stdout": [],
+                          "stderr": [],
+                          "retry": 1,
+                          "startTime": "2026-08-10T10:31:10.449Z",
+                          "annotations": [],
+                          "attachments": [
+                            {
+                              "name": "error-context",
+                              "contentType": "text/markdown",
+                              "path": "/repo/test-results/sample-task-board-reorder-moves-a-task-above-its-neighbour-chromium-retry1/error-context.md"
+                            }
+                          ],
+                          "errorLocation": {
+                            "file": "/repo/specs/sample.spec.ts",
+                            "column": 26,
+                            "line": 13
+                          }
+                        },
+                        {
+                          "workerIndex": 2,
+                          "parallelIndex": 0,
+                          "status": "failed",
+                          "duration": 4,
+                          "error": {
+                            "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoEqual\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // deep equality\u001b[22m\n\n\u001b[32m- Expected  - 1\u001b[39m\n\u001b[31m+ Received  + 1\u001b[39m\n\n\u001b[2m  Array [\u001b[22m\n\u001b[32m-   \"a\",\u001b[39m\n\u001b[2m    \"b\",\u001b[22m\n\u001b[31m+   \"a\",\u001b[39m\n\u001b[2m  ]\u001b[22m",
+                            "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoEqual\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // deep equality\u001b[22m\n\n\u001b[32m- Expected  - 1\u001b[39m\n\u001b[31m+ Received  + 1\u001b[39m\n\n\u001b[2m  Array [\u001b[22m\n\u001b[32m-   \"a\",\u001b[39m\n\u001b[2m    \"b\",\u001b[22m\n\u001b[31m+   \"a\",\u001b[39m\n\u001b[2m  ]\u001b[22m\n    at /repo/specs/sample.spec.ts:13:26",
+                            "location": {
+                              "file": "/repo/specs/sample.spec.ts",
+                              "column": 26,
+                              "line": 13
+                            },
+                            "snippet": "  11 |   test.describe('reorder', () => {\n  12 |     test('moves a task above its neighbour', async () => {\n> 13 |       expect(['b', 'a']).toEqual(['a', 'b'])\n     |                          ^\n  14 |     })\n  15 |   })\n  16 | })"
+                          },
+                          "errors": [
+                            {
+                              "location": {
+                                "file": "/repo/specs/sample.spec.ts",
+                                "column": 26,
+                                "line": 13
+                              },
+                              "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoEqual\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // deep equality\u001b[22m\n\n\u001b[32m- Expected  - 1\u001b[39m\n\u001b[31m+ Received  + 1\u001b[39m\n\n\u001b[2m  Array [\u001b[22m\n\u001b[32m-   \"a\",\u001b[39m\n\u001b[2m    \"b\",\u001b[22m\n\u001b[31m+   \"a\",\u001b[39m\n\u001b[2m  ]\u001b[22m\n\n  11 |   test.describe('reorder', () => {\n  12 |     test('moves a task above its neighbour', async () => {\n> 13 |       expect(['b', 'a']).toEqual(['a', 'b'])\n     |                          ^\n  14 |     })\n  15 |   })\n  16 | })\n    at /repo/specs/sample.spec.ts:13:26"
+                            }
+                          ],
+                          "stdout": [],
+                          "stderr": [],
+                          "retry": 2,
+                          "startTime": "2026-08-10T10:31:10.649Z",
+                          "annotations": [],
+                          "attachments": [
+                            {
+                              "name": "error-context",
+                              "contentType": "text/markdown",
+                              "path": "/repo/test-results/sample-task-board-reorder-moves-a-task-above-its-neighbour-chromium-retry2/error-context.md"
+                            }
+                          ],
+                          "errorLocation": {
+                            "file": "/repo/specs/sample.spec.ts",
+                            "column": 26,
+                            "line": 13
+                          }
+                        }
+                      ],
+                      "status": "unexpected"
+                    }
+                  ],
+                  "id": "b92766bcf73bd5c029a8-7be10cfa6da011233bfc",
+                  "file": "sample.spec.ts",
+                  "line": 12,
+                  "column": 9
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "errors": [],
+  "stats": {
+    "startTime": "2026-08-10T10:31:10.059Z",
+    "duration": 1864.0789999999997,
+    "expected": 1,
+    "skipped": 1,
+    "unexpected": 2,
+    "flaky": 1
+  }
+}


### PR DESCRIPTION
Closes #14

## What changed

`normalisePlaywrightReport(raw, meta)` turns Playwright's JSON reporter output into a `TestRun`. Every Playwright-specific field is handled in this one file, behind a Zod schema of the source format.

## Why

Isolating the format means a Playwright major bump breaks one module with a legible error, instead of corrupting `analysis.json` three stages downstream where the symptom is "every test suddenly looks new".

## Decisions worth reviewing

**The fixture is real output, not a hand-written approximation.** `tests/fixtures/reporters/playwright-1.62.1.json` was produced by actually running `@playwright/test` with `retries: 2` against a throwaway suite built to contain, on purpose: nested suites, a pass, an assertion failure retried to exhaustion, a test that failed and then passed on retry, a `test.skip` with an annotation, and a timeout.

A fixture written to match what the documentation says encodes the author's belief about the format — and that belief is precisely what an upgrade invalidates. Only absolute machine paths were rewritten (to `/repo` and `/usr/local/bin/node`); nothing else is edited.

**The source schema is loose, not strict.** The opposite of the `TestRun` schema, deliberately. Playwright adds fields between minor versions and failing on an addition would be pure noise; what must fail is a change to a field this module *reads*, and those are required. Both behaviours are tested.

**Three pieces of signal that are easy to lose, and are not:**

- **Full titles.** The suite path below the file is joined into the title, so `reorder › moves a task up` cannot collide with another `moves a task up` elsewhere. The outermost suite is dropped because its title is the filename, which `file` already carries.
- **Retries.** `attempts` counts every entry in `results[]`. A test that failed and then passed is the strongest within-run intermittency evidence there is, and it exists nowhere else once the run is over — the history file records one status per run, not per attempt.
- **The error of a flaky test.** Its *final* attempt passed, so the last result has no error. The normaliser walks backwards for the attempt that actually failed. Taking the last result would silently produce a flaky test with no error attached.

**`interrupted` maps to `timedOut`, not `failed`.** Both mean the assertion was never reached, which is the distinction `TestStatus` exists to preserve. Mapping it to `failed` would tell the classifier an assertion ran and disagreed, which is not what happened.

**Run identity comes from the caller.** The reporter records no commit, branch or run id — those belong to CI, not to the test tool — so `meta` is a parameter rather than something guessed from the environment inside a pure function.

## How it was verified

86 assertions total, 20 new. Against the real fixture, they check each of the above specifically: the flaky test comes back `passed` with `attempts: 2`, `flakyWithinRun: true` and the failing attempt's error; the exhausted failure comes back with `attempts: 3` and message, stack and snippet; the timeout keeps its own status; the skip keeps its annotation text.

Three tests cover the upgrade path directly — a missing field fails with a message naming this file and the fixture directory, a *renamed* field is rejected rather than read as `undefined`, and an *added* field is tolerated.

There is also a blanket assertion that no required field on any normalised result is `undefined`, which is the shape the quiet failure would take.

```bash
npm run lint && npm run format:check && npm run typecheck && npm run test:unit   # all clean
```

## Checklist

- [x] Title is a valid Conventional Commit
- [x] Linked to exactly one issue with `Closes #N`
- [x] All checks clean
- [x] Tests cover the failure modes, including the upgrade path
- [x] Fixture provenance documented in `tests/fixtures/reporters/README.md`

## Notes for the reviewer

`PlaywrightSuite` declares `file?: string | undefined` explicitly. With `exactOptionalPropertyTypes` on, Zod's inferred optionals include `undefined`, and the recursive interface does not match the schema it describes without it — worth knowing before someone "tidies" it.

`@playwright/test` is a dev dependency from here rather than M5. Generating genuine fixtures needs the real reporter, and the throwaway suite that produced this one runs without a browser install.
