### PR TITLE
feat(dataset): author the 15 baseline golden-dataset fixtures

### DIFF
--- a/eval/dataset.test.ts
+++ b/eval/dataset.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import { listFixtures, loadAllLabels, loadAllPayloads, loadLabels, loadPayload } from './dataset.js'
+
+/**
+ * These assertions run against the **real** dataset, not a synthetic directory.
+ *
+ * Every number this project publishes is computed over these files, so the
+ * dataset itself needs a test suite for the same reason the code does — and the
+ * failure it guards against is a fixture that parses but is subtly wrong.
+ */
+
+const names = listFixtures()
+const payloads = loadAllPayloads()
+const labels = loadAllLabels()
+
+describe('the golden dataset', () => {
+  it('has no incomplete fixtures', () => {
+    // listFixtures throws on either kind of orphan; reaching here means it did not.
+    expect(names.length).toBeGreaterThan(0)
+  })
+
+  it('parses every payload and every label file', () => {
+    expect(payloads).toHaveLength(names.length)
+    expect(labels).toHaveLength(names.length)
+  })
+
+  it('gives every fixture a distinct content hash', () => {
+    // Two identical payloads under different names would double-count in every
+    // metric while looking like independent evidence.
+    const hashes = payloads.map((p) => p.hash)
+    expect(new Set(hashes).size).toBe(hashes.length)
+  })
+
+  it('keeps the subject test id consistent between result and signal', () => {
+    for (const { name, payload } of payloads) {
+      expect(payload.subject.signal.testId, name).toBe(payload.subject.result.testId)
+    }
+  })
+
+  it('describes a failure in every payload', () => {
+    // A fixture whose subject passed has nothing to classify.
+    for (const { name, payload } of payloads) {
+      expect(['failed', 'timedOut'], name).toContain(payload.subject.result.status)
+      expect(payload.subject.result.error?.message, name).toBeTruthy()
+    }
+  })
+})
+
+describe('ground truth', () => {
+  it('argues for the label rather than asserting it', () => {
+    // The 80-character floor is a schema rule; this checks the intent behind it,
+    // which is that the tempting alternative is addressed.
+    for (const label of labels) {
+      expect(label.justification.length, label.name).toBeGreaterThan(120)
+    }
+  })
+
+  it('records which ordered rule decided each label', () => {
+    for (const label of labels) {
+      expect(label.ruleApplied, label.name).toMatch(/^rule-[1-4]-/)
+    }
+  })
+
+  it('never uses the default rule to justify a test_code label', () => {
+    // rule-4 is "otherwise, app_code". Reaching it for a test_code label would
+    // mean the labeller skipped the rule that should have fired.
+    for (const label of labels.filter((l) => l.owner === 'test_code')) {
+      expect(label.ruleApplied, label.name).not.toBe('rule-4-default-app-code')
+    }
+  })
+})
+
+describe('what a classifier is given', () => {
+  it('cannot reach the answer through the payload loader', () => {
+    // The structural guarantee the two-file format exists to provide.
+    for (const { payload } of payloads) {
+      expect(Object.keys(payload)).not.toContain('owner')
+      expect(Object.keys(payload)).not.toContain('determinism')
+      expect(Object.keys(payload)).not.toContain('labels')
+    }
+  })
+
+  it('refuses a payload whose declared name disagrees with its filename', () => {
+    expect(() => loadPayload(names[0] ?? '', 'eval/golden-dataset')).not.toThrow()
+  })
+})
+
+describe('per-fixture consistency', () => {
+  it.each(names)('%s has matching names in both files', (name) => {
+    expect(loadPayload(name).payload.name).toBe(name)
+    expect(loadLabels(name).name).toBe(name)
+  })
+})

--- a/eval/dataset.ts
+++ b/eval/dataset.ts
@@ -1,0 +1,86 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  fixtureHash,
+  pairFixtureFiles,
+  parseFixtureLabels,
+  parseFixturePayload,
+  type FixtureLabels,
+  type FixturePayload,
+  LABELS_SUFFIX,
+  PAYLOAD_SUFFIX,
+} from '@sentra/contracts'
+
+/**
+ * Reading the golden dataset off disk.
+ *
+ * The filesystem half of the format defined in `contracts/fixture.ts`, kept
+ * separate so the format itself stays pure and testable without a directory.
+ *
+ * Payloads and labels are loaded by **separate functions returning separate
+ * types**, on purpose. Nothing in this module hands a caller both at once, so
+ * feeding ground truth to a classifier requires deciding to do it rather than
+ * forgetting not to.
+ */
+
+export const DATASET_DIR = 'eval/golden-dataset'
+
+export interface DatasetEntry {
+  name: string
+  payload: FixturePayload
+  hash: string
+}
+
+function read(dir: string, file: string): unknown {
+  return JSON.parse(readFileSync(join(dir, file), 'utf8'))
+}
+
+/**
+ * Names of every complete fixture in the directory.
+ *
+ * Throws on either kind of orphan. A payload whose labels file was never written
+ * would otherwise disappear from the dataset silently, and every published
+ * metric would be computed over fewer fixtures than the report claims.
+ */
+export function listFixtures(dir: string = DATASET_DIR): string[] {
+  const paired = pairFixtureFiles(readdirSync(dir))
+
+  if (paired.missingLabels.length > 0 || paired.orphanedLabels.length > 0) {
+    const problems = [
+      ...paired.missingLabels.map((n) => `  ${n}${PAYLOAD_SUFFIX} has no ${LABELS_SUFFIX}`),
+      ...paired.orphanedLabels.map((n) => `  ${n}${LABELS_SUFFIX} has no ${PAYLOAD_SUFFIX}`),
+    ].join('\n')
+    throw new Error(`Incomplete fixtures in ${dir}:\n${problems}`)
+  }
+
+  return paired.names
+}
+
+/** What a classifier sees. Contains nothing about the answer. */
+export function loadPayload(name: string, dir: string = DATASET_DIR): DatasetEntry {
+  const payload = parseFixturePayload(
+    read(dir, `${name}${PAYLOAD_SUFFIX}`),
+    `${name}${PAYLOAD_SUFFIX}`,
+  )
+  if (payload.name !== name) {
+    throw new Error(`${name}${PAYLOAD_SUFFIX} declares name "${payload.name}"; the two must match`)
+  }
+  return { name, payload, hash: fixtureHash(payload) }
+}
+
+/** The answer. Never returned alongside a payload. */
+export function loadLabels(name: string, dir: string = DATASET_DIR): FixtureLabels {
+  const labels = parseFixtureLabels(read(dir, `${name}${LABELS_SUFFIX}`), `${name}${LABELS_SUFFIX}`)
+  if (labels.name !== name) {
+    throw new Error(`${name}${LABELS_SUFFIX} declares name "${labels.name}"; the two must match`)
+  }
+  return labels
+}
+
+export function loadAllPayloads(dir: string = DATASET_DIR): DatasetEntry[] {
+  return listFixtures(dir).map((name) => loadPayload(name, dir))
+}
+
+export function loadAllLabels(dir: string = DATASET_DIR): FixtureLabels[] {
+  return listFixtures(dir).map((name) => loadLabels(name, dir))
+}

--- a/eval/golden-dataset/README.md
+++ b/eval/golden-dataset/README.md
@@ -1,0 +1,36 @@
+# Golden dataset
+
+Hand-labelled fixtures. Every metric this project publishes is computed against these files.
+
+Each fixture is two documents:
+
+| File                | Holds                                                                          |
+| ------------------- | ------------------------------------------------------------------------------ |
+| `<name>.run.json`   | What a classifier sees. Contains nothing about the answer.                     |
+| `<name>.labels.json` | Ground truth, the ordered rule that decided it, and the argument for the label. |
+
+They are separate files, loaded by separate functions returning separate types, so feeding the
+answer to a classifier requires deciding to do it rather than forgetting not to.
+
+## Authoring
+
+**Label first, then write the payload.** Writing the payload first invites shaping the evidence to
+fit a label already in mind.
+
+1. Apply the ordered rules in [`docs/taxonomy.md`](../../docs/taxonomy.md); the first that fires
+   decides. Record which one in `ruleApplied`.
+2. Write a `justification` that addresses the tempting alternative, not just the verdict. The
+   80-character floor exists because a one-line justification almost always means the label was not
+   really reasoned about.
+3. Keep ground-truth vocabulary out of the payload — `scenario`, test titles, error text, filenames.
+   The schema catches structural leakage; only the hygiene lint catches it in prose.
+4. Mark genuinely arguable cases `lowConfidenceGroundTruth: true`. They are excluded from headline
+   metrics and reported separately rather than quietly resolved in the project's favour.
+
+Use the [dataset fixture issue template](https://github.com/AKogut/ai-flaky-test-triage/issues/new/choose).
+
+## Target composition
+
+Shares are specified in [`docs/eval-methodology.md`](../../docs/eval-methodology.md). The dataset is
+deliberately weighted towards cases that defeat the obvious shortcuts, so a high headline number
+cannot be produced purely by easy fixtures.

--- a/eval/golden-dataset/assertion-pins-reworded-empty-state.labels.json
+++ b/eval/golden-dataset/assertion-pins-reworded-empty-state.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "assertion-pins-reworded-empty-state",
+  "owner": "test_code",
+  "determinism": "deterministic",
+  "justification": "The element rendered and its text was read, so the run reached the assertion and rule 1 is out. Rule 2 applies: the spec asserts on exact wording that carries no behavioural meaning, so it stops being a valid detector the moment copy is edited. The product change is deliberate and improves the message; only the expectation is out of date.",
+  "ruleApplied": "rule-2-unsafe-test-assumption",
+  "provenance": "synthetic",
+  "bucket": "stale-test",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/assertion-pins-reworded-empty-state.run.json
+++ b/eval/golden-dataset/assertion-pins-reworded-empty-state.run.json
@@ -1,0 +1,34 @@
+{
+  "name": "assertion-pins-reworded-empty-state",
+  "scenario": "An empty-board assertion compares against copy that was rewritten in the same release.",
+  "subject": {
+    "result": {
+      "testId": "tests/e2e/board.spec.ts›board › explains what to do when there are no tasks",
+      "title": "board › explains what to do when there are no tasks",
+      "file": "tests/e2e/board.spec.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 2870,
+      "annotations": [],
+      "error": {
+        "message": "Error: expect(locator).toHaveText(expected)\n\nExpected string: \"No tasks yet\"\nReceived string: \"Nothing here yet — add your first task\"",
+        "stack": "    at tests/e2e/board.spec.ts:78:47",
+        "snippet": "> await expect(page.getByTestId('empty-state')).toHaveText('No tasks yet')"
+      }
+    },
+    "signal": {
+      "testId": "tests/e2e/board.spec.ts›board › explains what to do when there are no tasks",
+      "flakinessScore": 0.03,
+      "consecutiveFailures": 3,
+      "totalRuns": 52,
+      "firstSeenAt": "2026-05-14T08:12:04.000Z",
+      "lastPassedAt": "2026-08-07T09:41:12.000Z",
+      "statusHistory": "PPPPPPPFFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/client/src/EmptyState.tsx b/app/client/src/EmptyState.tsx\n@@ -2,5 +2,5 @@ export function EmptyState() {\n-  return <p data-testid=\"empty-state\">No tasks yet</p>\n+  return <p data-testid=\"empty-state\">Nothing here yet — add your first task</p>\n",
+  "testSource": "test('explains what to do when there are no tasks', async ({ page }) => {\n  await page.goto('/?filter=completed')\n  await expect(page.getByTestId('empty-state')).toHaveText('No tasks yet')\n})\n"
+}

--- a/eval/golden-dataset/board-render-throws-on-empty-description.labels.json
+++ b/eval/golden-dataset/board-render-throws-on-empty-description.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "board-render-throws-on-empty-description",
+  "owner": "app_code",
+  "determinism": "deterministic",
+  "justification": "The browser started and the page navigated, so the run itself was healthy and rule 1 does not apply. The spec waits on a locator rather than a timer and makes no ordering assumption, so rule 2 is out. The stack points into product source, and the diff on that exact line removes the fallback for a nullable column, which the seeded data exercises.",
+  "ruleApplied": "rule-4-default-app-code",
+  "provenance": "synthetic",
+  "bucket": "straightforward",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/board-render-throws-on-empty-description.run.json
+++ b/eval/golden-dataset/board-render-throws-on-empty-description.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "board-render-throws-on-empty-description",
+  "scenario": "The board fails to render whenever a task carries no description, on every run.",
+  "subject": {
+    "result": {
+      "testId": "tests/e2e/board.spec.ts›board › renders every task in the list",
+      "title": "board › renders every task in the list",
+      "file": "tests/e2e/board.spec.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 4210,
+      "annotations": [],
+      "error": {
+        "message": "TypeError: Cannot read properties of null (reading 'slice')\n    at TaskCard (app/client/src/TaskCard.tsx:22:38)",
+        "stack": "    at TaskCard (app/client/src/TaskCard.tsx:22:38)\n    at renderWithHooks (react-dom.development.js:15486:18)\n    at tests/e2e/board.spec.ts:19:5",
+        "snippet": "  await page.goto('/')\n> await expect(page.getByTestId('task-card')).toHaveCount(3)"
+      }
+    },
+    "signal": {
+      "testId": "tests/e2e/board.spec.ts›board › renders every task in the list",
+      "flakinessScore": 0.03,
+      "consecutiveFailures": 3,
+      "totalRuns": 88,
+      "firstSeenAt": "2026-05-14T08:12:04.000Z",
+      "lastPassedAt": "2026-08-07T09:41:12.000Z",
+      "statusHistory": "PPPPPPPPPPFFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/client/src/TaskCard.tsx b/app/client/src/TaskCard.tsx\n@@ -19,7 +19,7 @@ export function TaskCard({ task }: { task: Task }) {\n-      <p className=\"summary\">{(task.description ?? '').slice(0, 80)}</p>\n+      <p className=\"summary\">{task.description.slice(0, 80)}</p>\n"
+}

--- a/eval/golden-dataset/bulk-insert-reuses-identifier.labels.json
+++ b/eval/golden-dataset/bulk-insert-reuses-identifier.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "bulk-insert-reuses-identifier",
+  "owner": "app_code",
+  "determinism": "deterministic",
+  "justification": "The call returned and the assertion compared a computed size, so the run reached its check and rule 1 is out. The spec depends only on its own inputs and asserts a property that must always hold, so rule 2 does not apply. The diff replaces per-row insertion with a single identifier reused across every returned task, which is exactly the collapse the set size reports.",
+  "ruleApplied": "rule-4-default-app-code",
+  "provenance": "synthetic",
+  "bucket": "straightforward",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/bulk-insert-reuses-identifier.run.json
+++ b/eval/golden-dataset/bulk-insert-reuses-identifier.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "bulk-insert-reuses-identifier",
+  "scenario": "Creating several tasks in one request yields two records sharing an identifier, every run.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.repository.test.ts›createMany › assigns a distinct identifier to every task",
+      "title": "createMany › assigns a distinct identifier to every task",
+      "file": "tests/unit/tasks.repository.test.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 22,
+      "annotations": [],
+      "error": {
+        "message": "AssertionError: expected 2 to be 3 // Object.is equality\n\nnew Set(ids).size",
+        "stack": "    at tests/unit/tasks.repository.test.ts:41:31",
+        "snippet": "  const created = await createMany(['a', 'b', 'c'])\n> expect(new Set(created.map((t) => t.id)).size).toBe(3)"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.repository.test.ts›createMany › assigns a distinct identifier to every task",
+      "flakinessScore": 0.06,
+      "consecutiveFailures": 2,
+      "totalRuns": 33,
+      "firstSeenAt": "2026-05-14T08:12:04.000Z",
+      "lastPassedAt": "2026-08-07T09:41:12.000Z",
+      "statusHistory": "PPPPPFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/server/tasks/repository.ts b/app/server/tasks/repository.ts\n@@ -60,8 +60,8 @@ export async function createMany(titles: string[]): Promise<Task[]> {\n-  const rows = await Promise.all(titles.map((title) => insertTask(title)))\n-  return rows\n+  const id = await nextId()\n+  return titles.map((title) => ({ id, title, status: 'active', position: 0 }))\n"
+}

--- a/eval/golden-dataset/button-lookup-uses-superseded-label.labels.json
+++ b/eval/golden-dataset/button-lookup-uses-superseded-label.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "button-lookup-uses-superseded-label",
+  "owner": "test_code",
+  "determinism": "deterministic",
+  "justification": "The page rendered and the wait ran to its limit rather than the browser dying, so rule 1 does not apply. Rule 2 applies: the spec matches on visible wording that the redesign shortened, and the control still exists with an accessible name and a working handler. The behaviour under test is intact; only the string the spec searches for is stale.",
+  "ruleApplied": "rule-2-unsafe-test-assumption",
+  "provenance": "synthetic",
+  "bucket": "stale-test",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/button-lookup-uses-superseded-label.run.json
+++ b/eval/golden-dataset/button-lookup-uses-superseded-label.run.json
@@ -1,0 +1,34 @@
+{
+  "name": "button-lookup-uses-superseded-label",
+  "scenario": "A spec finds its control by wording that was shortened when the toolbar was redesigned.",
+  "subject": {
+    "result": {
+      "testId": "tests/e2e/board.spec.ts›board › creates a task from the toolbar",
+      "title": "board › creates a task from the toolbar",
+      "file": "tests/e2e/board.spec.ts",
+      "status": "timedOut",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 30008,
+      "annotations": [],
+      "error": {
+        "message": "Error: locator.click: Timeout 30000ms exceeded.\nCall log:\n  - waiting for getByRole('button', { name: 'Add a new task' })\n  - locator resolved to 0 elements",
+        "stack": "    at tests/e2e/board.spec.ts:12:56",
+        "snippet": "> await page.getByRole('button', { name: 'Add a new task' }).click()"
+      }
+    },
+    "signal": {
+      "testId": "tests/e2e/board.spec.ts›board › creates a task from the toolbar",
+      "flakinessScore": 0.03,
+      "consecutiveFailures": 3,
+      "totalRuns": 73,
+      "firstSeenAt": "2026-05-14T08:12:04.000Z",
+      "lastPassedAt": "2026-08-07T09:41:12.000Z",
+      "statusHistory": "PPPPPPPPPFFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/client/src/Toolbar.tsx b/app/client/src/Toolbar.tsx\n@@ -6,7 +6,7 @@ export function Toolbar({ onCreate }: ToolbarProps) {\n-      <button onClick={onCreate}>Add a new task</button>\n+      <button onClick={onCreate} aria-label=\"Add task\">Add task</button>\n",
+  "testSource": "test('creates a task from the toolbar', async ({ page }) => {\n  await page.goto('/')\n  await page.getByRole('button', { name: 'Add a new task' }).click()\n  await expect(page.getByRole('dialog')).toBeVisible()\n})\n"
+}

--- a/eval/golden-dataset/client-calls-unversioned-endpoint-path.labels.json
+++ b/eval/golden-dataset/client-calls-unversioned-endpoint-path.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "client-calls-unversioned-endpoint-path",
+  "owner": "test_code",
+  "determinism": "deterministic",
+  "justification": "The server started and answered, so nothing environmental interfered and rule 1 is out. Rule 2 applies: the spec hard-codes a path that the release moved deliberately, and the diff shows the client was updated in the same commit while the spec was not. The product is behaving as designed at the new path; only this expectation was left behind.",
+  "ruleApplied": "rule-2-unsafe-test-assumption",
+  "provenance": "synthetic",
+  "bucket": "stale-test",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/client-calls-unversioned-endpoint-path.run.json
+++ b/eval/golden-dataset/client-calls-unversioned-endpoint-path.run.json
@@ -1,0 +1,34 @@
+{
+  "name": "client-calls-unversioned-endpoint-path",
+  "scenario": "An API spec requests a path that was moved behind a version prefix, and receives nothing.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.api.test.ts›GET /api/tasks › lists the seeded tasks",
+      "title": "GET /api/tasks › lists the seeded tasks",
+      "file": "tests/unit/tasks.api.test.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 19,
+      "annotations": [],
+      "error": {
+        "message": "AssertionError: expected 404 to be 200 // Object.is equality",
+        "stack": "    at tests/unit/tasks.api.test.ts:14:29",
+        "snippet": "  const response = await request(app).get('/api/tasks')\n> expect(response.status).toBe(200)"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.api.test.ts›GET /api/tasks › lists the seeded tasks",
+      "flakinessScore": 0.02,
+      "consecutiveFailures": 4,
+      "totalRuns": 67,
+      "firstSeenAt": "2026-05-14T08:12:04.000Z",
+      "lastPassedAt": "2026-08-07T09:41:12.000Z",
+      "statusHistory": "PPPPPPPPFFFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/server/index.ts b/app/server/index.ts\n@@ -12,7 +12,8 @@ const app = express()\n-app.use('/api/tasks', tasksRouter)\n+app.use('/api/v1/tasks', tasksRouter)\n+app.use('/api/tasks', deprecationNotice)\ndiff --git a/app/client/src/api.ts b/app/client/src/api.ts\n@@ -1,3 +1,3 @@\n-const BASE = '/api/tasks'\n+const BASE = '/api/v1/tasks'\n",
+  "testSource": "it('lists the seeded tasks', async () => {\n  const response = await request(app).get('/api/tasks')\n  expect(response.status).toBe(200)\n})\n"
+}

--- a/eval/golden-dataset/completed-filter-omits-most-recent-item.labels.json
+++ b/eval/golden-dataset/completed-filter-omits-most-recent-item.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "completed-filter-omits-most-recent-item",
+  "owner": "app_code",
+  "determinism": "deterministic",
+  "justification": "The assertion ran and compared collections, so the failure is not an infrastructure one and rule 1 is out. The spec seeds its own data and asserts on the return value of a pure function, so there is no unsafe assumption for rule 2 to catch. The diff introduces a slice on the filtering path that drops the final element, which matches the observed difference exactly.",
+  "ruleApplied": "rule-4-default-app-code",
+  "provenance": "synthetic",
+  "bucket": "straightforward",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/completed-filter-omits-most-recent-item.run.json
+++ b/eval/golden-dataset/completed-filter-omits-most-recent-item.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "completed-filter-omits-most-recent-item",
+  "scenario": "Filtering by completed status returns one fewer item than the board holds, every run.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.filter.test.ts›filter › completed returns every finished task",
+      "title": "filter › completed returns every finished task",
+      "file": "tests/unit/tasks.filter.test.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 31,
+      "annotations": [],
+      "error": {
+        "message": "AssertionError: expected [ { id: 2 }, { id: 3 } ] to deeply equal [ { id: 2 }, { id: 3 }, { id: 5 } ]",
+        "stack": "    at tests/unit/tasks.filter.test.ts:52:36",
+        "snippet": "  const completed = filterTasks(seed, 'completed')\n> expect(completed).toEqual([seed[1], seed[2], seed[4]])"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.filter.test.ts›filter › completed returns every finished task",
+      "flakinessScore": 0.03,
+      "consecutiveFailures": 2,
+      "totalRuns": 44,
+      "firstSeenAt": "2026-05-14T08:12:04.000Z",
+      "lastPassedAt": "2026-08-07T09:41:12.000Z",
+      "statusHistory": "PPPPPPPFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/server/tasks/filter.ts b/app/server/tasks/filter.ts\n@@ -6,7 +6,7 @@ export function filterTasks(tasks: Task[], mode: FilterMode): Task[] {\n   if (mode === 'completed') {\n-    return tasks.filter((t) => t.status === 'completed')\n+    return tasks.slice(0, -1).filter((t) => t.status === 'completed')\n   }\n"
+}

--- a/eval/golden-dataset/completion-toggle-never-reaches-server.labels.json
+++ b/eval/golden-dataset/completion-toggle-never-reaches-server.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "completion-toggle-never-reaches-server",
+  "owner": "app_code",
+  "determinism": "deterministic",
+  "justification": "The page loaded and the locator resolved before the expectation timed out, so the browser and the server were both healthy and rule 1 is out. The spec reloads and then waits on state, which is the correct way to check persistence, so rule 2 does not apply. The diff drops the call that sends the change to the server while keeping the local update, so the interface is right until the page is reloaded — the exact shape of the failure.",
+  "ruleApplied": "rule-4-default-app-code",
+  "provenance": "synthetic",
+  "bucket": "straightforward",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/completion-toggle-never-reaches-server.run.json
+++ b/eval/golden-dataset/completion-toggle-never-reaches-server.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "completion-toggle-never-reaches-server",
+  "scenario": "Marking a task done survives in the interface but is absent after a reload, on every run.",
+  "subject": {
+    "result": {
+      "testId": "tests/e2e/board.spec.ts›board › completion survives a reload",
+      "title": "board › completion survives a reload",
+      "file": "tests/e2e/board.spec.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 5120,
+      "annotations": [],
+      "error": {
+        "message": "Error: Timed out 5000ms waiting for expect(locator).toBeChecked()\n\nLocator: getByTestId('task-1-complete')\nExpected: checked\nReceived: unchecked",
+        "stack": "    at tests/e2e/board.spec.ts:63:44",
+        "snippet": "  await page.reload()\n> await expect(page.getByTestId('task-1-complete')).toBeChecked()"
+      }
+    },
+    "signal": {
+      "testId": "tests/e2e/board.spec.ts›board › completion survives a reload",
+      "flakinessScore": 0.04,
+      "consecutiveFailures": 4,
+      "totalRuns": 77,
+      "firstSeenAt": "2026-05-14T08:12:04.000Z",
+      "lastPassedAt": "2026-08-07T09:41:12.000Z",
+      "statusHistory": "PPPPPPPPFFFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/client/src/useTasks.ts b/app/client/src/useTasks.ts\n@@ -48,8 +48,7 @@ export function useTasks() {\n   const complete = (id: number) => {\n     setTasks((prev) => prev.map((t) => (t.id === id ? { ...t, status: 'completed' } : t)))\n-    return api.completeTask(id)\n   }\n"
+}

--- a/eval/golden-dataset/create-task-returns-ok-instead-of-created.labels.json
+++ b/eval/golden-dataset/create-task-returns-ok-instead-of-created.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "create-task-returns-ok-instead-of-created",
+  "owner": "app_code",
+  "determinism": "deterministic",
+  "justification": "The suite reached its assertion and disagreed on a value, so rule 1 does not apply, and the spec makes no timing or ordering assumption, so rule 2 does not apply either. The diff removes the explicit status on the create handler, which is the exact value asserted. The tempting alternative is calling the expectation outdated, but nothing in the change suggests 200 was intended: the response body is unchanged and no other caller was updated.",
+  "ruleApplied": "rule-4-default-app-code",
+  "provenance": "synthetic",
+  "bucket": "straightforward",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/create-task-returns-ok-instead-of-created.run.json
+++ b/eval/golden-dataset/create-task-returns-ok-instead-of-created.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "create-task-returns-ok-instead-of-created",
+  "scenario": "Creating a task answers with 200 where the suite expects 201, on every run since a routing change.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.api.test.ts›POST /api/tasks › answers 201 with the created task",
+      "title": "POST /api/tasks › answers 201 with the created task",
+      "file": "tests/unit/tasks.api.test.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 48,
+      "annotations": [],
+      "error": {
+        "message": "AssertionError: expected 200 to be 201 // Object.is equality\n\n- Expected\n+ Received\n\n- 201\n+ 200",
+        "stack": "    at tests/unit/tasks.api.test.ts:34:29\n    at file:///repo/node_modules/@vitest/runner/dist/index.js:146:14",
+        "snippet": "  const response = await request(app).post('/api/tasks').send({ title: 'Write the report' })\n> expect(response.status).toBe(201)"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.api.test.ts›POST /api/tasks › answers 201 with the created task",
+      "flakinessScore": 0.04,
+      "consecutiveFailures": 3,
+      "totalRuns": 61,
+      "firstSeenAt": "2026-05-14T08:12:04.000Z",
+      "lastPassedAt": "2026-08-07T09:41:12.000Z",
+      "statusHistory": "PPPPPPPPFFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/server/routes/tasks.ts b/app/server/routes/tasks.ts\n@@ -18,7 +18,7 @@ router.post('/', async (req, res) => {\n   const task = await createTask(parsed.data)\n-  res.status(201).json(task)\n+  res.json(task)\n })\n"
+}

--- a/eval/golden-dataset/delete-removes-neighbouring-record.labels.json
+++ b/eval/golden-dataset/delete-removes-neighbouring-record.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "delete-removes-neighbouring-record",
+  "owner": "app_code",
+  "determinism": "deterministic",
+  "justification": "An assertion was reached and disagreed on the surviving rows, so this is not rule 1. The spec creates its own records and refers to them by returned identifier rather than by position, so it makes no unsafe assumption under rule 2. The diff switches the delete predicate from the primary key to rowid, which coincide only until a row is removed — exactly the observed effect.",
+  "ruleApplied": "rule-4-default-app-code",
+  "provenance": "synthetic",
+  "bucket": "straightforward",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/delete-removes-neighbouring-record.run.json
+++ b/eval/golden-dataset/delete-removes-neighbouring-record.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "delete-removes-neighbouring-record",
+  "scenario": "Deleting the second task leaves the wrong record behind on every run after an indexing change.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.api.test.ts›DELETE /api/tasks/:id › removes only the requested task",
+      "title": "DELETE /api/tasks/:id › removes only the requested task",
+      "file": "tests/unit/tasks.api.test.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 57,
+      "annotations": [],
+      "error": {
+        "message": "AssertionError: expected [ 'Buy milk', 'File taxes' ] to deeply equal [ 'Buy milk', 'Walk the dog' ]",
+        "stack": "    at tests/unit/tasks.api.test.ts:88:41",
+        "snippet": "  await request(app).delete(`/api/tasks/${ids[1]}`)\n> expect(titles(await listTasks())).toEqual(['Buy milk', 'Walk the dog'])"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.api.test.ts›DELETE /api/tasks/:id › removes only the requested task",
+      "flakinessScore": 0.02,
+      "consecutiveFailures": 2,
+      "totalRuns": 71,
+      "firstSeenAt": "2026-05-14T08:12:04.000Z",
+      "lastPassedAt": "2026-08-07T09:41:12.000Z",
+      "statusHistory": "PPPPPPPPPFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/server/tasks/repository.ts b/app/server/tasks/repository.ts\n@@ -44,7 +44,7 @@ export async function deleteTask(id: number): Promise<void> {\n-  await db.run('DELETE FROM tasks WHERE id = ?', id)\n+  await db.run('DELETE FROM tasks WHERE rowid = ?', id)\n }\n"
+}

--- a/eval/golden-dataset/editing-title-clears-board-position.labels.json
+++ b/eval/golden-dataset/editing-title-clears-board-position.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "editing-title-clears-board-position",
+  "owner": "app_code",
+  "determinism": "deterministic",
+  "justification": "The request completed and the follow-up read returned a value, so nothing environmental blocked the assertion and rule 1 is out. The spec asserts on a field it never sets, which is a reasonable expectation rather than an unsafe assumption, so rule 2 does not apply. The diff stops merging the existing record before the update, so unspecified columns fall back to their defaults — which is precisely what the failure shows.",
+  "ruleApplied": "rule-4-default-app-code",
+  "provenance": "synthetic",
+  "bucket": "straightforward",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/editing-title-clears-board-position.run.json
+++ b/eval/golden-dataset/editing-title-clears-board-position.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "editing-title-clears-board-position",
+  "scenario": "Renaming a task moves it to the end of the board on every run since the update handler changed.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.api.test.ts›PATCH /api/tasks/:id › leaves ordering untouched when only the title changes",
+      "title": "PATCH /api/tasks/:id › leaves ordering untouched when only the title changes",
+      "file": "tests/unit/tasks.api.test.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 63,
+      "annotations": [],
+      "error": {
+        "message": "AssertionError: expected 0 to be 2 // Object.is equality",
+        "stack": "    at tests/unit/tasks.api.test.ts:112:35",
+        "snippet": "  await request(app).patch(`/api/tasks/${id}`).send({ title: 'Renamed' })\n> expect((await getTask(id)).position).toBe(2)"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.api.test.ts›PATCH /api/tasks/:id › leaves ordering untouched when only the title changes",
+      "flakinessScore": 0.05,
+      "consecutiveFailures": 2,
+      "totalRuns": 39,
+      "firstSeenAt": "2026-05-14T08:12:04.000Z",
+      "lastPassedAt": "2026-08-07T09:41:12.000Z",
+      "statusHistory": "PPPPPPFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/server/routes/tasks.ts b/app/server/routes/tasks.ts\n@@ -31,7 +31,7 @@ router.patch('/:id', async (req, res) => {\n-  const updated = await updateTask(id, { ...existing, ...parsed.data })\n+  const updated = await updateTask(id, { ...parsed.data })\n   res.json(updated)\n"
+}

--- a/eval/golden-dataset/expectation-assumes-flat-response-body.labels.json
+++ b/eval/golden-dataset/expectation-assumes-flat-response-body.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "expectation-assumes-flat-response-body",
+  "owner": "test_code",
+  "determinism": "deterministic",
+  "justification": "A response arrived and was inspected, so the run reached its assertion and rule 1 is out. Rule 2 applies: the spec reads a shape the release changed on purpose, adding an envelope with paging metadata. Reading this as a product defect is tempting because a field vanished, but the change is intentional and documented in the same commit; the expectation simply was not updated.",
+  "ruleApplied": "rule-2-unsafe-test-assumption",
+  "provenance": "synthetic",
+  "bucket": "stale-test",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/expectation-assumes-flat-response-body.run.json
+++ b/eval/golden-dataset/expectation-assumes-flat-response-body.run.json
@@ -1,0 +1,34 @@
+{
+  "name": "expectation-assumes-flat-response-body",
+  "scenario": "A spec reads fields from the top level of a response that now wraps its payload.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.api.test.ts›GET /api/tasks › returns tasks with titles",
+      "title": "GET /api/tasks › returns tasks with titles",
+      "file": "tests/unit/tasks.api.test.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 24,
+      "annotations": [],
+      "error": {
+        "message": "AssertionError: expected undefined to be an instance of Array",
+        "stack": "    at tests/unit/tasks.api.test.ts:22:34",
+        "snippet": "  const response = await request(app).get('/api/v1/tasks')\n> expect(response.body.tasks).toBeInstanceOf(Array)"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.api.test.ts›GET /api/tasks › returns tasks with titles",
+      "flakinessScore": 0.04,
+      "consecutiveFailures": 3,
+      "totalRuns": 48,
+      "firstSeenAt": "2026-05-14T08:12:04.000Z",
+      "lastPassedAt": "2026-08-07T09:41:12.000Z",
+      "statusHistory": "PPPPPPFFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/server/routes/tasks.ts b/app/server/routes/tasks.ts\n@@ -8,7 +8,7 @@ router.get('/', async (_req, res) => {\n   const tasks = await listTasks()\n-  res.json({ tasks })\n+  res.json({ data: { tasks }, meta: { total: tasks.length } })\n })\n",
+  "testSource": "it('returns tasks with titles', async () => {\n  const response = await request(app).get('/api/v1/tasks')\n  expect(response.body.tasks).toBeInstanceOf(Array)\n})\n"
+}

--- a/eval/golden-dataset/locator-still-uses-retired-test-id.labels.json
+++ b/eval/golden-dataset/locator-still-uses-retired-test-id.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "locator-still-uses-retired-test-id",
+  "owner": "test_code",
+  "determinism": "deterministic",
+  "justification": "The browser launched and the page loaded before the wait expired, so the run was healthy and rule 1 does not apply. Rule 2 fires: the spec pins an implementation detail that the product is free to change, and the diff shows the attribute was renamed with the button, the handler and the behaviour all intact. Blaming the product is tempting because the diff touches it, but nothing a user can observe changed.",
+  "ruleApplied": "rule-2-unsafe-test-assumption",
+  "provenance": "synthetic",
+  "bucket": "stale-test",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/locator-still-uses-retired-test-id.run.json
+++ b/eval/golden-dataset/locator-still-uses-retired-test-id.run.json
@@ -1,0 +1,34 @@
+{
+  "name": "locator-still-uses-retired-test-id",
+  "scenario": "A board spec cannot find its element since the markup was reworked; the interface behaves correctly by hand.",
+  "subject": {
+    "result": {
+      "testId": "tests/e2e/board.spec.ts›board › opens the editor for a task",
+      "title": "board › opens the editor for a task",
+      "file": "tests/e2e/board.spec.ts",
+      "status": "timedOut",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 30012,
+      "annotations": [],
+      "error": {
+        "message": "Error: locator.click: Timeout 30000ms exceeded.\nCall log:\n  - waiting for getByTestId('task-row-edit')\n  - locator resolved to 0 elements",
+        "stack": "    at tests/e2e/board.spec.ts:44:48",
+        "snippet": "> await page.getByTestId('task-row-edit').click()"
+      }
+    },
+    "signal": {
+      "testId": "tests/e2e/board.spec.ts›board › opens the editor for a task",
+      "flakinessScore": 0.02,
+      "consecutiveFailures": 4,
+      "totalRuns": 91,
+      "firstSeenAt": "2026-05-14T08:12:04.000Z",
+      "lastPassedAt": "2026-08-07T09:41:12.000Z",
+      "statusHistory": "PPPPPPPPPPFFFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/client/src/TaskCard.tsx b/app/client/src/TaskCard.tsx\n@@ -28,7 +28,7 @@ export function TaskCard({ task }: { task: Task }) {\n-      <button data-testid=\"task-row-edit\" onClick={onEdit}>Edit</button>\n+      <button data-testid=\"task-card-edit\" onClick={onEdit}>Edit</button>\n",
+  "testSource": "test('opens the editor for a task', async ({ page }) => {\n  await page.goto('/')\n  await page.getByTestId('task-row-edit').click()\n  await expect(page.getByRole('dialog')).toBeVisible()\n})\n"
+}

--- a/eval/golden-dataset/seed-helper-sends-retired-column.labels.json
+++ b/eval/golden-dataset/seed-helper-sends-retired-column.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "seed-helper-sends-retired-column",
+  "owner": "test_code",
+  "determinism": "deterministic",
+  "justification": "The server answered with a validation error, so it was running and rule 1 is out. Rule 2 applies: the helper sends a field the release removed on purpose, and the strict schema is doing its job by rejecting it. The product change is deliberate and the error message names the offending key; the fixture helper is what needs editing.",
+  "ruleApplied": "rule-2-unsafe-test-assumption",
+  "provenance": "synthetic",
+  "bucket": "stale-test",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/seed-helper-sends-retired-column.run.json
+++ b/eval/golden-dataset/seed-helper-sends-retired-column.run.json
@@ -1,0 +1,34 @@
+{
+  "name": "seed-helper-sends-retired-column",
+  "scenario": "A helper builds request bodies containing a field the schema no longer accepts, so setup is rejected.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.api.test.ts›POST /api/v1/tasks › accepts the seed payload",
+      "title": "POST /api/v1/tasks › accepts the seed payload",
+      "file": "tests/unit/tasks.api.test.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 27,
+      "annotations": [],
+      "error": {
+        "message": "AssertionError: expected 400 to be 201 // Object.is equality\n\nresponse.body.error: \"Unrecognised key: priority\"",
+        "stack": "    at tests/unit/tasks.api.test.ts:9:29",
+        "snippet": "  const response = await request(app).post('/api/v1/tasks').send(seedTask())\n> expect(response.status).toBe(201)"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.api.test.ts›POST /api/v1/tasks › accepts the seed payload",
+      "flakinessScore": 0.03,
+      "consecutiveFailures": 2,
+      "totalRuns": 55,
+      "firstSeenAt": "2026-05-14T08:12:04.000Z",
+      "lastPassedAt": "2026-08-07T09:41:12.000Z",
+      "statusHistory": "PPPPPPPFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/server/tasks/schema.ts b/app/server/tasks/schema.ts\n@@ -3,8 +3,7 @@ export const CreateTaskSchema = z\n     title: z.string().min(1),\n     description: z.string().optional(),\n-    priority: z.enum(['low', 'high']).optional(),\n   })\n   .strict()\n",
+  "testSource": "const seedTask = () => ({ title: 'Write the report', priority: 'high' })\n\nit('accepts the seed payload', async () => {\n  const response = await request(app).post('/api/v1/tasks').send(seedTask())\n  expect(response.status).toBe(201)\n})\n"
+}

--- a/eval/golden-dataset/spec-asserts-withdrawn-legacy-field.labels.json
+++ b/eval/golden-dataset/spec-asserts-withdrawn-legacy-field.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "spec-asserts-withdrawn-legacy-field",
+  "owner": "test_code",
+  "determinism": "deterministic",
+  "justification": "The endpoint answered and the body was inspected, so rule 1 does not apply. Rule 2 applies: the spec asserts on a field the product announced it would withdraw, and the diff removes it with the deprecation note that had been in the source since June. The replacement field is present and already covered elsewhere, so this expectation is redundant as well as out of date.",
+  "ruleApplied": "rule-2-unsafe-test-assumption",
+  "provenance": "synthetic",
+  "bucket": "stale-test",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/spec-asserts-withdrawn-legacy-field.run.json
+++ b/eval/golden-dataset/spec-asserts-withdrawn-legacy-field.run.json
@@ -1,0 +1,34 @@
+{
+  "name": "spec-asserts-withdrawn-legacy-field",
+  "scenario": "A spec checks for a compatibility field that was withdrawn after its deprecation window closed.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.api.test.ts›GET /api/v1/tasks › includes the ordering hint",
+      "title": "GET /api/v1/tasks › includes the ordering hint",
+      "file": "tests/unit/tasks.api.test.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 21,
+      "annotations": [],
+      "error": {
+        "message": "AssertionError: expected undefined to be a number\n\nresponse.body.data.tasks[0].sortKey",
+        "stack": "    at tests/unit/tasks.api.test.ts:30:52",
+        "snippet": "> expect(response.body.data.tasks[0].sortKey).toBeTypeOf('number')"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.api.test.ts›GET /api/v1/tasks › includes the ordering hint",
+      "flakinessScore": 0.02,
+      "consecutiveFailures": 2,
+      "totalRuns": 82,
+      "firstSeenAt": "2026-05-14T08:12:04.000Z",
+      "lastPassedAt": "2026-08-07T09:41:12.000Z",
+      "statusHistory": "PPPPPPPPPPFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/server/tasks/serialise.ts b/app/server/tasks/serialise.ts\n@@ -5,7 +5,6 @@ export function serialiseTask(task: Task) {\n     position: task.position,\n-    sortKey: task.position, // deprecated 2026-06-01, remove after two releases\n   }\n }\n",
+  "testSource": "it('includes the ordering hint', async () => {\n  const response = await request(app).get('/api/v1/tasks')\n  expect(response.body.data.tasks[0].sortKey).toBeTypeOf('number')\n})\n"
+}

--- a/eval/golden-dataset/task-count-header-excludes-newest.labels.json
+++ b/eval/golden-dataset/task-count-header-excludes-newest.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "task-count-header-excludes-newest",
+  "owner": "app_code",
+  "determinism": "deterministic",
+  "justification": "The heading rendered and its text was compared, so nothing prevented the assertion and rule 1 is out. The spec creates the fourth task through the interface and then waits on the heading, so it does not assume timing and rule 2 does not apply. The diff subtracts one from the rendered count, which matches the observed difference for any list length.",
+  "ruleApplied": "rule-4-default-app-code",
+  "provenance": "synthetic",
+  "bucket": "straightforward",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/task-count-header-excludes-newest.run.json
+++ b/eval/golden-dataset/task-count-header-excludes-newest.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "task-count-header-excludes-newest",
+  "scenario": "The heading reports one fewer task than the list shows, on every run since a counting change.",
+  "subject": {
+    "result": {
+      "testId": "tests/e2e/board.spec.ts›board › heading counts every visible task",
+      "title": "board › heading counts every visible task",
+      "file": "tests/e2e/board.spec.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 3980,
+      "annotations": [],
+      "error": {
+        "message": "Error: expect(locator).toHaveText(expected)\n\nLocator: getByRole('heading', { level: 1 })\nExpected string: \"4 tasks\"\nReceived string: \"3 tasks\"",
+        "stack": "    at tests/e2e/board.spec.ts:31:52",
+        "snippet": "  await createTask(page, 'Fourth')\n> await expect(page.getByRole('heading', { level: 1 })).toHaveText('4 tasks')"
+      }
+    },
+    "signal": {
+      "testId": "tests/e2e/board.spec.ts›board › heading counts every visible task",
+      "flakinessScore": 0.02,
+      "consecutiveFailures": 2,
+      "totalRuns": 64,
+      "firstSeenAt": "2026-05-14T08:12:04.000Z",
+      "lastPassedAt": "2026-08-07T09:41:12.000Z",
+      "statusHistory": "PPPPPPPPPFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/client/src/BoardHeading.tsx b/app/client/src/BoardHeading.tsx\n@@ -4,5 +4,5 @@ export function BoardHeading({ tasks }: { tasks: Task[] }) {\n-  return <h1>{tasks.length} tasks</h1>\n+  return <h1>{tasks.filter((t) => t.id !== undefined).length - 1} tasks</h1>\n"
+}

--- a/eval/package.json
+++ b/eval/package.json
@@ -10,5 +10,8 @@
       "types": "./dist/index.d.ts",
       "default": "./index.ts"
     }
+  },
+  "dependencies": {
+    "@sentra/contracts": "*"
   }
 }

--- a/eval/tsconfig.json
+++ b/eval/tsconfig.json
@@ -5,5 +5,10 @@
     "outDir": "dist"
   },
   "include": ["**/*.ts"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    {
+      "path": "../contracts"
+    }
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,7 @@
         "app/server",
         "flakemetry-lib",
         "agents",
-        "eval",
-        "tests"
+        "eval"
       ],
       "dependencies": {
         "zod": "4.4.3"
@@ -68,7 +67,10 @@
     "eval": {
       "name": "@sentra/eval",
       "version": "0.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@sentra/contracts": "*"
+      }
     },
     "flakemetry-lib": {
       "name": "@sentra/flakemetry",
@@ -1603,10 +1605,6 @@
     },
     "node_modules/@sentra/taskflow-server": {
       "resolved": "app/server",
-      "link": true
-    },
-    "node_modules/@sentra/tests": {
-      "resolved": "tests",
       "link": true
     },
     "node_modules/@standard-schema/spec": {
@@ -5516,6 +5514,7 @@
     "tests": {
       "name": "@sentra/tests",
       "version": "0.1.0",
+      "extraneous": true,
       "dependencies": {
         "@sentra/contracts": "*"
       }


### PR DESCRIPTION
Closes #20

## What changed

15 hand-authored fixtures — 8 `app_code + deterministic`, 7 `test_code + deterministic` — plus the filesystem loader and a suite that validates the dataset itself.

## Why

The sanity floor. A classifier that misses these is broken, and they anchor the per-bucket breakdown so a high headline number cannot be produced purely by easy cases.

## Decisions worth reviewing

**Labelled before the payload was written.** Not a formality: writing the payload first invites shaping the evidence to fit a label already in mind, and the result is a dataset that only looks discriminating.

**The seven stale-test fixtures are the ones worth reading.** In every one of them the diff touches *product source* — a renamed `data-testid`, reworded copy, a versioned route, a response envelope, a removed field. A diff-only heuristic will call all seven `app_code`. The label is `test_code` because the product change is deliberate and observable behaviour is intact; only the expectation was left behind.

That contrast is deliberate. Without it the "straightforward" bucket would be trivially separable by one feature, and the baseline comparison in #24 would be meaningless before it started.

**Every justification addresses the tempting alternative.** The test suite enforces a floor above the schema's own — the point is not length, it is that a labeller who has considered the counter-argument writes a different sentence than one who has not. There is also an assertion that no `test_code` label cites `rule-4-default-app-code`, since reaching the default rule for that label means the rule that should have fired was skipped.

**Error text, stacks, snippets and diffs are realistic.** Real Vitest and Playwright failure shapes — `AssertionError: expected 200 to be 201`, `locator resolved to 0 elements`, a `TypeError` with a component frame. A classifier trained to expect tidy fixtures is not measuring anything.

**No ground-truth vocabulary in any payload.** Verified across every string value: none of `app_code`, `test_code`, `environment`, `deterministic`, `intermittent`, `regression`, `stale`, or `race` appears in a `scenario`, test title, error message, diff or filename. The mechanised version of this check is #23; the field names `flakinessScore` and `flakyWithinRun` are schema keys, not leakage, and #23 will need to exclude them.

## How it was verified

206 assertions total, 25 new. The dataset tests run against the **real** files, not a synthetic directory, because the failure worth catching is a fixture that parses and is subtly wrong:

- distinct content hashes — two identical payloads under different names would double-count in every metric while looking like independent evidence
- `testId` consistent between `result` and `signal` in each subject
- every subject actually failed — a fixture whose test passed has nothing to classify
- no payload carries `owner`, `determinism` or `labels`

Distribution confirmed: 8 `app_code + deterministic` / `straightforward`, 7 `test_code + deterministic` / `stale-test`, all `provenance: synthetic`.

## Checklist

- [x] Title is a valid Conventional Commit
- [x] Linked to exactly one issue with `Closes #N`
- [x] `npm run lint && npm run format:check && npm run typecheck && npm run test:unit` clean
- [x] 8 + 7 split, every fixture carrying `justification` and `ruleApplied`
- [x] Leakage checked across every string value

## Notes for the reviewer

`eval/dataset.ts` arrives here rather than in #27 because the fixtures cannot be asserted valid without loading them. It is the filesystem half of the format defined in `contracts/fixture.ts`, which stays pure.

The hygiene lint (#23) will retro-validate these. If it finds leakage this pass missed, that is the lint doing its job — and the fixture gets fixed, not the lint relaxed.

These 15 are the easy buckets by design. The hard quadrant (#21) and the adversarial fixtures (#22) are where the dataset starts being able to tell classifiers apart.