### PR TITLE
feat(dataset): author the 8 adversarial fixtures

### DIFF
--- a/eval/baseline.test.ts
+++ b/eval/baseline.test.ts
@@ -229,14 +229,42 @@ describe('scored against the committed dataset', () => {
     expect(docsOnly?.predicted.evidence.join(' ')).not.toContain('README.md')
   })
 
+  it('is defeated by the adversarial buckets, which is what they are for (#22)', () => {
+    // One of the eight is deliberately not a trap: an EADDRINUSE failure inside
+    // a commit that touches the server bootstrap, where the obvious reading and
+    // the correct one agree. A bucket of nothing but traps would teach the
+    // opposite reflex — that anything infrastructure-shaped near a product diff
+    // must be environment.
+    const adversarial = scored.filter(
+      (s) =>
+        s.labels.bucket === 'misleading-history' || s.labels.bucket === 'environment-as-regression',
+    )
+    const missed = adversarial.filter(
+      (s) =>
+        s.predicted.owner !== s.labels.owner || s.predicted.determinism !== s.labels.determinism,
+    )
+    expect(adversarial.length).toBe(8)
+    expect(missed.length).toBe(7)
+  })
+
+  it('reads every misleading-history fixture as unstable when it has settled', () => {
+    // The determinism rule keys on a consecutive-failure streak. These have a
+    // new cause that reproduces every time but only one run old, so the streak
+    // is short and the months of alternation behind it are irrelevant.
+    for (const s of scored.filter((s) => s.labels.bucket === 'misleading-history')) {
+      expect(s.labels.determinism, s.name).toBe('deterministic')
+      expect(s.predicted.determinism, s.name).toBe('intermittent')
+    }
+  })
+
   it('records the current owner-axis accuracy so a change to the rules is visible', () => {
     // 8 of 15 by construction: every straightforward fixture, no stale-test one.
-    expect(accuracy((s) => s.predicted.owner === s.labels.owner)).toBeCloseTo(14 / 25, 5)
+    expect(accuracy((s) => s.predicted.owner === s.labels.owner)).toBeCloseTo(18 / 33, 5)
   })
 
   it('records the current determinism-axis accuracy', () => {
     expect(accuracy((s) => s.predicted.determinism === s.labels.determinism)).toBeCloseTo(
-      22 / 25,
+      26 / 33,
       5,
     )
   })

--- a/eval/golden-dataset/board-control-appears-twice-after-panel-split.labels.json
+++ b/eval/golden-dataset/board-control-appears-twice-after-panel-split.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "board-control-appears-twice-after-panel-split",
+  "owner": "test_code",
+  "determinism": "deterministic",
+  "justification": "Two features mislead at once. The long alternating history invites treating this as more noise, and the commit touches product source, which invites blaming the panel that was added. Both are wrong. The panel is a deliberate feature and works; the spec identifies its target by an attribute that was never unique by contract, so it stops being a valid detector the moment a second control appears. It now fails on every attempt, so nothing about it is unsettled any more.",
+  "ruleApplied": "rule-2-unsafe-test-assumption",
+  "provenance": "synthetic",
+  "bucket": "misleading-history",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/board-control-appears-twice-after-panel-split.run.json
+++ b/eval/golden-dataset/board-control-appears-twice-after-panel-split.run.json
@@ -1,0 +1,34 @@
+{
+  "name": "board-control-appears-twice-after-panel-split",
+  "scenario": "A long-unstable board test now fails on every attempt because its target resolves to two nodes.",
+  "subject": {
+    "result": {
+      "testId": "tests/e2e/board.spec.ts›board › the toolbar control opens the editor",
+      "title": "board › the toolbar control opens the editor",
+      "file": "tests/e2e/board.spec.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 3120,
+      "annotations": [],
+      "error": {
+        "message": "Error: strict mode violation: getByTestId('open-editor') resolved to 2 elements:\n    1) <button data-testid=\"open-editor\">Edit</button>\n    2) <button data-testid=\"open-editor\">Edit</button>",
+        "stack": "    at tests/e2e/board.spec.ts:26:45",
+        "snippet": "> await page.getByTestId('open-editor').click()"
+      }
+    },
+    "signal": {
+      "testId": "tests/e2e/board.spec.ts›board › the toolbar control opens the editor",
+      "flakinessScore": 0.66,
+      "consecutiveFailures": 1,
+      "totalRuns": 188,
+      "firstSeenAt": "2026-02-11T09:03:47.000Z",
+      "lastPassedAt": "2026-08-09T20:44:51.000Z",
+      "statusHistory": "PFPPFPFPPFPPFPF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/client/src/Board.tsx b/app/client/src/Board.tsx\n@@ -22,6 +22,7 @@ export function Board({ tasks }: BoardProps) {\n       <Toolbar onCreate={onCreate} />\n+      <SidePanel onCreate={onCreate} />\n     </div>\n",
+  "testSource": "test('the toolbar control opens the editor', async ({ page }) => {\n  await page.goto('/')\n  await page.getByTestId('open-editor').click()\n  await expect(page.getByRole('dialog')).toBeVisible()\n})\n"
+}

--- a/eval/golden-dataset/export-now-includes-archived-rows.labels.json
+++ b/eval/golden-dataset/export-now-includes-archived-rows.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "export-now-includes-archived-rows",
+  "owner": "app_code",
+  "determinism": "deterministic",
+  "justification": "The misleading feature is the score, built from months of alternation caused by export ordering that was fixed long ago. It is wrong here because the count is now off by a fixed amount on every run: the filter that excluded archived rows was removed, so the export returns all seven rather than the four the board shows. A rerun reproduces it exactly, and the difference matches the number of archived rows in the seed.",
+  "ruleApplied": "rule-3-reproduces-against-unchanged-product",
+  "provenance": "synthetic",
+  "bucket": "misleading-history",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/export-now-includes-archived-rows.run.json
+++ b/eval/golden-dataset/export-now-includes-archived-rows.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "export-now-includes-archived-rows",
+  "scenario": "A long-unstable export test fails on every attempt since a filter was dropped from the query.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.export.test.ts›export › contains only rows the board shows",
+      "title": "export › contains only rows the board shows",
+      "file": "tests/unit/tasks.export.test.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 52,
+      "annotations": [],
+      "error": {
+        "message": "AssertionError: expected 7 to be 4 // Object.is equality\n\nrows.length",
+        "stack": "    at tests/unit/tasks.export.test.ts:19:26",
+        "snippet": "  const rows = await exportTasks()\n> expect(rows.length).toBe(4)"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.export.test.ts›export › contains only rows the board shows",
+      "flakinessScore": 0.64,
+      "consecutiveFailures": 1,
+      "totalRuns": 176,
+      "firstSeenAt": "2026-02-11T09:03:47.000Z",
+      "lastPassedAt": "2026-08-09T16:38:12.000Z",
+      "statusHistory": "FPPFPFPPFPFPPF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/server/tasks/export.ts b/app/server/tasks/export.ts\n@@ -7,7 +7,7 @@ export async function exportTasks(): Promise<Row[]> {\n-  return db.all('SELECT * FROM tasks WHERE archived = 0')\n+  return db.all('SELECT * FROM tasks')\n }\n"
+}

--- a/eval/golden-dataset/package-registry-certificate-expired-on-agent.labels.json
+++ b/eval/golden-dataset/package-registry-certificate-expired-on-agent.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "package-registry-certificate-expired-on-agent",
+  "owner": "environment",
+  "determinism": "deterministic",
+  "justification": "The diff changes the default endpoint and the stack names that function, so blaming the commit is the natural reading, and it is what makes this hard. The transport never completed: the agent rejected an expired certificate, so no request was answered and no assertion ran, which rule 1 settles first. The certificate belongs to the host's trust store, not to this repository, and every job on that agent failed the same way in the same window.",
+  "ruleApplied": "rule-1-no-assertion-reached",
+  "provenance": "synthetic",
+  "bucket": "environment-as-regression",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/package-registry-certificate-expired-on-agent.run.json
+++ b/eval/golden-dataset/package-registry-certificate-expired-on-agent.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "package-registry-certificate-expired-on-agent",
+  "scenario": "Every test in the file fails during setup while the agent cannot validate a certificate.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.client.test.ts›client › fetches the task list",
+      "title": "client › fetches the task list",
+      "file": "tests/unit/tasks.client.test.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 1804,
+      "annotations": [],
+      "error": {
+        "message": "FetchError: request to https://registry.internal/api failed, reason: certificate has expired\n    at ClientRequest.<anonymous> (node_modules/node-fetch/lib/index.js:1491:11)",
+        "stack": "    at ClientRequest.<anonymous> (node_modules/node-fetch/lib/index.js:1491:11)\n    at setupClient (app/client/src/api.ts:14:20)",
+        "snippet": "> const client = await setupClient()"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.client.test.ts›client › fetches the task list",
+      "flakinessScore": 0.07,
+      "consecutiveFailures": 3,
+      "totalRuns": 118,
+      "firstSeenAt": "2026-02-11T09:03:47.000Z",
+      "lastPassedAt": "2026-08-08T07:12:44.000Z",
+      "statusHistory": "PPPPPPPFFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/client/src/api.ts b/app/client/src/api.ts\n@@ -11,7 +11,7 @@ export async function setupClient(): Promise<Client> {\n-  const base = process.env.API_URL ?? 'http://localhost:3001'\n+  const base = process.env.API_URL ?? 'https://registry.internal/api'\n   return createClient(base)\n"
+}

--- a/eval/golden-dataset/port-still-held-by-the-previous-job.labels.json
+++ b/eval/golden-dataset/port-still-held-by-the-previous-job.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "port-still-held-by-the-previous-job",
+  "owner": "environment",
+  "determinism": "deterministic",
+  "justification": "This is the one in the group where the obvious reading and the correct one agree, which is why it is here: a bucket of nothing but traps teaches a classifier that anything touching product source in an infrastructure failure must be environment. The bind failed before any assertion, so rule 1 settles it. The commit is genuinely implicated in making the suite fragile — a fixed port instead of an ephemeral one — but the failure is still the host's, and the fix belongs in CI isolation as much as in this line.",
+  "ruleApplied": "rule-1-no-assertion-reached",
+  "provenance": "synthetic",
+  "bucket": "environment-as-regression",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/port-still-held-by-the-previous-job.run.json
+++ b/eval/golden-dataset/port-still-held-by-the-previous-job.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "port-still-held-by-the-previous-job",
+  "scenario": "The suite fails during startup while the port it needs is still held from an earlier job.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.api.test.ts›GET /api/v1/tasks › lists the seeded tasks",
+      "title": "GET /api/v1/tasks › lists the seeded tasks",
+      "file": "tests/unit/tasks.api.test.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 94,
+      "annotations": [],
+      "error": {
+        "message": "Error: listen EADDRINUSE: address already in use :::3001\n    at Server.setupListenHandle (node:net:1908:16)\n    at startServer (app/server/index.ts:28:6)",
+        "stack": "    at Server.setupListenHandle (node:net:1908:16)\n    at startServer (app/server/index.ts:28:6)",
+        "snippet": "> await startServer()"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.api.test.ts›GET /api/v1/tasks › lists the seeded tasks",
+      "flakinessScore": 0.06,
+      "consecutiveFailures": 2,
+      "totalRuns": 97,
+      "firstSeenAt": "2026-02-11T09:03:47.000Z",
+      "lastPassedAt": "2026-08-09T19:07:35.000Z",
+      "statusHistory": "PPPPPPPPFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/server/index.ts b/app/server/index.ts\n@@ -25,7 +25,7 @@ export async function startServer(): Promise<Server> {\n-  return app.listen(0)\n+  return app.listen(Number(process.env.PORT ?? 3001))\n }\n"
+}

--- a/eval/golden-dataset/proxy-answers-a-data-request-with-a-login-page.labels.json
+++ b/eval/golden-dataset/proxy-answers-a-data-request-with-a-login-page.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "proxy-answers-a-data-request-with-a-login-page",
+  "owner": "environment",
+  "determinism": "intermittent",
+  "justification": "The commit rewrites the parsing helper and the stack points inside it, which is exactly the coincidence that makes this look like a product defect. The body being parsed is a sign-in page, so nothing answered the request but the network in front of it — no assertion was reached, and rule 1 applies. The rewritten helper handles valid payloads correctly, which is why the retry in the same run passed once the interception window closed.",
+  "ruleApplied": "rule-1-no-assertion-reached",
+  "provenance": "synthetic",
+  "bucket": "environment-as-regression",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/proxy-answers-a-data-request-with-a-login-page.run.json
+++ b/eval/golden-dataset/proxy-answers-a-data-request-with-a-login-page.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "proxy-answers-a-data-request-with-a-login-page",
+  "scenario": "A client test fails while an interception layer replaces responses with a sign-in page.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.client.test.ts›client › parses the task list",
+      "title": "client › parses the task list",
+      "file": "tests/unit/tasks.client.test.ts",
+      "status": "failed",
+      "attempts": 2,
+      "flakyWithinRun": true,
+      "durationMs": 642,
+      "annotations": [],
+      "error": {
+        "message": "SyntaxError: Unexpected token '<', \"<!DOCTYPE \"... is not valid JSON\n    at JSON.parse (<anonymous>)\n    at parseResponse (app/client/src/api.ts:38:24)",
+        "stack": "    at JSON.parse (<anonymous>)\n    at parseResponse (app/client/src/api.ts:38:24)\n    at tests/unit/tasks.client.test.ts:41:26",
+        "snippet": "> const tasks = await client.listTasks()"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.client.test.ts›client › parses the task list",
+      "flakinessScore": 0.18,
+      "consecutiveFailures": 0,
+      "totalRuns": 131,
+      "firstSeenAt": "2026-02-11T09:03:47.000Z",
+      "lastPassedAt": "2026-08-10T09:22:11.000Z",
+      "statusHistory": "PPPFPPPPPFP",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/client/src/api.ts b/app/client/src/api.ts\n@@ -35,7 +35,7 @@ async function parseResponse(response: Response) {\n-  return response.json()\n+  return JSON.parse(await response.text())\n }\n"
+}

--- a/eval/golden-dataset/search-rejects-the-empty-query-it-used-to-allow.labels.json
+++ b/eval/golden-dataset/search-rejects-the-empty-query-it-used-to-allow.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "search-rejects-the-empty-query-it-used-to-allow",
+  "owner": "app_code",
+  "determinism": "deterministic",
+  "justification": "The misleading feature is the score: 214 runs of alternation put this near the top of any instability ranking, and the obvious conclusion is more of the same. It is wrong here because the cause changed. The old alternation came from a shared search index warming up; today's failure is a validation error that reproduces on every attempt and on a rerun in isolation. Reading the history rather than the failure would send someone to rerun a test that will never pass again until either the endpoint or the expectation moves.",
+  "ruleApplied": "rule-3-reproduces-against-unchanged-product",
+  "provenance": "synthetic",
+  "bucket": "misleading-history",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/search-rejects-the-empty-query-it-used-to-allow.run.json
+++ b/eval/golden-dataset/search-rejects-the-empty-query-it-used-to-allow.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "search-rejects-the-empty-query-it-used-to-allow",
+  "scenario": "A long-unstable search test began failing on every attempt after validation was tightened.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.search.test.ts›search › an empty query returns every task",
+      "title": "search › an empty query returns every task",
+      "file": "tests/unit/tasks.search.test.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 34,
+      "annotations": [],
+      "error": {
+        "message": "AssertionError: expected 400 to be 200 // Object.is equality\n\nresponse.body.error: \"query must contain at least 1 character\"",
+        "stack": "    at tests/unit/tasks.search.test.ts:29:29",
+        "snippet": "  const response = await request(app).get('/api/v1/tasks/search?q=')\n> expect(response.status).toBe(200)"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.search.test.ts›search › an empty query returns every task",
+      "flakinessScore": 0.71,
+      "consecutiveFailures": 1,
+      "totalRuns": 214,
+      "firstSeenAt": "2026-02-11T09:03:47.000Z",
+      "lastPassedAt": "2026-08-09T22:17:03.000Z",
+      "statusHistory": "PFPPFPFPPFPFPPFPF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/server/tasks/schema.ts b/app/server/tasks/schema.ts\n@@ -14,7 +14,7 @@ export const SearchQuerySchema = z.object({\n-  q: z.string().optional(),\n+  q: z.string().min(1),\n })\n"
+}

--- a/eval/golden-dataset/timestamps-serialised-without-an-offset.labels.json
+++ b/eval/golden-dataset/timestamps-serialised-without-an-offset.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "timestamps-serialised-without-an-offset",
+  "owner": "app_code",
+  "determinism": "deterministic",
+  "justification": "The score is the misleading feature: this test alternated for months while it compared whole timestamps against a clock, and that comparison was replaced with a pattern match long ago. Today's failure has nothing to do with timing. The formatter was swapped for one that drops the offset, so the emitted value can never match the pattern regardless of when the run happens, on any machine, in any zone.",
+  "ruleApplied": "rule-3-reproduces-against-unchanged-product",
+  "provenance": "synthetic",
+  "bucket": "misleading-history",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/timestamps-serialised-without-an-offset.run.json
+++ b/eval/golden-dataset/timestamps-serialised-without-an-offset.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "timestamps-serialised-without-an-offset",
+  "scenario": "A long-unstable serialisation test fails on every attempt after the date formatter changed.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.serialise.test.ts›serialise › emits an offset with every timestamp",
+      "title": "serialise › emits an offset with every timestamp",
+      "file": "tests/unit/tasks.serialise.test.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 15,
+      "annotations": [],
+      "error": {
+        "message": "AssertionError: expected '2026-08-10 09:15:00' to match /\\+\\d{2}:\\d{2}|Z$/",
+        "stack": "    at tests/unit/tasks.serialise.test.ts:11:38",
+        "snippet": "> expect(serialiseTask(task).createdAt).toMatch(/\\+\\d{2}:\\d{2}|Z$/)"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.serialise.test.ts›serialise › emits an offset with every timestamp",
+      "flakinessScore": 0.68,
+      "consecutiveFailures": 1,
+      "totalRuns": 203,
+      "firstSeenAt": "2026-02-11T09:03:47.000Z",
+      "lastPassedAt": "2026-08-09T13:52:29.000Z",
+      "statusHistory": "PFPPFPFPPFPFPF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/server/tasks/serialise.ts b/app/server/tasks/serialise.ts\n@@ -8,7 +8,7 @@ export function serialiseTask(task: Task) {\n-    createdAt: task.createdAt.toISOString(),\n+    createdAt: formatLocal(task.createdAt),\n }\n"
+}

--- a/eval/golden-dataset/write-fails-when-the-runner-disk-fills.labels.json
+++ b/eval/golden-dataset/write-fails-when-the-runner-disk-fills.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "write-fails-when-the-runner-disk-fills",
+  "owner": "environment",
+  "determinism": "intermittent",
+  "justification": "Everything points at the commit: it changes the insert statement, and the stack names the very line it changed. That is the misleading feature. No assertion ran — the write never completed because the storage layer reported the disk exhausted, which rule 1 settles before the diff is worth reading. The changed statement is valid and passes everywhere else; the run happened to land on an agent another job had filled.",
+  "ruleApplied": "rule-1-no-assertion-reached",
+  "provenance": "synthetic",
+  "bucket": "environment-as-regression",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/write-fails-when-the-runner-disk-fills.run.json
+++ b/eval/golden-dataset/write-fails-when-the-runner-disk-fills.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "write-fails-when-the-runner-disk-fills",
+  "scenario": "A persistence test fails when the agent's disk is exhausted by another job on the same host.",
+  "subject": {
+    "result": {
+      "testId": "tests/unit/tasks.repository.test.ts›createTask › persists the row",
+      "title": "createTask › persists the row",
+      "file": "tests/unit/tasks.repository.test.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 203,
+      "annotations": [],
+      "error": {
+        "message": "SqliteError: SQLITE_FULL: database or disk is full\n    at Database.run (node_modules/better-sqlite3/lib/methods/wrappers.js:5:21)\n    at insertTask (app/server/tasks/repository.ts:21:18)",
+        "stack": "    at insertTask (app/server/tasks/repository.ts:21:18)\n    at tests/unit/tasks.repository.test.ts:12:20",
+        "snippet": "> const task = await createTask('Write the report')"
+      }
+    },
+    "signal": {
+      "testId": "tests/unit/tasks.repository.test.ts›createTask › persists the row",
+      "flakinessScore": 0.09,
+      "consecutiveFailures": 1,
+      "totalRuns": 142,
+      "firstSeenAt": "2026-02-11T09:03:47.000Z",
+      "lastPassedAt": "2026-08-10T08:44:02.000Z",
+      "statusHistory": "PPPPPPPPPPF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "diff": "diff --git a/app/server/tasks/repository.ts b/app/server/tasks/repository.ts\n@@ -18,7 +18,8 @@ export async function insertTask(title: string): Promise<Task> {\n-  const { lastID } = await db.run('INSERT INTO tasks (title) VALUES (?)', title)\n+  const { lastID } = await db.run('INSERT INTO tasks (title, created_at) VALUES (?, ?)',\n+    title, new Date().toISOString())\n   return getTask(lastID)\n"
+}


### PR DESCRIPTION
Closes #22

## What changed

8 fixtures aimed at the two shortcuts any classifier here is tempted by. The dataset is now 33 fixtures across five buckets.

## The two traps

**Misleading history (4).** A test that has alternated for ~200 runs and today fails for a *new* cause that reproduces every time — tightened validation, a dropped SQL filter, a swapped date formatter, a duplicated test id. History says unstable; the truth is settled.

The trap is sharper than it looks. The determinism rule keys on a consecutive-failure **streak**, and the new cause is only one run old, so the streak is short while the months of alternation behind it are irrelevant. The baseline reads all four as `intermittent`. Reading history rather than the failure sends someone to rerun a test that will never pass again.

**Infrastructure failure inside a suspicious commit (4).** The run broke before any assertion, and the commit touches the very file the stack names — a disk-full write, an expired certificate, a proxy returning a sign-in page. Diff-led reading calls each a product change.

These are deliberately chosen so the messages do **not** match the baseline's infrastructure patterns. That list is narrow on purpose (a loose pattern turns product failures into `environment`, the label that tells a developer to do nothing), and the cost of that narrowness is exactly this: real infrastructure failures it does not recognise.

## One of the eight is not a trap

`port-still-held-by-the-previous-job` is an `EADDRINUSE` failure inside a commit that changes the server bootstrap from an ephemeral port to a fixed one. The obvious reading and the correct one agree, and the baseline gets it right.

That is deliberate. A bucket of nothing but traps teaches the opposite reflex — that anything infrastructure-shaped near a product diff must be `environment` — and a classifier that learns *that* is no better than one that learns the shortcut. Its justification says so, and notes the genuinely uncomfortable part: the commit really is implicated in making the suite fragile, and the failure is still the host's.

## Verification

7 of 8 wrong, above the 6 the issue requires.

| Bucket | Baseline joint | |
|---|---|---|
| Misleading history | 0/4 | all read as `intermittent` |
| Environment as regression | 1/4 | the one that is not a trap |

Dataset totals, all pinned as assertions:

| | Before | After |
|---|---|---|
| `owner` | 14/25 | **18/33** |
| `determinism` | 22/25 | **26/33** |
| Joint | — | **12/33** |
| Hard quadrant joint-wrong | 7/10 | 7/10 |

## How it was verified

259 assertions. Two new pinned tests: the adversarial buckets as a whole, and a specific one asserting that *every* misleading-history fixture is labelled `deterministic` and predicted `intermittent` — so if a future rule change fixes that, it surfaces here with the mechanism named rather than as a small movement in an aggregate.

Leakage checked across every string value and filename.

## Checklist

- [x] Title is a valid Conventional Commit
- [x] Linked to exactly one issue with `Closes #N`
- [x] `npm run lint && npm run format:check && npm run typecheck && npm run test:unit` clean
- [x] 4 misleading-history + 4 environment-as-regression
- [x] Each justification names the feature that misleads and why it is wrong here
- [x] Baseline verified to miss ≥6 of 8

## Notes for the reviewer

`board-control-appears-twice-after-panel-split` is the one worth arguing about. Two features mislead at once — long alternating history *and* a product diff — and the label is `test_code`, because the added panel is a working feature and the spec identified its target by an attribute that was never unique by contract. If you would call that `app_code`, the justification is the argument to attack.

12/33 joint for the baseline is a low number and it should be. Three of the five buckets exist specifically to defeat it, and the delta once the agent lands in #38 is the number that matters — not this one.