### PR TITLE
feat(eval): normalise Vitest JSON reporter output

### DIFF
--- a/contracts/index.ts
+++ b/contracts/index.ts
@@ -8,3 +8,4 @@
 
 export * from './test-run.js'
 export * from './reporters/playwright.js'
+export * from './reporters/vitest.js'

--- a/contracts/reporters/vitest.test.ts
+++ b/contracts/reporters/vitest.test.ts
@@ -1,0 +1,126 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { normaliseVitestReport, toRepositoryPath } from './vitest.js'
+import { TestRunSchema } from '../test-run.js'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const report: unknown = JSON.parse(
+  readFileSync(join(root, 'tests/fixtures/reporters/vitest-4.1.10.json'), 'utf8'),
+)
+
+const meta = { runId: 'run-1', commitSha: 'abc1234', branch: 'main', repositoryRoot: '/repo' }
+const run = normaliseVitestReport(report, meta)
+const byTitle = (needle: string) => run.results.find((r) => r.title.includes(needle))
+
+describe('normaliseVitestReport', () => {
+  it('produces a valid TestRun indistinguishable in shape from a Playwright one', () => {
+    expect(() => TestRunSchema.parse(run)).not.toThrow()
+    expect(run.source).toBe('vitest')
+  })
+
+  it('keeps every assertion', () => {
+    expect(run.results).toHaveLength(4)
+  })
+
+  it('rebuilds the title from the ancestor titles rather than trusting fullName', () => {
+    // Vitest joins ancestors with a space, so `describe('a') > it('b c')` and
+    // `describe('a b') > it('c')` collapse to the same fullName. Rebuilding from
+    // the parts keeps them apart — and matches the Playwright separator.
+    expect(byTitle('out-of-range')?.title).toBe(
+      'task api › reorder › rejects an out-of-range position',
+    )
+  })
+
+  it('makes paths repository-relative so ids match across machines', () => {
+    for (const result of run.results) {
+      expect(result.file).toBe('specs/tasks.test.ts')
+      expect(result.testId.startsWith('specs/tasks.test.ts')).toBe(true)
+    }
+  })
+
+  it('splits the assertion message from the stack', () => {
+    const failed = byTitle('out-of-range')
+    expect(failed?.error?.message).toBe(
+      'AssertionError: expected { position: 9 } to deeply equal { position: 1 }',
+    )
+    expect(failed?.error?.stack).toContain('    at ')
+    expect(failed?.error?.message).not.toContain('    at ')
+  })
+
+  it('handles a thrown error as well as a failed assertion', () => {
+    expect(byTitle('missing task')?.error?.message).toContain('TypeError')
+  })
+
+  it('records skipped tests as skipped with no error', () => {
+    const skipped = byTitle('bulk delete')
+    expect(skipped?.status).toBe('skipped')
+    expect(skipped?.error).toBeUndefined()
+  })
+
+  it('reports one attempt and no within-run flakiness, because Vitest records neither', () => {
+    // The absence is information: "we do not know", not "passed first time".
+    // Inventing retries here would manufacture confidence on the determinism
+    // axis that the data does not support.
+    for (const result of run.results) {
+      expect(result.attempts).toBe(1)
+      expect(result.flakyWithinRun).toBe(false)
+    }
+  })
+
+  it('leaves no required field undefined', () => {
+    for (const result of run.results) {
+      for (const [key, value] of Object.entries(result)) {
+        expect(value, `${result.title}.${key}`).toBeDefined()
+      }
+    }
+  })
+})
+
+describe('toRepositoryPath', () => {
+  it.each([
+    ['/repo/tests/a.test.ts', '/repo', 'tests/a.test.ts'],
+    ['/home/runner/work/repo/tests/a.test.ts', '/home/runner/work/repo', 'tests/a.test.ts'],
+    ['/repo/tests/a.test.ts', '/repo/', 'tests/a.test.ts'],
+    ['C:\\repo\\tests\\a.test.ts', 'C:/repo', 'tests/a.test.ts'],
+  ])('%s under %s -> %s', (absolute, repoRoot, expected) => {
+    expect(toRepositoryPath(absolute, repoRoot)).toBe(expected)
+  })
+
+  it('leaves a path outside the repository alone rather than mangling it', () => {
+    expect(toRepositoryPath('/elsewhere/a.test.ts', '/repo')).toBe('elsewhere/a.test.ts')
+  })
+})
+
+describe('when the reporter format changes', () => {
+  it('fails loudly and says where to look', () => {
+    expect(() => normaliseVitestReport({ testResults: [] }, meta)).toThrow(
+      /reporter format may have changed[\s\S]*contracts\/reporters\/vitest\.ts/,
+    )
+  })
+
+  it('tolerates fields Vitest adds that this module does not read', () => {
+    const withExtras = {
+      startTime: 1_700_000_000_000,
+      newTopLevel: true,
+      testResults: [
+        {
+          name: '/repo/a.test.ts',
+          somethingNew: 1,
+          assertionResults: [
+            {
+              title: 't',
+              fullName: 't',
+              ancestorTitles: [],
+              status: 'passed',
+              failureMessages: [],
+              futureField: 'x',
+            },
+          ],
+        },
+      ],
+    }
+    expect(normaliseVitestReport(withExtras, meta).results).toHaveLength(1)
+  })
+})

--- a/contracts/reporters/vitest.ts
+++ b/contracts/reporters/vitest.ts
@@ -1,0 +1,162 @@
+import { z } from 'zod'
+import {
+  deriveTestId,
+  normaliseFilePath,
+  type TestError,
+  type TestResult,
+  type TestRun,
+  type TestStatus,
+} from '../test-run.js'
+import type { RunMetadata } from './playwright.js'
+
+/**
+ * Vitest JSON reporter → `TestRun`.
+ *
+ * Unit failures classify differently from end-to-end failures in practice: far
+ * more often `deterministic`, far more often `app_code`. A dataset built only
+ * from browser failures would teach the classifier that every failure has a
+ * locator in it, so both reporters have to reach the same normalised shape.
+ *
+ * The important difference from Playwright is what Vitest does **not** record.
+ * There is no retry information in the default configuration, and no per-attempt
+ * history. That absence is information — it means "we do not know", not "the
+ * test passed first time" — and conflating the two would manufacture confidence
+ * in the `determinism` axis that the data does not support.
+ */
+
+const VitestAssertionSchema = z.looseObject({
+  title: z.string(),
+  fullName: z.string(),
+  ancestorTitles: z.array(z.string()).default([]),
+  status: z.enum(['passed', 'failed', 'skipped', 'pending', 'todo']),
+  duration: z.number().nullable().optional(),
+  failureMessages: z.array(z.string()).default([]),
+})
+
+const VitestFileSchema = z.looseObject({
+  /** Absolute path on the machine that ran the suite. */
+  name: z.string(),
+  assertionResults: z.array(VitestAssertionSchema),
+  startTime: z.number().optional(),
+  endTime: z.number().optional(),
+})
+
+export const VitestReportSchema = z.looseObject({
+  startTime: z.number(),
+  testResults: z.array(VitestFileSchema),
+})
+
+export type VitestReport = z.infer<typeof VitestReportSchema>
+
+const STATUS: Record<z.infer<typeof VitestAssertionSchema>['status'], TestStatus> = {
+  passed: 'passed',
+  failed: 'failed',
+  skipped: 'skipped',
+  // Vitest's own words for "declared but not run".
+  pending: 'skipped',
+  todo: 'skipped',
+}
+
+/**
+ * Vitest reports absolute paths. Everything downstream keys on a
+ * repository-relative path, and `testId` is built from it — so an id derived
+ * from `/home/runner/work/repo/tests/a.test.ts` locally and
+ * `/Users/x/repo/tests/a.test.ts` in CI would be two different tests with two
+ * separate histories.
+ */
+export function toRepositoryPath(absolute: string, repositoryRoot: string): string {
+  const root = normaliseFilePath(repositoryRoot).replace(/\/+$/, '')
+  const path = normaliseFilePath(absolute)
+  return root !== '' && path.startsWith(`${root}/`) ? path.slice(root.length + 1) : path
+}
+
+/**
+ * Vitest concatenates failure messages; the first line is the assertion and the
+ * rest is the stack. Splitting them keeps the error shape identical to
+ * Playwright's, so nothing downstream has to know which reporter it came from.
+ */
+function toError(messages: string[]): TestError | undefined {
+  const raw = messages[0]
+  if (raw === undefined || raw.trim() === '') return undefined
+
+  const lines = raw.split('\n')
+  const firstFrame = lines.findIndex((line) => /^\s+at\s/.test(line))
+  const message = (firstFrame === -1 ? lines : lines.slice(0, firstFrame)).join('\n').trim()
+  const stack = firstFrame === -1 ? undefined : lines.slice(firstFrame).join('\n')
+
+  const error: TestError = { message: message === '' ? raw.trim() : message }
+  if (stack !== undefined) error.stack = stack
+  return error
+}
+
+/**
+ * Validate a Vitest JSON report and normalise it.
+ *
+ * `repositoryRoot` is required rather than inferred from `process.cwd()`: this
+ * has to stay a pure function so it can be tested without a filesystem, and
+ * because the path that matters is the checkout root, not wherever the CLI ran.
+ */
+export function normaliseVitestReport(
+  raw: unknown,
+  meta: RunMetadata & { repositoryRoot: string },
+): TestRun {
+  const parsed = VitestReportSchema.safeParse(raw)
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .slice(0, 5)
+      .map((i) => `  ${i.path.join('.') || '<root>'}: ${i.message}`)
+      .join('\n')
+    throw new Error(
+      `Not a Vitest JSON report. The reporter format may have changed:\n${issues}\n` +
+        `Update contracts/reporters/vitest.ts and the fixture in tests/fixtures/reporters/.`,
+    )
+  }
+
+  const results: TestResult[] = []
+  let latestEnd = parsed.data.startTime
+
+  for (const file of parsed.data.testResults) {
+    const path = toRepositoryPath(file.name, meta.repositoryRoot)
+    latestEnd = Math.max(latestEnd, file.endTime ?? parsed.data.startTime)
+
+    for (const assertion of file.assertionResults) {
+      // `fullName` already includes the ancestor titles, but it joins them with
+      // a space, so `describe('a') > it('b c')` and `describe('a b') > it('c')`
+      // collapse to the same string. Rebuilding from the parts keeps them apart
+      // and matches the separator the Playwright normaliser uses.
+      const title = [...assertion.ancestorTitles, assertion.title].join(' › ')
+
+      const result: TestResult = {
+        testId: deriveTestId(path, title),
+        title,
+        file: path,
+        status: STATUS[assertion.status],
+        // Vitest does not retry by default and records no per-attempt history.
+        attempts: 1,
+        flakyWithinRun: false,
+        durationMs: assertion.duration ?? 0,
+        annotations:
+          assertion.status === 'todo'
+            ? ['todo']
+            : assertion.status === 'pending'
+              ? ['pending']
+              : [],
+      }
+
+      const error = toError(assertion.failureMessages)
+      if (error !== undefined) result.error = error
+
+      results.push(result)
+    }
+  }
+
+  return {
+    runId: meta.runId,
+    commitSha: meta.commitSha,
+    branch: meta.branch,
+    startedAt: new Date(parsed.data.startTime).toISOString(),
+    durationMs: Math.max(0, latestEnd - parsed.data.startTime),
+    source: 'vitest',
+    results,
+  }
+}

--- a/tests/fixtures/reporters/vitest-4.1.10.json
+++ b/tests/fixtures/reporters/vitest-4.1.10.json
@@ -1,0 +1,83 @@
+{
+  "numTotalTestSuites": 3,
+  "numPassedTestSuites": 0,
+  "numFailedTestSuites": 3,
+  "numPendingTestSuites": 0,
+  "numTotalTests": 4,
+  "numPassedTests": 1,
+  "numFailedTests": 2,
+  "numPendingTests": 1,
+  "numTodoTests": 0,
+  "snapshot": {
+    "added": 0,
+    "failure": false,
+    "filesAdded": 0,
+    "filesRemoved": 0,
+    "filesRemovedList": [],
+    "filesUnmatched": 0,
+    "filesUpdated": 0,
+    "matched": 0,
+    "total": 0,
+    "unchecked": 0,
+    "uncheckedKeysByFile": [],
+    "unmatched": 0,
+    "updated": 0,
+    "didUpdate": false
+  },
+  "startTime": 1786358165424,
+  "success": false,
+  "testResults": [
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": ["task api"],
+          "fullName": "task api creates a task",
+          "status": "passed",
+          "title": "creates a task",
+          "duration": 0.6606670000000037,
+          "failureMessages": [],
+          "meta": {},
+          "tags": []
+        },
+        {
+          "ancestorTitles": ["task api", "reorder"],
+          "fullName": "task api reorder rejects an out-of-range position",
+          "status": "failed",
+          "title": "rejects an out-of-range position",
+          "duration": 2.762208000000001,
+          "failureMessages": [
+            "AssertionError: expected { position: 9 } to deeply equal { position: 1 }\n    at /repo/specs/tasks.test.ts:10:31\n    at file:///repo/node_modules/@vitest/runner/dist/chunk-artifact.js:302:11\n    at file:///repo/node_modules/@vitest/runner/dist/chunk-artifact.js:1903:26\n    at file:///repo/node_modules/@vitest/runner/dist/chunk-artifact.js:2326:20\n    at new Promise (<anonymous>)\n    at runWithCancel (file:///repo/node_modules/@vitest/runner/dist/chunk-artifact.js:2323:10)\n    at file:///repo/node_modules/@vitest/runner/dist/chunk-artifact.js:2305:20\n    at new Promise (<anonymous>)\n    at runWithTimeout (file:///repo/node_modules/@vitest/runner/dist/chunk-artifact.js:2272:10)\n    at file:///repo/node_modules/@vitest/runner/dist/chunk-artifact.js:2955:64"
+          ],
+          "meta": {},
+          "tags": []
+        },
+        {
+          "ancestorTitles": ["task api"],
+          "fullName": "task api supports bulk delete",
+          "status": "skipped",
+          "title": "supports bulk delete",
+          "failureMessages": [],
+          "meta": {},
+          "tags": []
+        },
+        {
+          "ancestorTitles": ["task api"],
+          "fullName": "task api throws on a missing task",
+          "status": "failed",
+          "title": "throws on a missing task",
+          "duration": 0.32099999999999795,
+          "failureMessages": [
+            "TypeError: Cannot read properties of undefined (reading 'id')\n    at /repo/specs/tasks.test.ts:19:11\n    at file:///repo/node_modules/@vitest/runner/dist/chunk-artifact.js:302:11\n    at file:///repo/node_modules/@vitest/runner/dist/chunk-artifact.js:1903:26\n    at file:///repo/node_modules/@vitest/runner/dist/chunk-artifact.js:2326:20\n    at new Promise (<anonymous>)\n    at runWithCancel (file:///repo/node_modules/@vitest/runner/dist/chunk-artifact.js:2323:10)\n    at file:///repo/node_modules/@vitest/runner/dist/chunk-artifact.js:2305:20\n    at new Promise (<anonymous>)\n    at runWithTimeout (file:///repo/node_modules/@vitest/runner/dist/chunk-artifact.js:2272:10)\n    at file:///repo/node_modules/@vitest/runner/dist/chunk-artifact.js:2955:64"
+          ],
+          "meta": {},
+          "tags": []
+        }
+      ],
+      "startTime": 1786358165495,
+      "endTime": 1786358165498.7622,
+      "status": "failed",
+      "message": "",
+      "name": "/repo/specs/tasks.test.ts"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #15

## What changed

`normaliseVitestReport(raw, meta)` produces `TestRun` values indistinguishable in shape from the Playwright normaliser's. Fixture is real Vitest JSON reporter output.

## Why

Unit failures classify differently from end-to-end failures in practice — far more often `deterministic`, far more often `app_code`. A dataset built only from browser failures would teach the classifier that every failure has a locator in it.

## Decisions worth reviewing

**The absence of retry data is represented, not defaulted away.** Vitest does not retry by default and records no per-attempt history. Reporting `attempts: 1` and `flakyWithinRun: false` is honest only because it means "we do not know" — and the code says so at the point where a future reader would otherwise be tempted to synthesise something. Inventing retries here would manufacture confidence on the `determinism` axis that the data does not support.

**Titles are rebuilt from `ancestorTitles`, not taken from `fullName`.** Vitest joins ancestors with a plain space, so `describe('a') > it('b c')` and `describe('a b') > it('c')` produce the same `fullName`. Rebuilding from the parts keeps them apart and uses the same separator as the Playwright normaliser, so `testId`s from the two reporters are consistent.

**Paths are made repository-relative, and the root is a parameter.** Vitest reports absolute paths. Since `testId` derives from the path, the same test would otherwise have one history under `/home/runner/work/repo/...` and another under `/Users/x/repo/...` — every test looking new on every machine. `repositoryRoot` is passed in rather than read from `process.cwd()` so the function stays pure and testable, and because the path that matters is the checkout root, not wherever the CLI happened to run.

**Failure messages are split into message and stack.** Vitest concatenates them into one string. Splitting at the first stack frame keeps the error shape identical to Playwright's, so nothing downstream needs to know which reporter produced a run.

## How it was verified

102 assertions total, 16 new. Against the real fixture: nested `describe` titles, the assertion/stack split checked in both directions (message contains no frames, stack does), a thrown `TypeError` as well as a failed assertion, a skip with no error, and repository-relative paths on every result.

`toRepositoryPath` is table-tested including a Windows path and a path outside the repository, which is left alone rather than mangled.

Same two upgrade-path tests as the Playwright normaliser: a missing field fails with a message naming this file, an added field is tolerated.

## Checklist

- [x] Title is a valid Conventional Commit
- [x] Linked to exactly one issue with `Closes #N`
- [x] `npm run lint && npm run format:check && npm run typecheck && npm run test:unit` clean
- [x] Tests cover failure modes
- [x] Fixture provenance documented

## Notes for the reviewer

`RunMetadata` is imported from the Playwright module rather than duplicated. If a third reporter ever appears it should move to a shared file, but moving it now would be a file whose only purpose is to hold one interface.