### PR TITLE
fix(eval): stop the baseline reading documentation as product source

### DIFF
--- a/docs/eval-methodology.md
+++ b/docs/eval-methodology.md
@@ -35,14 +35,19 @@ the spec suggests `test_code`, while a diff touching the implementation suggests
 heuristic cannot map a test to its implementation, so the rule is stated as written above: any
 changed non-test path counts.
 
-It has two consequences, both left in deliberately. Every fixture in the `stale-test` bucket has a
-product diff, so the baseline calls all of them `app_code` and gets all of them wrong. And "non-test
-path" includes `README.md` and CI configuration, so a commit that changes only documentation reads
-as a product change — which occasionally makes the baseline right for the wrong reason.
+"Source file" means a path with a code extension, outside `.github/`, `docs/` and `wiki/`. An
+earlier version counted every non-test path, so a documentation-only commit read as a product
+change — the right answer for the wrong reason, fixed in #112.
 
-Patching around either would mean tuning the control against the dataset it is meant to control
-for. Both are asserted by tests, so a future change to the rules surfaces as a failure with a
-number in it rather than being absorbed silently.
+The rule's remaining crudeness is left in deliberately. Every fixture in the `stale-test` bucket
+has a genuine product diff, so the baseline calls all of them `app_code` and gets all of them
+wrong. Narrowing that would mean tuning the control against the dataset it exists to control for,
+and the distinction matters: excluding documentation makes the rule mean what this page says it
+means, while excluding "diffs that only look product-ish" would mean fitting the control to the
+answers.
+
+Per-bucket outcomes are asserted by tests, so a future change to the rules surfaces as a failure
+with a number in it rather than being absorbed silently.
 
 Roughly sixty lines. Every agent number is reported **alongside** the baseline on the same
 fixtures, and the headline metric is the _delta_, not the absolute.

--- a/eval/baseline.test.ts
+++ b/eval/baseline.test.ts
@@ -71,6 +71,18 @@ describe('owner rules, in order', () => {
     expect(classifyWithBaseline(payload({ diff: productDiff })).owner).toBe('app_code')
   })
 
+  it.each([
+    ['documentation', 'diff --git a/README.md b/README.md\n'],
+    ['CI configuration', 'diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml\n'],
+    ['the wiki', 'diff --git a/wiki/Home.md b/wiki/Home.md\n'],
+    ['a lockfile', 'diff --git a/package-lock.json b/package-lock.json\n'],
+    ['tooling config', 'diff --git a/eslint.config.js b/eslint.config.js\n'],
+  ])('does not treat a change to %s as product source (#112)', (_label, diff) => {
+    const withDocs = classifyWithBaseline(payload({ diff }))
+    const withNone = classifyWithBaseline(payload({}))
+    expect(withDocs.reasoning).toBe(withNone.reasoning)
+  })
+
   it('does not let a test-only diff fire the product-change rule', () => {
     // Both land on app_code — the second rule and the fallback share a label —
     // so asserting on the label alone would pass whether or not the rule fired.
@@ -205,21 +217,21 @@ describe('scored against the committed dataset', () => {
         s.predicted.owner !== s.labels.owner || s.predicted.determinism !== s.labels.determinism,
     )
     expect(hard.length).toBe(10)
-    expect(missed.length).toBe(6)
+    expect(missed.length).toBe(7)
   })
 
-  it('counts documentation and CI files as product source, right for the wrong reason', () => {
-    // A weakness of the rule as specified, not a defect: "any non-test path"
-    // includes README.md. One hard-quadrant fixture has a docs-only diff and is
-    // classified app_code because of it. Kept visible rather than tidied away.
-    const byDocsDiff = scored.find((s) => s.name === 'reorder-reconciliation-overwrites-later-drag')
-    expect(byDocsDiff?.predicted.owner).toBe('app_code')
-    expect(byDocsDiff?.predicted.evidence.join(' ')).toContain('README.md')
+  it('does not read a documentation-only commit as a product change (#112)', () => {
+    // This fixture used to come back app_code because its diff touches
+    // README.md and a workflow file. Right answer, wrong reason — and the wrong
+    // reason was hiding one more miss on the quadrant that matters.
+    const docsOnly = scored.find((s) => s.name === 'reorder-reconciliation-overwrites-later-drag')
+    expect(docsOnly?.predicted.owner).toBe('test_code')
+    expect(docsOnly?.predicted.evidence.join(' ')).not.toContain('README.md')
   })
 
   it('records the current owner-axis accuracy so a change to the rules is visible', () => {
     // 8 of 15 by construction: every straightforward fixture, no stale-test one.
-    expect(accuracy((s) => s.predicted.owner === s.labels.owner)).toBeCloseTo(15 / 25, 5)
+    expect(accuracy((s) => s.predicted.owner === s.labels.owner)).toBeCloseTo(14 / 25, 5)
   })
 
   it('records the current determinism-axis accuracy', () => {

--- a/eval/baseline.ts
+++ b/eval/baseline.ts
@@ -44,6 +44,18 @@ const LOCATOR_OR_WAIT =
 const TEST_PATH = /(^|\/)(tests?|__tests__|e2e|spec)\/|\.(test|spec)\.[cm]?[jt]sx?$/
 
 /**
+ * A changed path counts as product source only if it looks like code.
+ *
+ * Without this, a commit touching only `README.md` reads as a product change and
+ * the second rule fires — the right answer for entirely the wrong reason. That
+ * is different from the rule's *inherent* crudeness, which is left alone: a real
+ * product diff on a stale test still yields `app_code`, because narrowing that
+ * would be tuning the control against the dataset it exists to control for.
+ */
+const SOURCE_EXTENSION = /\.(ts|tsx|js|jsx|mjs|cjs|sql|css|html)$/i
+const NOT_PRODUCT = /^(\.github|docs|wiki)\/|\.config\.[cm]?js$/
+
+/**
  * Confidence per rule, from how specific the rule is.
  *
  * An infrastructure pattern names the failure outright, so it earns more than
@@ -65,7 +77,9 @@ const CONFIDENCE = {
 function changedPaths(diff: string): { product: string[]; test: string[] } {
   const paths = [...diff.matchAll(/^diff --git a\/(\S+) b\/\S+$/gm)].map((m) => m[1] ?? '')
   return {
-    product: paths.filter((p) => p !== '' && !TEST_PATH.test(p)),
+    product: paths.filter(
+      (p) => p !== '' && SOURCE_EXTENSION.test(p) && !TEST_PATH.test(p) && !NOT_PRODUCT.test(p),
+    ),
     test: paths.filter((p) => p !== '' && TEST_PATH.test(p)),
   }
 }


### PR DESCRIPTION
Closes #112

## What changed

The baseline's product-change rule now requires a path to look like code and to sit outside `.github/`, `docs/` and `wiki/`. Previously any non-test path counted, so a documentation-only commit read as a product change.

## Why this is a fix and not tuning

Worth arguing, because #21 deliberately declined to patch two *other* weaknesses in this same rule, and the difference is not obvious at a glance.

The test is whether the change fits the control to the answers:

| | Effect on the rule | Effect on the score | Verdict |
|---|---|---|---|
| Excluding documentation | Makes it mean what the methodology says | **Worse** — 15/25 → 14/25 | Fix |
| Excluding "diffs that only look product-ish" | Adds knowledge the rule does not have | Better | Tuning — refused |

A heuristic a competent engineer writes in an afternoon does not call a README edit a code change. But the same engineer would not know which product file relates to which test either — so the `stale-test` weakness stays exactly as it is, and `docs/eval-methodology.md` now spells out where that line falls.

## The pinned assertions did their job

Three tests failed on the first run of the fix:

```
× gets a majority of the hard quadrant wrong    expected 7 to be 6
× counts documentation as product source        expected 'test_code' to be 'app_code'
× records the current owner-axis accuracy       expected 0.56 to be close to 0.6
```

That is the entire reason those numbers are asserted rather than merely computed into a report. The change is intentional, so the numbers move — visibly, in a diff, with an argument attached.

**The wrong reason had been hiding a real miss.** Hard-quadrant misses go from 6 to 7 and `owner` accuracy from 15/25 to 14/25. The baseline was getting `reorder-reconciliation-overwrites-later-drag` right by accident; it now gets it wrong, which is the honest result and strengthens the dataset's ability to discriminate rather than weakening it.

## How it was verified

249 assertions. The old "right for the wrong reason" test is replaced by its inverse, plus a table covering all five categories now excluded — documentation, CI configuration, the wiki, lockfiles and tooling config — each asserted to produce reasoning identical to a run with no diff at all, so the rule provably does not fire rather than merely landing on the same label.

Logic is still 55 lines.

## Checklist

- [x] Title is a valid Conventional Commit
- [x] Linked to exactly one issue with `Closes #N`
- [x] `npm run lint && npm run format:check && npm run typecheck && npm run test:unit` clean
- [x] Regression tests for every excluded category
- [x] `docs/eval-methodology.md` updated with the rule and where the line falls

## Notes for the reviewer

`eslint.config.js` is excluded by a `.config.js` suffix rule. It has a code extension and lives at the repository root, so nothing else would have caught it, and a commit touching only lint configuration being read as a product change is the same defect in a smaller costume.