### PR TITLE
feat(dataset): author the 10 hard-quadrant fixtures

### DIFF
--- a/docs/eval-methodology.md
+++ b/docs/eval-methodology.md
@@ -35,9 +35,14 @@ the spec suggests `test_code`, while a diff touching the implementation suggests
 heuristic cannot map a test to its implementation, so the rule is stated as written above: any
 changed non-test path counts.
 
-That is a real weakness, deliberately left in. Every fixture in the `stale-test` bucket has a
-product diff, so the baseline calls all of them `app_code` and gets all of them wrong. Patching
-around it would mean tuning the control against the dataset it is meant to control for.
+It has two consequences, both left in deliberately. Every fixture in the `stale-test` bucket has a
+product diff, so the baseline calls all of them `app_code` and gets all of them wrong. And "non-test
+path" includes `README.md` and CI configuration, so a commit that changes only documentation reads
+as a product change — which occasionally makes the baseline right for the wrong reason.
+
+Patching around either would mean tuning the control against the dataset it is meant to control
+for. Both are asserted by tests, so a future change to the rules surfaces as a failure with a
+number in it rather than being absorbed silently.
 
 Roughly sixty lines. Every agent number is reported **alongside** the baseline on the same
 fixtures, and the headline metric is the _delta_, not the absolute.

--- a/eval/baseline.test.ts
+++ b/eval/baseline.test.ts
@@ -195,12 +195,37 @@ describe('scored against the committed dataset', () => {
     for (const s of stale) expect(s.predicted.owner, s.name).toBe('app_code')
   })
 
+  it('gets a majority of the hard quadrant wrong, which is why the dataset can discriminate', () => {
+    // The acceptance criterion for #21: if the control gets most of these right,
+    // the fixtures are not hard enough and the dataset cannot tell classifiers
+    // apart. Recorded as a number so tuning either side shows up here.
+    const hard = scored.filter((s) => s.labels.bucket === 'hard-quadrant')
+    const missed = hard.filter(
+      (s) =>
+        s.predicted.owner !== s.labels.owner || s.predicted.determinism !== s.labels.determinism,
+    )
+    expect(hard.length).toBe(10)
+    expect(missed.length).toBe(6)
+  })
+
+  it('counts documentation and CI files as product source, right for the wrong reason', () => {
+    // A weakness of the rule as specified, not a defect: "any non-test path"
+    // includes README.md. One hard-quadrant fixture has a docs-only diff and is
+    // classified app_code because of it. Kept visible rather than tidied away.
+    const byDocsDiff = scored.find((s) => s.name === 'reorder-reconciliation-overwrites-later-drag')
+    expect(byDocsDiff?.predicted.owner).toBe('app_code')
+    expect(byDocsDiff?.predicted.evidence.join(' ')).toContain('README.md')
+  })
+
   it('records the current owner-axis accuracy so a change to the rules is visible', () => {
     // 8 of 15 by construction: every straightforward fixture, no stale-test one.
-    expect(accuracy((s) => s.predicted.owner === s.labels.owner)).toBeCloseTo(8 / 15, 5)
+    expect(accuracy((s) => s.predicted.owner === s.labels.owner)).toBeCloseTo(15 / 25, 5)
   })
 
   it('records the current determinism-axis accuracy', () => {
-    expect(accuracy((s) => s.predicted.determinism === s.labels.determinism)).toBeCloseTo(1, 5)
+    expect(accuracy((s) => s.predicted.determinism === s.labels.determinism)).toBeCloseTo(
+      22 / 25,
+      5,
+    )
   })
 })

--- a/eval/golden-dataset/completion-lost-when-two-updates-overlap.labels.json
+++ b/eval/golden-dataset/completion-lost-when-two-updates-overlap.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "completion-lost-when-two-updates-overlap",
+  "owner": "app_code",
+  "determinism": "intermittent",
+  "justification": "The tempting reading is that a three-run failure streak means this always fails, so it belongs on the deterministic side. It does not: rerunning the file alone passes, and the streak coincides with three busy runs on the shared runner where the two writes overlap more often. The other alternative is blaming the spec for issuing concurrent writes, but that is the behaviour under test and the assertion is on a value, not on timing. Each write reads the whole row and writes it back, so whichever finishes second discards the other's field.",
+  "ruleApplied": "rule-4-default-app-code",
+  "provenance": "synthetic",
+  "bucket": "hard-quadrant",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/completion-lost-when-two-updates-overlap.run.json
+++ b/eval/golden-dataset/completion-lost-when-two-updates-overlap.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "completion-lost-when-two-updates-overlap",
+  "scenario": "Completing a task while its description is being saved leaves the completion unrecorded.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.concurrency.test.ts›updates › two overlapping writes both survive",
+      "title": "updates › two overlapping writes both survive",
+      "file": "tests/unit/tasks.concurrency.test.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 88,
+      "annotations": [],
+      "error": {
+        "message": "AssertionError: expected 'active' to be 'completed' // Object.is equality\n\n- Expected\n+ Received\n\n- completed\n+ active",
+        "stack": "    at tests/unit/tasks.concurrency.test.ts:27:38",
+        "snippet": "  await Promise.all([updateTask(id, { description: 'x' }), completeTask(id)])\n> expect((await getTask(id)).status).toBe('completed')"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.concurrency.test.ts›updates › two overlapping writes both survive",
+      "flakinessScore": 0.29,
+      "consecutiveFailures": 3,
+      "totalRuns": 58,
+      "firstSeenAt": "2026-04-02T07:31:19.000Z",
+      "lastPassedAt": "2026-08-06T11:14:02.000Z",
+      "statusHistory": "PPPPPPPFFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "testSource": "it('two overlapping writes both survive', async () => {\n  const id = await seedTask()\n  await Promise.all([updateTask(id, { description: 'x' }), completeTask(id)])\n  expect((await getTask(id)).status).toBe('completed')\n})\n"
+}

--- a/eval/golden-dataset/control-shows-earlier-state-after-quick-toggle.labels.json
+++ b/eval/golden-dataset/control-shows-earlier-state-after-quick-toggle.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "control-shows-earlier-state-after-quick-toggle",
+  "owner": "app_code",
+  "determinism": "intermittent",
+  "justification": "A wait that expired on a locator invites the reading that the spec is badly synchronised. It is not: the starting state is asserted first, both interactions are awaited, and the final check is a web-first assertion with its own timeout. The control genuinely never reaches the expected state — the second update resolves against a snapshot taken before the first landed, so the earlier value wins whenever the two responses arrive close together. The timeout is the symptom, not the cause.",
+  "ruleApplied": "rule-3-reproduces-against-unchanged-product",
+  "provenance": "synthetic",
+  "bucket": "hard-quadrant",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/control-shows-earlier-state-after-quick-toggle.run.json
+++ b/eval/golden-dataset/control-shows-earlier-state-after-quick-toggle.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "control-shows-earlier-state-after-quick-toggle",
+  "scenario": "Toggling a task twice quickly leaves the control showing the earlier of the two states on a rerun of an unchanged commit.",
+  "subject": {
+    "result": {
+      "testId": "tests/e2e/board.spec.ts›board › the control reflects the final state after two quick toggles",
+      "title": "board › the control reflects the final state after two quick toggles",
+      "file": "tests/e2e/board.spec.ts",
+      "status": "timedOut",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 9040,
+      "annotations": [],
+      "error": {
+        "message": "Error: Timed out 5000ms waiting for expect(locator).toBeChecked()\n\nLocator: getByTestId('task-2-complete')\nExpected: checked\nReceived: unchecked\n\nCall log:\n  - expect.toBeChecked with timeout 5000ms\n  - waiting for getByTestId('task-2-complete')\n  - locator resolved to <input type=\"checkbox\" data-testid=\"task-2-complete\"/>",
+        "stack": "    at tests/e2e/board.spec.ts:52:49",
+        "snippet": "  await toggle(page, 2)\n  await toggle(page, 2)\n> await expect(page.getByTestId('task-2-complete')).toBeChecked()"
+      }
+    },
+    "signal": {
+      "testId": "tests/e2e/board.spec.ts›board › the control reflects the final state after two quick toggles",
+      "flakinessScore": 0.35,
+      "consecutiveFailures": 1,
+      "totalRuns": 91,
+      "firstSeenAt": "2026-04-02T07:31:19.000Z",
+      "lastPassedAt": "2026-08-10T08:13:57.000Z",
+      "statusHistory": "PFPPPFPPFPP",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "testSource": "test('the control reflects the final state after two quick toggles', async ({ page }) => {\n  await page.goto('/')\n  await expect(page.getByTestId('task-2-complete')).not.toBeChecked()\n  await toggle(page, 2)\n  await toggle(page, 2)\n  await expect(page.getByTestId('task-2-complete')).toBeChecked()\n})\n"
+}

--- a/eval/golden-dataset/counter-drifts-when-updates-interleave.labels.json
+++ b/eval/golden-dataset/counter-drifts-when-updates-interleave.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "counter-drifts-when-updates-interleave",
+  "owner": "app_code",
+  "determinism": "intermittent",
+  "justification": "The alternative is that the heading simply needs longer, making this a synchronisation problem in the spec. The assertion already waits five seconds and the list settles at five items well inside that window, so more waiting changes nothing. The heading is derived from a counter kept beside the list rather than from the list itself, and two creations that resolve together increment it once. The two views stay out of step until a reload, which is a defect in the product regardless of how long anyone waits.",
+  "ruleApplied": "rule-3-reproduces-against-unchanged-product",
+  "provenance": "synthetic",
+  "bucket": "hard-quadrant",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/counter-drifts-when-updates-interleave.run.json
+++ b/eval/golden-dataset/counter-drifts-when-updates-interleave.run.json
@@ -1,0 +1,32 @@
+{
+  "name": "counter-drifts-when-updates-interleave",
+  "scenario": "The heading and the list disagree about how many tasks exist after several quick edits.",
+  "subject": {
+    "result": {
+      "testId": "tests/e2e/board.spec.ts›board › the heading agrees with the list after rapid edits",
+      "title": "board › the heading agrees with the list after rapid edits",
+      "file": "tests/e2e/board.spec.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 5610,
+      "annotations": [],
+      "error": {
+        "message": "Error: expect(locator).toHaveText(expected)\n\nLocator: getByRole('heading', { level: 1 })\nExpected string: \"5 tasks\"\nReceived string: \"4 tasks\"\n\nCall log:\n  - expect.toHaveText with timeout 5000ms",
+        "stack": "    at tests/e2e/board.spec.ts:118:54",
+        "snippet": "  await Promise.all([createTask(page, 'D'), createTask(page, 'E')])\n> await expect(page.getByRole('heading', { level: 1 })).toHaveText('5 tasks')"
+      }
+    },
+    "signal": {
+      "testId": "tests/e2e/board.spec.ts›board › the heading agrees with the list after rapid edits",
+      "flakinessScore": 0.33,
+      "consecutiveFailures": 1,
+      "totalRuns": 79,
+      "firstSeenAt": "2026-04-02T07:31:19.000Z",
+      "lastPassedAt": "2026-08-10T04:18:22.000Z",
+      "statusHistory": "PPFPPPPFPPF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true
+}

--- a/eval/golden-dataset/debounced-save-skips-final-keystroke.labels.json
+++ b/eval/golden-dataset/debounced-save-skips-final-keystroke.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "debounced-save-skips-final-keystroke",
+  "owner": "app_code",
+  "determinism": "intermittent",
+  "justification": "The alternative is that the spec closes the editor too quickly and should wait for the save to settle. There is nothing observable to wait for: the interface gives no saving indicator, and the final assertion already waits five seconds for the value to appear. The cleanup now cancels the pending timer without flushing it, so a close that lands inside the debounce window discards the last change. It depends on typing speed relative to the window, which is why the retry passed.",
+  "ruleApplied": "rule-3-reproduces-against-unchanged-product",
+  "provenance": "synthetic",
+  "bucket": "hard-quadrant",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/debounced-save-skips-final-keystroke.run.json
+++ b/eval/golden-dataset/debounced-save-skips-final-keystroke.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "debounced-save-skips-final-keystroke",
+  "scenario": "The last character typed before leaving the editor is missing from the saved title.",
+  "subject": {
+    "result": {
+      "testId": "tests/e2e/editor.spec.ts›editor › keeps every character typed before closing",
+      "title": "editor › keeps every character typed before closing",
+      "file": "tests/e2e/editor.spec.ts",
+      "status": "timedOut",
+      "attempts": 2,
+      "flakyWithinRun": true,
+      "durationMs": 8890,
+      "annotations": [],
+      "error": {
+        "message": "Error: Timed out 5000ms waiting for expect(locator).toHaveText(expected)\n\nLocator: getByTestId('task-1-title')\nExpected string: \"Quarterly report\"\nReceived string: \"Quarterly repor\"\n\nCall log:\n  - expect.toHaveText with timeout 5000ms",
+        "stack": "    at tests/e2e/editor.spec.ts:38:47",
+        "snippet": "  await page.getByRole('button', { name: 'Done' }).click()\n> await expect(page.getByTestId('task-1-title')).toHaveText('Quarterly report')"
+      }
+    },
+    "signal": {
+      "testId": "tests/e2e/editor.spec.ts›editor › keeps every character typed before closing",
+      "flakinessScore": 0.4,
+      "consecutiveFailures": 1,
+      "totalRuns": 88,
+      "firstSeenAt": "2026-04-02T07:31:19.000Z",
+      "lastPassedAt": "2026-08-10T09:01:48.000Z",
+      "statusHistory": "PPFPPFPPPF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/client/src/useDebouncedSave.ts b/app/client/src/useDebouncedSave.ts\n@@ -10,7 +10,7 @@ export function useDebouncedSave(save: Save) {\n   useEffect(() => {\n     const timer = setTimeout(() => save(value), 300)\n-    return () => { clearTimeout(timer); save.flush() }\n+    return () => clearTimeout(timer)\n   }, [value])\n"
+}

--- a/eval/golden-dataset/delete-resurrected-by-in-flight-refetch.labels.json
+++ b/eval/golden-dataset/delete-resurrected-by-in-flight-refetch.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "delete-resurrected-by-in-flight-refetch",
+  "owner": "app_code",
+  "determinism": "intermittent",
+  "justification": "The obvious reading is an unstable spec, because it passed on the second attempt. That is evidence about the product, not about the spec: the wait is a web-first count assertion with no fixed delay, and it is preceded by a confirmed starting count. A refresh started before the removal completes writes its older snapshot over the newer state, so the removed row returns until something triggers another fetch. Passing on retry is what a product defect that depends on interleaving looks like from the outside.",
+  "ruleApplied": "rule-3-reproduces-against-unchanged-product",
+  "provenance": "synthetic",
+  "bucket": "hard-quadrant",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/delete-resurrected-by-in-flight-refetch.run.json
+++ b/eval/golden-dataset/delete-resurrected-by-in-flight-refetch.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "delete-resurrected-by-in-flight-refetch",
+  "scenario": "A task removed while the list is refreshing reappears until the next reload.",
+  "subject": {
+    "result": {
+      "testId": "tests/e2e/board.spec.ts›board › a deleted task stays deleted",
+      "title": "board › a deleted task stays deleted",
+      "file": "tests/e2e/board.spec.ts",
+      "status": "failed",
+      "attempts": 2,
+      "flakyWithinRun": true,
+      "durationMs": 7180,
+      "annotations": [],
+      "error": {
+        "message": "Error: expect(locator).toHaveCount(expected)\n\nLocator: getByTestId('task-card')\nExpected: 2\nReceived: 3\n\nCall log:\n  - expect.toHaveCount with timeout 5000ms\n  - waiting for getByTestId('task-card')",
+        "stack": "    at tests/e2e/board.spec.ts:96:44",
+        "snippet": "  await deleteTask(page, 'Beta')\n> await expect(page.getByTestId('task-card')).toHaveCount(2)"
+      }
+    },
+    "signal": {
+      "testId": "tests/e2e/board.spec.ts›board › a deleted task stays deleted",
+      "flakinessScore": 0.44,
+      "consecutiveFailures": 0,
+      "totalRuns": 83,
+      "firstSeenAt": "2026-04-02T07:31:19.000Z",
+      "lastPassedAt": "2026-08-10T07:55:31.000Z",
+      "statusHistory": "PFPPFPPPFP",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "testSource": "test('a deleted task stays deleted', async ({ page }) => {\n  await page.goto('/')\n  await expect(page.getByTestId('task-card')).toHaveCount(3)\n  await deleteTask(page, 'Beta')\n  await expect(page.getByTestId('task-card')).toHaveCount(2)\n})\n"
+}

--- a/eval/golden-dataset/duplicate-key-when-two-clients-create-at-once.labels.json
+++ b/eval/golden-dataset/duplicate-key-when-two-clients-create-at-once.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "duplicate-key-when-two-clients-create-at-once",
+  "owner": "app_code",
+  "determinism": "intermittent",
+  "justification": "The alternative is that concurrent creation is an unreasonable thing for a spec to ask of a single-file database. It is not: the endpoint is called from a browser and two users can create tasks at once, so the guarantee is real. The change replaces the database's own identifier allocation with a read-then-write, and two callers that read before either writes compute the same value. It fails only when the two reads interleave, which is why the same spec passed on its retry.",
+  "ruleApplied": "rule-3-reproduces-against-unchanged-product",
+  "provenance": "synthetic",
+  "bucket": "hard-quadrant",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/duplicate-key-when-two-clients-create-at-once.run.json
+++ b/eval/golden-dataset/duplicate-key-when-two-clients-create-at-once.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "duplicate-key-when-two-clients-create-at-once",
+  "scenario": "Simultaneous creates occasionally hand back the same identifier to both callers.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.repository.test.ts›createTask › gives concurrent callers distinct identifiers",
+      "title": "createTask › gives concurrent callers distinct identifiers",
+      "file": "tests/unit/tasks.repository.test.ts",
+      "status": "failed",
+      "attempts": 2,
+      "flakyWithinRun": true,
+      "durationMs": 64,
+      "annotations": [],
+      "error": {
+        "message": "AssertionError: expected 1 to be 2 // Object.is equality\n\nnew Set([a.id, b.id]).size",
+        "stack": "    at tests/unit/tasks.repository.test.ts:55:41",
+        "snippet": "  const [a, b] = await Promise.all([createTask('A'), createTask('B')])\n> expect(new Set([a.id, b.id]).size).toBe(2)"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.repository.test.ts›createTask › gives concurrent callers distinct identifiers",
+      "flakinessScore": 0.36,
+      "consecutiveFailures": 0,
+      "totalRuns": 67,
+      "firstSeenAt": "2026-04-02T07:31:19.000Z",
+      "lastPassedAt": "2026-08-10T05:40:09.000Z",
+      "statusHistory": "PPPPFPFPPP",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/server/tasks/repository.ts b/app/server/tasks/repository.ts\n@@ -18,9 +18,10 @@ export async function createTask(title: string): Promise<Task> {\n-  const { lastID } = await db.run('INSERT INTO tasks (title) VALUES (?)', title)\n-  return getTask(lastID)\n+  const next = (await db.get('SELECT MAX(id) AS m FROM tasks')).m + 1\n+  await db.run('INSERT INTO tasks (id, title) VALUES (?, ?)', next, title)\n+  return getTask(next)\n }\n"
+}

--- a/eval/golden-dataset/grouping-order-varies-with-key-insertion.labels.json
+++ b/eval/golden-dataset/grouping-order-varies-with-key-insertion.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "grouping-order-varies-with-key-insertion",
+  "owner": "app_code",
+  "determinism": "intermittent",
+  "justification": "The tempting alternative is that a spec should not depend on key order at all. The endpoint documents a fixed section order, so asserting it is exactly what this spec is for. The instability is data-driven rather than timing-driven: grouping builds a plain object keyed by status, so section order follows whichever status appears first in the rows, which in turn follows insertion order. Two consecutive failures look settled but reflect two runs that seeded in the same order; reseeding the other way passes.",
+  "ruleApplied": "rule-3-reproduces-against-unchanged-product",
+  "provenance": "synthetic",
+  "bucket": "hard-quadrant",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/grouping-order-varies-with-key-insertion.run.json
+++ b/eval/golden-dataset/grouping-order-varies-with-key-insertion.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "grouping-order-varies-with-key-insertion",
+  "scenario": "Grouping by status returns sections in a different order depending on which task loaded first.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.grouping.test.ts›groupByStatus › returns sections in a stable order",
+      "title": "groupByStatus › returns sections in a stable order",
+      "file": "tests/unit/tasks.grouping.test.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 17,
+      "annotations": [],
+      "error": {
+        "message": "AssertionError: expected [ 'completed', 'active' ] to deeply equal [ 'active', 'completed' ]",
+        "stack": "    at tests/unit/tasks.grouping.test.ts:23:44",
+        "snippet": "  const grouped = groupByStatus(await listTasks())\n> expect(Object.keys(grouped)).toEqual(['active', 'completed'])"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.grouping.test.ts›groupByStatus › returns sections in a stable order",
+      "flakinessScore": 0.24,
+      "consecutiveFailures": 2,
+      "totalRuns": 52,
+      "firstSeenAt": "2026-04-02T07:31:19.000Z",
+      "lastPassedAt": "2026-08-08T15:47:33.000Z",
+      "statusHistory": "PPPPPPFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "testSource": "it('returns sections in a stable order', async () => {\n  await seedTasks([{ status: 'completed' }, { status: 'active' }])\n  const grouped = groupByStatus(await listTasks())\n  expect(Object.keys(grouped)).toEqual(['active', 'completed'])\n})\n"
+}

--- a/eval/golden-dataset/position-collision-orders-by-insertion-id.labels.json
+++ b/eval/golden-dataset/position-collision-orders-by-insertion-id.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "position-collision-orders-by-insertion-id",
+  "owner": "app_code",
+  "determinism": "intermittent",
+  "justification": "The alternative reading is that the spec should not create two records concurrently and then assume an order. But creation order is a documented guarantee of the endpoint, so asserting it is legitimate, and the spec does nothing else questionable. The instability comes from data rather than from timing: the new ordering value has one-second resolution, so two tasks created inside the same second collide and the read falls back to identifier order, which is stable only until it is not. Whether it fails depends on where the run lands in the second.",
+  "ruleApplied": "rule-3-reproduces-against-unchanged-product",
+  "provenance": "synthetic",
+  "bucket": "hard-quadrant",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/position-collision-orders-by-insertion-id.run.json
+++ b/eval/golden-dataset/position-collision-orders-by-insertion-id.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "position-collision-orders-by-insertion-id",
+  "scenario": "Two tasks created in the same instant receive identical ordering values and swap between reads.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.ordering.test.ts›ordering › keeps creation order for tasks added together",
+      "title": "ordering › keeps creation order for tasks added together",
+      "file": "tests/unit/tasks.ordering.test.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 41,
+      "annotations": [],
+      "error": {
+        "message": "AssertionError: expected [ 'Second', 'First' ] to deeply equal [ 'First', 'Second' ]",
+        "stack": "    at tests/unit/tasks.ordering.test.ts:18:33",
+        "snippet": "  const [a, b] = await Promise.all([createTask('First'), createTask('Second')])\n> expect((await listTasks()).map((t) => t.title)).toEqual(['First', 'Second'])"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.ordering.test.ts›ordering › keeps creation order for tasks added together",
+      "flakinessScore": 0.31,
+      "consecutiveFailures": 1,
+      "totalRuns": 74,
+      "firstSeenAt": "2026-04-02T07:31:19.000Z",
+      "lastPassedAt": "2026-08-10T06:22:10.000Z",
+      "statusHistory": "PPPPFPPPPPF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/server/tasks/position.ts b/app/server/tasks/position.ts\n@@ -3,7 +3,7 @@ export async function nextPosition(): Promise<number> {\n-  const max = await db.get('SELECT MAX(position) AS m FROM tasks')\n-  return (max?.m ?? 0) + 1\n+  return Math.floor(Date.now() / 1000)\n }\n"
+}

--- a/eval/golden-dataset/reorder-reconciliation-overwrites-later-drag.labels.json
+++ b/eval/golden-dataset/reorder-reconciliation-overwrites-later-drag.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "reorder-reconciliation-overwrites-later-drag",
+  "owner": "app_code",
+  "determinism": "intermittent",
+  "justification": "The plausible alternative is that the spec asserts before the list settles. It does not: every step is a web-first assertion with a timeout, there is no fixed wait anywhere, and the first reorder is confirmed before the second begins. The wait expired because the rendered order never converged, not because it was checked too early. The reconciliation applies whichever response arrives last rather than whichever reorder happened last, so a slow first response silently reverts the second — a defect in the product that a correct spec can only catch sometimes.",
+  "ruleApplied": "rule-3-reproduces-against-unchanged-product",
+  "provenance": "synthetic",
+  "bucket": "hard-quadrant",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/reorder-reconciliation-overwrites-later-drag.run.json
+++ b/eval/golden-dataset/reorder-reconciliation-overwrites-later-drag.run.json
@@ -1,0 +1,34 @@
+{
+  "name": "reorder-reconciliation-overwrites-later-drag",
+  "scenario": "A drag that lands while an earlier reorder is still in flight ends up in the wrong place.",
+  "subject": {
+    "result": {
+      "testId": "tests/e2e/board.spec.ts›board › reordering twice in quick succession keeps the second order",
+      "title": "board › reordering twice in quick succession keeps the second order",
+      "file": "tests/e2e/board.spec.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 6320,
+      "annotations": [],
+      "error": {
+        "message": "Error: expect(locator).toHaveText(expected)\n\nLocator: getByTestId('task-list')\nExpected string: \"Alpha, Gamma, Beta\"\nReceived string: \"Alpha, Beta, Gamma\"\n\nCall log:\n  - expect.toHaveText with timeout 5000ms\n  - waiting for getByTestId('task-list')\n  - locator resolved to <ul data-testid=\"task-list\">…</ul>",
+        "stack": "    at tests/e2e/board.spec.ts:71:45",
+        "snippet": "  await dragTo(page, 'Gamma', 1)\n> await expect(page.getByTestId('task-list')).toHaveText('Alpha, Gamma, Beta')"
+      }
+    },
+    "signal": {
+      "testId": "tests/e2e/board.spec.ts›board › reordering twice in quick succession keeps the second order",
+      "flakinessScore": 0.38,
+      "consecutiveFailures": 1,
+      "totalRuns": 96,
+      "firstSeenAt": "2026-04-02T07:31:19.000Z",
+      "lastPassedAt": "2026-08-09T18:02:44.000Z",
+      "statusHistory": "PPFPPPFPPFP",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/README.md b/README.md\n@@ -12,3 +12,4 @@\n Progress is tracked as milestones.\n+Added a note about the seed script.\ndiff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml\n@@ -40,1 +40,1 @@\n-      - run: npm ci\n+      - run: npm ci --no-audit\n",
+  "testSource": "test('reordering twice in quick succession keeps the second order', async ({ page }) => {\n  await page.goto('/')\n  await expect(page.getByTestId('task-card')).toHaveCount(3)\n  await dragTo(page, 'Beta', 2)\n  await expect(page.getByTestId('task-list')).toHaveText('Alpha, Gamma, Beta')\n  await dragTo(page, 'Gamma', 1)\n  await expect(page.getByTestId('task-list')).toHaveText('Alpha, Gamma, Beta')\n})\n"
+}

--- a/eval/golden-dataset/token-refresh-cancels-in-flight-save.labels.json
+++ b/eval/golden-dataset/token-refresh-cancels-in-flight-save.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "token-refresh-cancels-in-flight-save",
+  "owner": "app_code",
+  "determinism": "intermittent",
+  "justification": "Two consecutive failures suggest something settled, which is the reading to resist. Running the file on its own passes; the two failures are runs where the refresh happened to land inside the save's window, which the shared runner makes more likely under load. Blaming the spec for starting both at once is also tempting, but overlapping a refresh with a save is ordinary client behaviour. The refresh replaces the underlying request controller and aborts whatever it was carrying, and the abort is swallowed rather than retried.",
+  "ruleApplied": "rule-4-default-app-code",
+  "provenance": "synthetic",
+  "bucket": "hard-quadrant",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/token-refresh-cancels-in-flight-save.run.json
+++ b/eval/golden-dataset/token-refresh-cancels-in-flight-save.run.json
@@ -1,0 +1,32 @@
+{
+  "name": "token-refresh-cancels-in-flight-save",
+  "scenario": "A save issued as the session token is refreshed is dropped without surfacing an error.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.client.test.ts›saveTask › completes even when the session is refreshed mid-request",
+      "title": "saveTask › completes even when the session is refreshed mid-request",
+      "file": "tests/unit/tasks.client.test.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 112,
+      "annotations": [],
+      "error": {
+        "message": "AssertionError: expected undefined to deeply equal { title: 'Renamed' }",
+        "stack": "    at tests/unit/tasks.client.test.ts:64:29",
+        "snippet": "  const [saved] = await Promise.all([saveTask(id, { title: 'Renamed' }), refreshSession()])\n> expect(saved).toEqual({ title: 'Renamed' })"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.client.test.ts›saveTask › completes even when the session is refreshed mid-request",
+      "flakinessScore": 0.21,
+      "consecutiveFailures": 2,
+      "totalRuns": 61,
+      "firstSeenAt": "2026-04-02T07:31:19.000Z",
+      "lastPassedAt": "2026-08-08T20:05:16.000Z",
+      "statusHistory": "PPPPPPPPFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true
+}


### PR DESCRIPTION
Closes #21

## What changed

10 fixtures labelled `app_code + intermittent` — a genuine defect in the product, caught by a correctly written test. The dataset is now 25 fixtures.

## Why

This is the quadrant the project exists for: indistinguishable from an unstable test by any simple signal, and the one case where rerunning until green causes real harm.

## What actually makes them hard

Not contrivance. A concurrency defect usually **predates the commit that exposes it** — it surfaces under load or a particular interleaving, not when it is written. So in most of these the current commit touches nothing relevant, and the failure reads as a wait that expired.

Those are exactly the two signals a heuristic uses to conclude "the test is wrong":

- **No product diff** → the diff rule cannot fire
- **A locator or timeout message** → the next rule fires and says `test_code`

Three fixtures carry a recent failure streak of two or three runs while still being genuinely intermittent — the streak reflects busy runs on a shared runner, and rerunning in isolation passes. That punishes reading history as settled, which is the determinism rule's whole basis.

**Every justification names the plausible alternative reading and says why it is wrong.** A fixture whose label cannot be argued for is not ground truth, it is an assertion.

**Five carry the spec source**, so the claim that the test is beyond criticism can be checked rather than taken on trust. **Two are unstable because of data and ordering rather than timing** — a one-second ordering value that collides, and section order following key insertion.

## The acceptance criterion, and what checking it turned up

The criterion is that the baseline must get a **majority** wrong; otherwise the fixtures are not hard enough and the dataset cannot discriminate.

The first draft managed only 5 of 10 — and the reason was worth more than the fix. Two fixtures had a diff touching `README.md` and `.github/workflows/ci.yml`. The baseline's rule is "any changed **non-test** path is product source", so a documentation-only commit reads as a product change and it answered `app_code`: right, for entirely the wrong reason.

Two options: patch the baseline, or change the fixtures. Patching the control against the dataset it exists to control for is exactly what `docs/eval-methodology.md` forbids, so:

- **One fixture** became a rerun of an unchanged commit with no diff at all — realistic, and it removes the accidental signal. Now `test_code`, wrong.
- **The other is kept as it was**, with a test asserting that the baseline classifies it `app_code` *citing `README.md` as evidence*. The weakness stays visible instead of being tidied away, and the methodology doc now records it.

Result: **6 of 10 wrong** — a majority, honestly obtained.

## Recorded scores

Asserted as numbers so tuning either side surfaces as a failing test:

| Axis | Baseline | Note |
|---|---|---|
| `owner` | 15/25 | 8/8 straightforward, 0/7 stale-test, 7/10 hard quadrant |
| `determinism` | 22/25 | the three misses are the streak-but-intermittent fixtures |
| Joint, hard quadrant | 4/10 | the criterion for this issue |

## How it was verified

244 assertions total. Leakage checked across every string value **and filename** — which caught one: `stale-render-after-rapid-toggle` contained a bucket name, renamed to `control-shows-earlier-state-after-quick-toggle`.

## Checklist

- [x] Title is a valid Conventional Commit
- [x] Linked to exactly one issue with `Closes #N`
- [x] `npm run lint && npm run format:check && npm run typecheck && npm run test:unit` clean
- [x] 10 fixtures, all `app_code + intermittent`; ≥3 with a correct spec (5); ≥2 data/ordering (2)
- [x] Baseline verified to miss a majority, with the method and the surprise documented

## Notes for the reviewer

The fixtures worth reading first are `completion-lost-when-two-updates-overlap` and `token-refresh-cancels-in-flight-save`. Both have a multi-run failure streak and are still labelled `intermittent`. If you disagree with either label, that is the most useful review comment this PR can get — they are the closest thing here to a judgement call, and the justification is the argument to attack.