### PR TITLE
feat(flakemetry): add FlakySignal and analysis.json schemas

### DIFF
--- a/contracts/analysis.test.ts
+++ b/contracts/analysis.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ANALYSIS_SCHEMA_VERSION,
+  AnalysisSchema,
+  FlakySignalSchema,
+  parseAnalysis,
+  selectForTriage,
+  StatusHistorySchema,
+} from './analysis.js'
+
+const signal = {
+  testId: 'a.spec.ts›t',
+  flakinessScore: 0.4,
+  consecutiveFailures: 0,
+  totalRuns: 12,
+  firstSeenAt: '2026-07-01T00:00:00.000Z',
+  lastPassedAt: '2026-08-01T00:00:00.000Z',
+  statusHistory: 'PPFPFPP',
+  isNew: false,
+}
+
+const result = {
+  testId: 'a.spec.ts›t',
+  title: 't',
+  file: 'a.spec.ts',
+  status: 'passed' as const,
+  attempts: 1,
+  flakyWithinRun: false,
+  durationMs: 10,
+  annotations: [],
+}
+
+const analysis = {
+  schemaVersion: ANALYSIS_SCHEMA_VERSION,
+  runId: 'run-1',
+  commitSha: 'abc1234',
+  branch: 'main',
+  analysedAt: '2026-08-10T00:00:00.000Z',
+  historyAvailable: true,
+  historyDepth: 12,
+  tests: [{ result, signal }],
+}
+
+describe('StatusHistorySchema', () => {
+  it.each(['', 'P', 'PPPFPFPPF', 'TTSS'])('accepts %s', (h) => {
+    expect(StatusHistorySchema.parse(h)).toBe(h)
+  })
+
+  it.each(['PPX', 'p', 'P F'])('rejects %s', (h) => {
+    expect(() => StatusHistorySchema.parse(h)).toThrow()
+  })
+})
+
+describe('FlakySignalSchema', () => {
+  it('round-trips through JSON unchanged', () => {
+    const once = FlakySignalSchema.parse(signal)
+    expect(FlakySignalSchema.parse(JSON.parse(JSON.stringify(once)))).toEqual(once)
+  })
+
+  it('keeps the score inside 0..1', () => {
+    expect(() => FlakySignalSchema.parse({ ...signal, flakinessScore: 1.2 })).toThrow()
+    expect(() => FlakySignalSchema.parse({ ...signal, flakinessScore: -0.1 })).toThrow()
+  })
+
+  it('allows a test that has never passed', () => {
+    expect(FlakySignalSchema.parse({ ...signal, lastPassedAt: null }).lastPassedAt).toBeNull()
+  })
+
+  it('rejects an unknown field rather than dropping it', () => {
+    expect(() => FlakySignalSchema.parse({ ...signal, score: 0.5 })).toThrow()
+  })
+})
+
+describe('AnalysisSchema', () => {
+  it('round-trips through JSON unchanged', () => {
+    const once = AnalysisSchema.parse(analysis)
+    expect(AnalysisSchema.parse(JSON.parse(JSON.stringify(once)))).toEqual(once)
+  })
+
+  it('requires the history flags, so a cache miss cannot look like a fresh suite', () => {
+    const { historyAvailable: _a, ...withoutFlag } = analysis
+    expect(() => AnalysisSchema.parse(withoutFlag)).toThrow()
+  })
+})
+
+describe('parseAnalysis', () => {
+  it('accepts the current version', () => {
+    expect(parseAnalysis(analysis, 'analysis.json').tests).toHaveLength(1)
+  })
+
+  it('refuses a future version instead of reading it best-effort', () => {
+    // Best-effort would hand the consumer `undefined` where a field used to be
+    // and let it carry on producing confident, wrong output.
+    expect(() => parseAnalysis({ ...analysis, schemaVersion: 99 }, 'analysis.json')).toThrow(
+      /schemaVersion 99[\s\S]*flakemetry:analyze/,
+    )
+  })
+
+  it('names the source and the failing path on malformed input', () => {
+    expect(() => parseAnalysis({ ...analysis, commitSha: 'x' }, 'fixture.json')).toThrow(
+      /fixture\.json is not a valid analysis document:[\s\S]*commitSha/,
+    )
+  })
+})
+
+describe('selectForTriage', () => {
+  const withTest = (r: Record<string, unknown>, s: Record<string, unknown> = {}) =>
+    selectForTriage(
+      AnalysisSchema.parse({
+        ...analysis,
+        tests: [{ result: { ...result, ...r }, signal: { ...signal, ...s } }],
+      }),
+    )
+
+  it('selects failures', () => {
+    expect(withTest({ status: 'failed' })).toHaveLength(1)
+  })
+
+  it('selects timeouts', () => {
+    expect(withTest({ status: 'timedOut' })).toHaveLength(1)
+  })
+
+  it('selects a test that failed and then passed within the run', () => {
+    // It passed, so a status filter alone would drop it — and a within-run flake
+    // is the strongest intermittency evidence the run contains.
+    expect(withTest({ status: 'passed', flakyWithinRun: true })).toHaveLength(1)
+  })
+
+  it('ignores a test that simply passed', () => {
+    expect(withTest({ status: 'passed' }, { flakinessScore: 0 })).toHaveLength(0)
+  })
+
+  it('ignores a historically flaky test that is currently green', () => {
+    // Its history is interesting; this run is not. Triaging it would spend
+    // budget on a test that did not fail.
+    expect(
+      withTest({ status: 'passed' }, { flakinessScore: 0.9, consecutiveFailures: 0 }),
+    ).toHaveLength(0)
+  })
+
+  it('ignores skipped tests', () => {
+    expect(withTest({ status: 'skipped' }, { flakinessScore: 0 })).toHaveLength(0)
+  })
+})

--- a/contracts/analysis.ts
+++ b/contracts/analysis.ts
@@ -1,0 +1,145 @@
+import { z } from 'zod'
+import { TestResultSchema } from './test-run.js'
+
+/**
+ * The seam between the statistical half of the pipeline and the AI half.
+ *
+ * `flakemetry-lib` writes this; the agents read it. It is also a committed
+ * fixture format — the integration tests and the eval harness both feed
+ * hand-written `analysis.json` files — so a change here is a breaking change to
+ * data that already exists on disk, which is why it carries a version from the
+ * first commit rather than from the first time it hurts.
+ *
+ * Specified in docs/architecture.md.
+ */
+
+/**
+ * Major version of the `analysis.json` document.
+ *
+ * Bumped when a field is removed, renamed, or changes meaning. Adding an
+ * optional field is not a bump: old readers keep working, and forcing a bump for
+ * additions trains everyone to ignore the number.
+ */
+export const ANALYSIS_SCHEMA_VERSION = 1
+
+/**
+ * A test's recent outcomes, most recent **last**.
+ *
+ * `P` passed, `F` failed, `T` timed out, `S` skipped. A compact string rather
+ * than an array because it is read by humans in reports and prompts far more
+ * often than it is computed over, and `PPPFPFPPF` is legible at a glance in a
+ * way that nine JSON objects are not.
+ */
+export const StatusHistorySchema = z.string().regex(/^[PFTS]*$/, {
+  message: 'statusHistory must contain only P, F, T or S, most recent last',
+})
+
+export const FlakySignalSchema = z
+  .object({
+    testId: z.string().min(1),
+
+    /**
+     * How much the test **alternates**, not how often it fails.
+     *
+     * A test that fails every single run scores near zero: it is broken, not
+     * flaky. Conflating the two would put every genuine regression into the
+     * `intermittent` bucket, which is the failure this whole taxonomy exists to
+     * avoid.
+     */
+    flakinessScore: z.number().min(0).max(1),
+
+    consecutiveFailures: z.int().min(0),
+    totalRuns: z.int().min(0),
+
+    firstSeenAt: z.iso.datetime(),
+    /** Null when the test has never passed in the retained history. */
+    lastPassedAt: z.iso.datetime().nullable(),
+
+    statusHistory: StatusHistorySchema,
+
+    /**
+     * True when this is the first run in which the test appears.
+     *
+     * Frequently means history was unavailable rather than that the test is new
+     * — a cache miss makes every test look new — so consumers must not read it
+     * as "recently added" on its own. `historyAvailable` on the document says
+     * which situation this is.
+     */
+    isNew: z.boolean(),
+  })
+  .strict()
+export type FlakySignal = z.infer<typeof FlakySignalSchema>
+
+export const AnalysedTestSchema = z
+  .object({
+    result: TestResultSchema,
+    signal: FlakySignalSchema,
+  })
+  .strict()
+export type AnalysedTest = z.infer<typeof AnalysedTestSchema>
+
+export const AnalysisSchema = z
+  .object({
+    schemaVersion: z.int().min(1),
+
+    runId: z.string().min(1),
+    commitSha: z.string().min(7),
+    branch: z.string().min(1),
+    analysedAt: z.iso.datetime(),
+
+    /**
+     * False when the history file was missing or empty.
+     *
+     * Without it, a cache miss and a genuinely new test suite are
+     * indistinguishable downstream, and the classifier would report the same
+     * confidence for both. The report says so out loud when this is false.
+     */
+    historyAvailable: z.boolean(),
+    /** How many runs of history the scoring could draw on. */
+    historyDepth: z.int().min(0),
+
+    /** Every test in the run, not only the failures — the agents filter. */
+    tests: z.array(AnalysedTestSchema),
+  })
+  .strict()
+export type Analysis = z.infer<typeof AnalysisSchema>
+
+/**
+ * Parse an `analysis.json` document, refusing an incompatible major version.
+ *
+ * A version mismatch has to be an error rather than a best-effort read: the
+ * consumer would otherwise get `undefined` where a field used to be and carry on
+ * producing confident, wrong output.
+ */
+export function parseAnalysis(value: unknown, sourceLabel: string): Analysis {
+  const versioned = z.looseObject({ schemaVersion: z.unknown() }).safeParse(value)
+  const found = versioned.success ? versioned.data.schemaVersion : undefined
+
+  if (typeof found === 'number' && found !== ANALYSIS_SCHEMA_VERSION) {
+    throw new Error(
+      `${sourceLabel} has analysis schemaVersion ${String(found)}, but this build reads ` +
+        `version ${String(ANALYSIS_SCHEMA_VERSION)}. Regenerate it with: npm run flakemetry:analyze`,
+    )
+  }
+
+  const parsed = AnalysisSchema.safeParse(value)
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .slice(0, 5)
+      .map((i) => `  ${i.path.join('.') || '<root>'}: ${i.message}`)
+      .join('\n')
+    throw new Error(`${sourceLabel} is not a valid analysis document:\n${issues}`)
+  }
+  return parsed.data
+}
+
+/** Tests the agents consider: failures, and anything newly unstable. */
+export function selectForTriage(analysis: Analysis): AnalysedTest[] {
+  return analysis.tests.filter(
+    (t) =>
+      t.result.status === 'failed' ||
+      t.result.status === 'timedOut' ||
+      t.result.flakyWithinRun ||
+      (t.signal.flakinessScore > 0 && t.signal.consecutiveFailures > 0),
+  )
+}

--- a/contracts/index.ts
+++ b/contracts/index.ts
@@ -9,3 +9,4 @@
 export * from './test-run.js'
 export * from './reporters/playwright.js'
 export * from './reporters/vitest.js'
+export * from './analysis.js'


### PR DESCRIPTION
Closes #16

## What changed

`FlakySignalSchema`, `AnalysisSchema`, a versioned `parseAnalysis`, and `selectForTriage` — the filter that decides which tests the agents spend budget on.

## Why

`analysis.json` is the seam between the statistical half of the pipeline and the AI half. It is also a committed fixture format: the integration tests and the eval harness both feed hand-written `analysis.json` files, so changing it breaks data that already exists on disk.

## Decisions worth reviewing

**`schemaVersion` from the first commit, and a mismatch is an error.** Not from the first time the lack of one hurts. A best-effort read across versions hands the consumer `undefined` where a field used to be and lets it carry on producing confident, wrong output — which is the failure mode this project exists to complain about.

The rule for bumping is written down: removal, rename, or a change of meaning. Adding an optional field is *not* a bump, because forcing one for additions trains everyone to ignore the number.

**`historyAvailable` and `historyDepth` are required, not optional.** Without them a cache miss and a genuinely new test suite are indistinguishable downstream, and the classifier would report identical confidence for both. `docs/limitations-and-guardrails.md` names silent degradation as the specific behaviour that turns a useful tool into a misleading one; this is where that promise gets teeth.

**`flakinessScore` is documented as alternation, not failure rate, at the point of definition.** The tempting implementation — failures over runs — scores a permanently broken test as maximally flaky, which would put every genuine regression into the `intermittent` bucket. M6 implements the scoring; the constraint belongs in the contract where it cannot be missed.

**`statusHistory` is a compact string, not an array.** `PPPFPFPPF` is legible at a glance in a report or a prompt; nine JSON objects are not. It is read by humans far more often than it is computed over. The regex enforces the alphabet and the doc comment fixes the direction, because "most recent first or last?" is exactly the detail two implementations get wrong in opposite ways.

**`selectForTriage` includes within-run flakes and excludes historically-flaky-but-green tests.** A test that failed and then passed inside this run has passed, so a status filter alone would drop it — and that is the strongest intermittency evidence a single run contains. Conversely, a test with a 0.9 flakiness score that was green this run is interesting history but nothing happened today; triaging it would spend budget on a test that did not fail.

## How it was verified

124 assertions total, 22 new. Round-trip through JSON for both schemas, the status-history alphabet in both directions, score bounds, `lastPassedAt: null` for a test that has never passed, unknown fields rejected, and the version guard with its exact remediation message.

`selectForTriage` is tested per branch, including the two judgement calls above.

## Checklist

- [x] Title is a valid Conventional Commit
- [x] Linked to exactly one issue with `Closes #N`
- [x] `npm run lint && npm run format:check && npm run typecheck && npm run test:unit` clean
- [x] Round-trip tests present per the milestone exit criterion
- [x] Field definitions match `docs/architecture.md`

## Notes for the reviewer

`Analysis.tests` holds **every** test in the run, not only the failures. The filter lives in `selectForTriage` so the same document can serve the agents, the history writer and any future report that wants pass-rate context — and so the filtering rule is one testable function rather than a condition repeated at three call sites.