### PR TITLE
feat(eval): add the non-LLM baseline classifier

### DIFF
--- a/docs/eval-methodology.md
+++ b/docs/eval-methodology.md
@@ -15,17 +15,31 @@ Four mechanisms keep the numbers honest.
 `eval/baseline.ts` implements a deliberately simple heuristic:
 
 ```
-if the run produced no assertion (crash/bind/install error)   → environment
-else if the diff touches the file under test                  → app_code
-else if the error is a locator/timeout error                  → test_code
-else                                                          → app_code
+owner:
+if the failure names an infrastructure error (bind / connect /  → environment
+    missing module / browser launch / OOM), so no assertion ran
+else if the commit changes any non-test source file             → app_code
+else if the failure names a selector or a wait, not a value     → test_code
+else                                                            → app_code
 
 determinism:
-if all attempts failed and history shows an unbroken streak   → deterministic
-else                                                          → intermittent
+if there was no pass on retry and the recent history shows an   → deterministic
+    unbroken failure streak of two or more
+else                                                            → intermittent
 ```
 
-Roughly thirty lines. Every agent number is reported **alongside** the baseline on the same
+The second rule deserves a note, because an earlier wording of it — "the diff touches the file
+under test" — is ambiguous in a way that changes the classifier. It could mean the _test_ file or
+the _implementation_ the test exercises, and the two point in opposite directions: a diff touching
+the spec suggests `test_code`, while a diff touching the implementation suggests `app_code`. A
+heuristic cannot map a test to its implementation, so the rule is stated as written above: any
+changed non-test path counts.
+
+That is a real weakness, deliberately left in. Every fixture in the `stale-test` bucket has a
+product diff, so the baseline calls all of them `app_code` and gets all of them wrong. Patching
+around it would mean tuning the control against the dataset it is meant to control for.
+
+Roughly sixty lines. Every agent number is reported **alongside** the baseline on the same
 fixtures, and the headline metric is the _delta_, not the absolute.
 
 This has two good outcomes and no bad one. If the agent wins, there is evidence the LLM earns its

--- a/eval/baseline.test.ts
+++ b/eval/baseline.test.ts
@@ -1,0 +1,206 @@
+import { ClassificationSchema, type FixturePayload } from '@sentra/contracts'
+import { describe, expect, it } from 'vitest'
+import { classifyWithBaseline } from './baseline.js'
+import { loadAllPayloads, loadLabels } from './dataset.js'
+
+const payload = (overrides: {
+  message?: string
+  stack?: string
+  diff?: string
+  consecutiveFailures?: number
+  flakyWithinRun?: boolean
+  historyAvailable?: boolean
+  statusHistory?: string
+}): FixturePayload => ({
+  name: 'probe',
+  scenario: 'A probe fixture built in the test to exercise one rule at a time.',
+  historyAvailable: overrides.historyAvailable ?? true,
+  ...(overrides.diff === undefined ? {} : { diff: overrides.diff }),
+  subject: {
+    result: {
+      testId: 'tests/unit/a.test.ts›t',
+      title: 't',
+      file: 'tests/unit/a.test.ts',
+      status: 'failed',
+      attempts: 1,
+      flakyWithinRun: overrides.flakyWithinRun ?? false,
+      durationMs: 10,
+      annotations: [],
+      error: {
+        message: overrides.message ?? 'AssertionError: expected 1 to be 2',
+        ...(overrides.stack === undefined ? {} : { stack: overrides.stack }),
+      },
+    },
+    signal: {
+      testId: 'tests/unit/a.test.ts›t',
+      flakinessScore: 0.1,
+      consecutiveFailures: overrides.consecutiveFailures ?? 0,
+      totalRuns: 20,
+      firstSeenAt: '2026-06-01T00:00:00.000Z',
+      lastPassedAt: '2026-08-01T00:00:00.000Z',
+      statusHistory: overrides.statusHistory ?? 'PPPPF',
+      isNew: false,
+    },
+  },
+})
+
+const productDiff = 'diff --git a/app/server/routes/tasks.ts b/app/server/routes/tasks.ts\n'
+const specDiff = 'diff --git a/tests/unit/a.test.ts b/tests/unit/a.test.ts\n'
+
+describe('owner rules, in order', () => {
+  it.each([
+    ['a port collision', 'Error: listen EADDRINUSE: address already in use :::3001'],
+    ['a refused connection', 'Error: connect ECONNREFUSED 127.0.0.1:3001'],
+    ['a missing module', "Error: Cannot find module '@sentra/contracts'"],
+    ['a browser that would not start', "browserType.launch: Executable doesn't exist"],
+    ['an out-of-memory kill', 'FATAL ERROR: JavaScript heap out of memory'],
+  ])('classifies %s as environment', (_label, message) => {
+    expect(classifyWithBaseline(payload({ message })).owner).toBe('environment')
+  })
+
+  it('prefers environment even when the commit changes product source', () => {
+    // Rule order matters: a run that never reached an assertion says nothing
+    // about the diff, however suspicious the diff looks.
+    const result = classifyWithBaseline(
+      payload({ message: 'Error: listen EADDRINUSE', diff: productDiff }),
+    )
+    expect(result.owner).toBe('environment')
+  })
+
+  it('classifies a product diff as app_code', () => {
+    expect(classifyWithBaseline(payload({ diff: productDiff })).owner).toBe('app_code')
+  })
+
+  it('does not let a test-only diff fire the product-change rule', () => {
+    // Both land on app_code — the second rule and the fallback share a label —
+    // so asserting on the label alone would pass whether or not the rule fired.
+    // The reasoning and the confidence are what distinguish them.
+    const testOnly = classifyWithBaseline(payload({ diff: specDiff }))
+    const noDiff = classifyWithBaseline(payload({}))
+    expect(testOnly.reasoning).toContain('fallback')
+    expect(testOnly.confidence).toBe(noDiff.confidence)
+  })
+
+  it.each([
+    [
+      'a locator timeout',
+      "locator.click: Timeout 30000ms exceeded.\n  - waiting for getByTestId('x')",
+    ],
+    ['an explicit wait', 'Error: Timed out 5000ms waiting for expect(locator).toBeVisible()'],
+  ])('classifies %s with no product diff as test_code', (_label, message) => {
+    expect(classifyWithBaseline(payload({ message })).owner).toBe('test_code')
+  })
+
+  it('falls back to app_code when nothing matches', () => {
+    expect(
+      classifyWithBaseline(payload({ message: 'AssertionError: expected 1 to be 2' })).owner,
+    ).toBe('app_code')
+  })
+
+  it('ranks the fallback below every rule that actually matched', () => {
+    // Confidence has to come from rule specificity, or the number carries no
+    // information at all — which is what #37 will measure.
+    const fallback = classifyWithBaseline(payload({}))
+    const matched = classifyWithBaseline(payload({ diff: productDiff }))
+    expect(fallback.confidence).toBeLessThan(matched.confidence)
+  })
+})
+
+describe('determinism rule', () => {
+  it('calls an unbroken failure streak deterministic', () => {
+    expect(
+      classifyWithBaseline(payload({ consecutiveFailures: 3, statusHistory: 'PPPFFF' }))
+        .determinism,
+    ).toBe('deterministic')
+  })
+
+  it('calls a single failure intermittent', () => {
+    expect(classifyWithBaseline(payload({ consecutiveFailures: 1 })).determinism).toBe(
+      'intermittent',
+    )
+  })
+
+  it('calls a within-run recovery intermittent however long the streak', () => {
+    // A pass on retry is direct evidence; history is circumstantial.
+    expect(
+      classifyWithBaseline(payload({ consecutiveFailures: 5, flakyWithinRun: true })).determinism,
+    ).toBe('intermittent')
+  })
+
+  it('lowers confidence when there is no history to draw on', () => {
+    const withHistory = classifyWithBaseline(payload({ consecutiveFailures: 3 }))
+    const without = classifyWithBaseline(
+      payload({ consecutiveFailures: 3, historyAvailable: false }),
+    )
+    expect(without.confidence).toBeLessThan(withHistory.confidence)
+  })
+})
+
+describe('output contract', () => {
+  it('emits a schema-valid Classification', () => {
+    expect(() => ClassificationSchema.parse(classifyWithBaseline(payload({})))).not.toThrow()
+  })
+
+  it('quotes evidence for both axes', () => {
+    const result = classifyWithBaseline(payload({ diff: productDiff, consecutiveFailures: 3 }))
+    expect(result.evidence.some((e) => e.includes('diff touches'))).toBe(true)
+    expect(result.evidence.some((e) => e.includes('history'))).toBe(true)
+  })
+
+  it('says something a human would read on a fork pull request', () => {
+    // ADR-0007: with no API key this is the only classifier the pipeline has.
+    const result = classifyWithBaseline(payload({ diff: productDiff }))
+    expect(result.reasoning).toContain('app_code')
+    expect(result.reasoning.length).toBeGreaterThan(40)
+  })
+
+  it('is deterministic', () => {
+    const once = classifyWithBaseline(payload({ diff: productDiff }))
+    expect(classifyWithBaseline(payload({ diff: productDiff }))).toEqual(once)
+  })
+
+  it('truncates an enormous error rather than overflowing the reasoning cap', () => {
+    const result = classifyWithBaseline(payload({ message: 'x'.repeat(5000) }))
+    expect(() => ClassificationSchema.parse(result)).not.toThrow()
+  })
+})
+
+describe('scored against the committed dataset', () => {
+  const scored = loadAllPayloads().map(({ name, payload: p }) => ({
+    name,
+    labels: loadLabels(name),
+    predicted: classifyWithBaseline(p),
+  }))
+
+  const accuracy = (pick: (s: (typeof scored)[number]) => boolean): number =>
+    scored.filter(pick).length / scored.length
+
+  it('runs over every fixture without throwing', () => {
+    expect(scored.length).toBeGreaterThan(0)
+  })
+
+  it('gets every straightforward regression right', () => {
+    // The sanity floor. A control that fails these is broken rather than simple.
+    const easy = scored.filter((s) => s.labels.bucket === 'straightforward')
+    expect(easy.length).toBeGreaterThan(0)
+    for (const s of easy) expect(s.predicted.owner, s.name).toBe(s.labels.owner)
+  })
+
+  it('gets every stale-test fixture wrong, exactly as documented', () => {
+    // Not a defect. Each of those fixtures has a product diff, so the second
+    // rule fires and calls it app_code. Patching around it would mean tuning
+    // the control against the dataset it exists to control for.
+    const stale = scored.filter((s) => s.labels.bucket === 'stale-test')
+    expect(stale.length).toBeGreaterThan(0)
+    for (const s of stale) expect(s.predicted.owner, s.name).toBe('app_code')
+  })
+
+  it('records the current owner-axis accuracy so a change to the rules is visible', () => {
+    // 8 of 15 by construction: every straightforward fixture, no stale-test one.
+    expect(accuracy((s) => s.predicted.owner === s.labels.owner)).toBeCloseTo(8 / 15, 5)
+  })
+
+  it('records the current determinism-axis accuracy', () => {
+    expect(accuracy((s) => s.predicted.determinism === s.labels.determinism)).toBeCloseTo(1, 5)
+  })
+})

--- a/eval/baseline.ts
+++ b/eval/baseline.ts
@@ -1,0 +1,138 @@
+import type { Classification, FixturePayload } from '@sentra/contracts'
+
+/**
+ * The control.
+ *
+ * A deliberately simple, model-free classifier producing the same
+ * `Classification` shape as the agent and scored on the same fixtures. Without
+ * it the agent's accuracy is a number with nothing to compare against, and the
+ * project cannot answer the only question that matters: does the model earn its
+ * cost?
+ *
+ * The rules come from docs/eval-methodology.md and are implemented unmodified.
+ * Two temptations are worth naming so they can be resisted in review: tuning
+ * this down until the agent looks good, and building it up until it looks
+ * impressive. It should be the classifier a competent engineer would write in an
+ * afternoon, and no more.
+ *
+ * It has a second job. On fork pull requests there is no API key
+ * (ADR-0007), so this is the only classifier the pipeline has — which is why it
+ * emits real `reasoning` and `evidence` rather than a label alone.
+ */
+
+/**
+ * Errors that mean the run itself broke before any assertion was reached.
+ *
+ * Kept narrow on purpose. Every pattern added here is a case moved out of the
+ * ordinary rules, so a loose pattern quietly turns product failures into
+ * `environment` — the classification that tells a developer to do nothing.
+ */
+const INFRASTRUCTURE = [
+  /EADDRINUSE|address already in use/i,
+  /ECONNREFUSED|ENOTFOUND|EAI_AGAIN/i,
+  /Cannot find module|MODULE_NOT_FOUND/i,
+  /browser(Type)?\.launch|Executable doesn't exist|browser has been closed/i,
+  /JavaScript heap out of memory|ENOSPC|EMFILE/i,
+  /spawn \w+ ENOENT/i,
+]
+
+/** Failures that name a selector or a wait rather than a value. */
+const LOCATOR_OR_WAIT =
+  /locator|getBy\w+|selector|Timed out \d+ms waiting|Timeout \d+ms exceeded|waitFor/i
+
+/** A changed path that is a test rather than product source. */
+const TEST_PATH = /(^|\/)(tests?|__tests__|e2e|spec)\/|\.(test|spec)\.[cm]?[jt]sx?$/
+
+/**
+ * Confidence per rule, from how specific the rule is.
+ *
+ * An infrastructure pattern names the failure outright, so it earns more than
+ * the fallback, which is a guess dressed as a rule. These are the weakest part
+ * of the baseline and are expected to be badly calibrated — measuring that is
+ * #37's job, and the same measurement applies to the agent.
+ */
+const CONFIDENCE = {
+  infrastructure: 0.8,
+  productDiff: 0.6,
+  locator: 0.65,
+  fallback: 0.35,
+  streak: 0.7,
+  noStreak: 0.5,
+  noHistory: 0.3,
+} as const
+
+/** Paths in the diff, split into product source and test source. */
+function changedPaths(diff: string): { product: string[]; test: string[] } {
+  const paths = [...diff.matchAll(/^diff --git a\/(\S+) b\/\S+$/gm)].map((m) => m[1] ?? '')
+  return {
+    product: paths.filter((p) => p !== '' && !TEST_PATH.test(p)),
+    test: paths.filter((p) => p !== '' && TEST_PATH.test(p)),
+  }
+}
+
+export function classifyWithBaseline(payload: FixturePayload): Classification {
+  const { result, signal } = payload.subject
+  const message = `${result.error?.message ?? ''}\n${result.error?.stack ?? ''}`
+  const changed = changedPaths(payload.diff ?? '')
+
+  const evidence: string[] = []
+  let owner: Classification['owner']
+  let ownerConfidence: number
+  let ownerReason: string
+
+  const infrastructure = INFRASTRUCTURE.find((p) => p.test(message))
+  if (infrastructure !== undefined) {
+    owner = 'environment'
+    ownerConfidence = CONFIDENCE.infrastructure
+    ownerReason = 'the failure names an infrastructure error, so no assertion was reached'
+    evidence.push(firstLine(message))
+  } else if (changed.product.length > 0) {
+    owner = 'app_code'
+    ownerConfidence = CONFIDENCE.productDiff
+    ownerReason = 'the commit changes product source'
+    evidence.push(`diff touches ${changed.product.slice(0, 3).join(', ')}`)
+  } else if (LOCATOR_OR_WAIT.test(message)) {
+    owner = 'test_code'
+    ownerConfidence = CONFIDENCE.locator
+    ownerReason = 'the failure names a selector or a wait rather than a value'
+    evidence.push(firstLine(message))
+  } else {
+    owner = 'app_code'
+    ownerConfidence = CONFIDENCE.fallback
+    ownerReason = 'no rule matched, so the fallback applies'
+    evidence.push(firstLine(message) || `status: ${result.status}`)
+  }
+
+  const streak = signal.consecutiveFailures >= 2 && !result.flakyWithinRun
+  const determinism: Classification['determinism'] = streak ? 'deterministic' : 'intermittent'
+  const determinismConfidence = !payload.historyAvailable
+    ? CONFIDENCE.noHistory
+    : streak
+      ? CONFIDENCE.streak
+      : CONFIDENCE.noStreak
+
+  evidence.push(
+    payload.historyAvailable
+      ? `history ${signal.statusHistory}, ${String(signal.consecutiveFailures)} consecutive failures`
+      : 'no history available',
+  )
+
+  return {
+    owner,
+    determinism,
+    confidence: round(Math.min(ownerConfidence, determinismConfidence)),
+    reasoning: truncate(
+      `${owner}: ${ownerReason}. ${determinism}: ${
+        streak ? 'an unbroken recent failure streak' : 'no unbroken failure streak'
+      }${payload.historyAvailable ? '' : ' and no history to draw on'}.`,
+      400,
+    ),
+    evidence: evidence.filter((e) => e !== '').slice(0, 6),
+  }
+}
+
+const firstLine = (s: string): string => truncate(s.split('\n')[0]?.trim() ?? '', 200)
+const truncate = (s: string, max: number): string =>
+  s.length > max ? `${s.slice(0, max - 1)}…` : s
+/** Two decimal places, so a floating-point tail cannot make output non-reproducible. */
+const round = (n: number): number => Math.round(n * 100) / 100


### PR DESCRIPTION
Closes #24

## What changed

`eval/baseline.ts` — a model-free classifier producing the same `Classification` shape as the agent, scored on the same fixtures. 55 lines of logic.

Taken out of order: #21 and #22 both have an acceptance criterion of the form *"verified: the baseline gets a majority of these wrong"*, which cannot be checked before the baseline exists.

## Why

Without a control, the agent's accuracy is a number with nothing to compare against, and the project cannot answer the only question that matters: does the model earn its cost?

## I clarified an ambiguity in my own spec rather than resolving it silently

The second rule was written as *"the diff touches the file under test"*. That is ambiguous, and the two readings point in opposite directions:

- **the test file** → a diff touching the spec suggests `test_code`
- **the implementation the test exercises** → a diff touching it suggests `app_code`

A heuristic cannot map a test to its implementation, so the rule is now stated as *any changed non-test path*, and `docs/eval-methodology.md` says so explicitly along with the consequence.

**The consequence is that the baseline gets all seven `stale-test` fixtures wrong.** Each of them has a product diff, so the second rule fires and calls it `app_code`. That is left in deliberately: patching around it would mean tuning the control against the dataset it exists to control for. It is documented in the methodology, not buried.

## Decisions worth reviewing

**Rule order is load-bearing and tested.** A run that never reached an assertion says nothing about the diff, however suspicious the diff looks — so `environment` is checked first, and there is a test for the case where both would match.

**The infrastructure pattern list is deliberately narrow.** Every pattern added moves a case out of the ordinary rules, and a loose pattern quietly converts product failures into `environment` — the one classification that tells a developer to do nothing.

**Confidence comes from rule specificity.** An infrastructure pattern names the failure outright (0.8); the fallback is a guess dressed as a rule (0.35). The two axes get separate confidences and the lower wins, so a confident owner call with no history to support the determinism call does not inherit the higher number. These values are the weakest part of the baseline and are expected to be badly calibrated — measuring that is #37's job, and the same measurement will apply to the agent.

**Current scores are asserted, not just computed.** 8/15 on `owner`, 15/15 on `determinism`. Pinning them means a future change to the rules shows up as a failing test with a number in it, rather than being absorbed into a report nobody diffs.

## How it was verified

232 assertions total, 26 new — one per rule, in both directions, plus the ordering case and the no-history case.

One test is worth calling out because the obvious version of it is useless: a test-only diff and no diff at all both produce `app_code`, since the product-change rule and the fallback share a label. Asserting on the label would pass whether or not the rule fired. The test asserts on the reasoning and the confidence instead, which are what actually distinguish the two paths.

## Checklist

- [x] Title is a valid Conventional Commit
- [x] Linked to exactly one issue with `Closes #N`
- [x] `npm run lint && npm run format:check && npm run typecheck && npm run test:unit` clean
- [x] Under 60 lines of logic (55, measured)
- [x] Unit tested per rule; deterministic
- [x] `docs/eval-methodology.md` updated where the spec was ambiguous

## Notes for the reviewer

The baseline takes a `FixturePayload`, which is the same evidence bundle the M3 context assembler will produce — error, signal, diff, test source, history availability. That is deliberate: the control and the agent must see exactly the same input, or the comparison measures the input rather than the classifier.

8/15 on `owner` looks weak, and it is. The honest reading is that this is a genuinely simple heuristic on a dataset deliberately built to defeat simple heuristics — and the number to watch is not the baseline's absolute score but the delta once the agent lands in #38. If the agent cannot beat 8/15 on fixtures like these, that is the finding.