### PR TITLE
test(eval): pin the reporter contract to committed real output

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@
 **An AI triage layer for CI test failures — packaged as a pipeline step, not a service.**
 
 [![CI](https://github.com/AKogut/ai-flaky-test-triage/actions/workflows/ci.yml/badge.svg)](https://github.com/AKogut/ai-flaky-test-triage/actions/workflows/ci.yml)
-[![Milestones](https://img.shields.io/github/milestones/progress-percent/AKogut/ai-flaky-test-triage/2?label=M1)](https://github.com/AKogut/ai-flaky-test-triage/milestones)
+[![Milestones](https://img.shields.io/github/milestones/progress-percent/AKogut/ai-flaky-test-triage/3?label=M2)](https://github.com/AKogut/ai-flaky-test-triage/milestones)
 [![Open issues](https://img.shields.io/github/issues/AKogut/ai-flaky-test-triage?label=open%20issues)](https://github.com/AKogut/ai-flaky-test-triage/issues)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](package.json)
 
 <!-- status:start -->
 
-> **Project status: M1 — Contracts, schemas & taxonomy.**
-> 1 of 11 milestones complete.
-> Current exit criterion: every artifact the pipeline reads or writes has a Zod schema, a TypeScript type inferred from it, and a round-trip test.
+> **Project status: M2 — Golden dataset, baseline & eval harness.**
+> 2 of 11 milestones complete.
+> Current exit criterion: `npm run eval` scores the baseline heuristic on ≥30 labelled fixtures and writes a report with per-axis accuracy, intervals, and both confusion matrices — with no model involved.
 >
 > Progress is tracked as [milestones](https://github.com/AKogut/ai-flaky-test-triage/milestones), not dates.
 > Commands marked 🚧 in the script table are not implemented yet and say so when run.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ The type boundaries everything else is written against: `TestRun`, `TestResult`,
 `Classification`, and the fixture format. Zod schemas at every boundary so a reporter version bump
 fails loudly in one file instead of silently three stages downstream.
 
-**Status:** in progress
+**Status:** done
 
 **Exit criterion:** every artifact the pipeline reads or writes has a Zod schema, a TypeScript type
 inferred from it, and a round-trip test.
@@ -39,7 +39,7 @@ The measurement apparatus, built before the thing it measures. Hand-authored adv
 the non-LLM baseline heuristic, metrics with confidence intervals, confusion matrices, and the CI
 gate.
 
-**Status:** planned
+**Status:** in progress
 
 **Exit criterion:** `npm run eval` scores the baseline heuristic on ≥30 labelled fixtures and
 writes a report with per-axis accuracy, intervals, and both confusion matrices — with no model

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "app/server",
         "flakemetry-lib",
         "agents",
-        "eval"
+        "eval",
+        "tests"
       ],
       "dependencies": {
         "zod": "4.4.3"
@@ -1602,6 +1603,10 @@
     },
     "node_modules/@sentra/taskflow-server": {
       "resolved": "app/server",
+      "link": true
+    },
+    "node_modules/@sentra/tests": {
+      "resolved": "tests",
       "link": true
     },
     "node_modules/@standard-schema/spec": {
@@ -5506,6 +5511,13 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "tests": {
+      "name": "@sentra/tests",
+      "version": "0.1.0",
+      "dependencies": {
+        "@sentra/contracts": "*"
       }
     }
   }

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@sentra/tests",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@sentra/contracts": "*"
+  }
+}

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -10,6 +10,9 @@
   "references": [
     {
       "path": "../scripts"
+    },
+    {
+      "path": "../contracts"
     }
   ]
 }

--- a/tests/unit/reporter-contract.test.ts
+++ b/tests/unit/reporter-contract.test.ts
@@ -1,0 +1,148 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  normalisePlaywrightReport,
+  normaliseVitestReport,
+  TestRunSchema,
+  type TestRun,
+} from '@sentra/contracts'
+
+/**
+ * The contract between this repository and the two test runners it consumes.
+ *
+ * The failure these tests exist to prevent is the quiet one. A reporter renames
+ * a field, the normaliser reads `undefined`, every test looks like it passed
+ * once, and the flakiness signal degrades with no error anywhere — worse than a
+ * crash, and far harder to notice, because `analysis.json` still parses and the
+ * report still renders.
+ *
+ * The fixtures are real output from the pinned versions. Regenerating them is
+ * deliberately manual: a version bump should be a conscious update with the new
+ * output committed, not a lockfile refresh nobody reads.
+ */
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const fixtureDir = join(root, 'tests/fixtures/reporters')
+
+const packageJson = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')) as {
+  devDependencies: Record<string, string>
+}
+
+const read = (file: string): unknown => JSON.parse(readFileSync(join(fixtureDir, file), 'utf8'))
+
+const meta = { runId: 'run-1', commitSha: 'abc1234', branch: 'main' }
+
+describe('pinned reporter versions', () => {
+  /**
+   * Fixtures are named for the version that produced them. If the dependency
+   * moves and the fixture does not, this fails — which is the point: it forces
+   * whoever bumps the version to regenerate the fixture and look at the diff.
+   */
+  it.each([
+    ['@playwright/test', 'playwright-'],
+    ['vitest', 'vitest-'],
+  ])('%s matches a committed fixture', (dependency, prefix) => {
+    const pinned = packageJson.devDependencies[dependency]
+    expect(pinned, `${dependency} must be pinned exactly, not a range`).toMatch(/^\d+\.\d+\.\d+$/)
+
+    const fixtures = readdirSync(fixtureDir).filter((f) => f.startsWith(prefix))
+    expect(
+      fixtures,
+      `No fixture for ${dependency}@${pinned ?? '?'}. Regenerate it and commit the output — ` +
+        `see tests/fixtures/reporters/README.md.`,
+    ).toContain(`${prefix}${pinned ?? ''}.json`)
+  })
+})
+
+const runs: [label: string, run: TestRun][] = [
+  ['playwright', normalisePlaywrightReport(read('playwright-1.62.1.json'), meta)],
+  [
+    'vitest',
+    normaliseVitestReport(read('vitest-4.1.10.json'), { ...meta, repositoryRoot: '/repo' }),
+  ],
+]
+
+describe.each(runs)('%s normalisation', (_label, run) => {
+  it('produces a schema-valid TestRun', () => {
+    expect(() => TestRunSchema.parse(run)).not.toThrow()
+  })
+
+  it('produces at least one result — an empty run would pass every other assertion', () => {
+    expect(run.results.length).toBeGreaterThan(0)
+  })
+
+  it('leaves no required field undefined', () => {
+    // The exact shape a renamed source field takes on the way through.
+    for (const result of run.results) {
+      for (const key of [
+        'testId',
+        'title',
+        'file',
+        'status',
+        'attempts',
+        'flakyWithinRun',
+        'durationMs',
+        'annotations',
+      ] as const) {
+        expect(result[key], `${result.title}.${key}`).toBeDefined()
+      }
+    }
+  })
+
+  it('gives every test a unique id', () => {
+    const ids = run.results.map((r) => r.testId)
+    expect(new Set(ids).size, 'duplicate testIds would merge two tests into one history').toBe(
+      ids.length,
+    )
+  })
+
+  it('uses repository-relative paths with no host directories', () => {
+    for (const result of run.results) {
+      expect(result.file).not.toMatch(/^\/|^[A-Za-z]:/)
+      expect(result.file).not.toContain('\\')
+    }
+  })
+
+  it('attaches an error to every failure and to none of the passes', () => {
+    for (const result of run.results) {
+      if (result.status === 'failed' || result.status === 'timedOut') {
+        expect(result.error?.message, `${result.title} failed with no error`).toBeTruthy()
+      }
+      if (result.status === 'skipped') {
+        expect(result.error, `${result.title} was skipped but carries an error`).toBeUndefined()
+      }
+    }
+  })
+
+  it('reports durations that are finite and non-negative', () => {
+    expect(Number.isFinite(run.durationMs)).toBe(true)
+    for (const result of run.results) {
+      expect(result.durationMs).toBeGreaterThanOrEqual(0)
+      expect(Number.isFinite(result.durationMs)).toBe(true)
+    }
+  })
+})
+
+describe('the two reporters agree on shape', () => {
+  it('produces results with identical key sets, ignoring optional fields', () => {
+    // Nothing downstream branches on `source`, so a field present from one
+    // reporter and absent from the other would be a silent asymmetry.
+    const required = (run: TestRun): string[] =>
+      Object.keys(run.results[0] ?? {})
+        .filter((k) => k !== 'error')
+        .sort()
+
+    const [playwright, vitest] = runs.map(([, run]) => required(run))
+    expect(playwright).toEqual(vitest)
+  })
+
+  it('derives ids the same way from the same file and title', () => {
+    const [playwrightRun, vitestRun] = runs.map(([, run]) => run)
+    const sample = playwrightRun?.results[0]
+    const other = vitestRun?.results[0]
+    expect(sample?.testId.includes('›')).toBe(true)
+    expect(other?.testId.includes('›')).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #19

## What changed

A contract suite that fails when a Playwright or Vitest upgrade changes the reporter format in a way the normalisers do not handle. Closes M1.

## Why

The failure this prevents is the quiet one. A reporter renames a field, the normaliser reads `undefined`, every test looks like it passed once, and the flakiness signal degrades with no error anywhere. `analysis.json` still parses, the report still renders, and the numbers are wrong — a crash would be strictly preferable.

## Decisions worth reviewing

**Fixture filenames carry the version, and the version is checked.** `playwright-1.62.1.json` is matched against the pinned `devDependencies` entry. Bump the dependency without regenerating the fixture and the suite fails with the exact remediation:

```
AssertionError: No fixture for vitest@4.2.0. Regenerate it and commit the output
— see tests/fixtures/reporters/README.md.
  expected [ 'vitest-4.1.10.json' ] to include 'vitest-4.2.0.json'
```

Both dependencies are also asserted to be pinned **exactly** rather than to a range, because a caret range makes the whole mechanism decorative — `npm ci` would silently install a version no fixture covers.

**Invariants are asserted per reporter, not per fixture.** The normaliser-specific tests in #14 and #15 check what each format means. These check what must be true of *any* normalised run: no undefined required field, unique ids, repository-relative paths, an error attached to every failure and to no skip, finite non-negative durations. Those are the shapes a renamed source field takes on the way through.

**A cross-reporter check.** Both must produce results with the same key set. Nothing downstream branches on `source`, so a field present from one reporter and absent from the other would be a silent asymmetry — the kind that surfaces as "the classifier is worse on unit tests" three milestones later.

**One assertion exists only to stop the suite passing vacuously**: at least one result per run. Every other test in this file iterates over `run.results`, and all of them pass trivially on an empty array.

## How it was verified

181 assertions total, 18 new. The version guard was checked in the failing direction by editing the pinned `vitest` version to `4.2.0` — output above — and reverting.

## Checklist

- [x] Title is a valid Conventional Commit
- [x] Linked to exactly one issue with `Closes #N`
- [x] `npm run lint && npm run format:check && npm run typecheck && npm run test:unit` clean
- [x] Guard verified in the failing direction
- [x] `ROADMAP.md` and the status banner advanced to M2

## Notes for the reviewer

`tests/` became a workspace so it can depend on `@sentra/contracts` by package name rather than by a relative path climbing out of the directory. That also means the suite imports the package's public surface — the thing other packages will actually consume — rather than reaching into individual modules.

**This closes M1.** Every artifact the pipeline reads or writes now has a Zod schema, a type inferred from it, and a round-trip test: `TestRun`, `FlakySignal`, `analysis.json`, all three agent outputs, and the fixture format.