### PR TITLE
feat(dataset): add the golden-dataset hygiene lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,13 @@ jobs:
           npm ci --silent
           npm run docs:status:check
 
+      # Label leakage is the quietest way to inflate an accuracy number, so this
+      # runs on every push rather than only when the dataset changes — a leaked
+      # term arrives just as easily through an edit to the checker itself.
+      - name: Golden dataset hygiene
+        if: steps.detect.outputs.has-code == 'true'
+        run: npm run eval:lint
+
       - name: No internal doc links point at missing files
         run: |
           python3 - <<'PY'

--- a/eval/hygiene.test.ts
+++ b/eval/hygiene.test.ts
@@ -1,0 +1,168 @@
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { Bucket, FixtureLabels } from '@sentra/contracts'
+import { describe, expect, it } from 'vitest'
+import { checkComposition, checkLeakage, runHygiene } from './hygiene.js'
+import { loadPayload } from './dataset.js'
+
+const real = loadPayload('create-task-returns-ok-instead-of-created').payload
+
+/** A payload with one string replaced, so each case differs in exactly one place. */
+const withText = (path: 'scenario' | 'title', text: string) =>
+  path === 'scenario'
+    ? { ...real, scenario: text }
+    : { ...real, subject: { ...real.subject, result: { ...real.subject.result, title: text } } }
+
+describe('checkLeakage', () => {
+  it('passes the real dataset', () => {
+    expect(checkLeakage('create-task-returns-ok-instead-of-created', real)).toEqual([])
+  })
+
+  it.each([
+    ['app_code', 'The app_code is at fault here in this scenario description.'],
+    ['flaky', 'A flaky reorder assertion that disagrees with the rendered order.'],
+    ['intermittent', 'An intermittent failure when two updates overlap on the board.'],
+    ['stale', 'A stale expectation left behind by the toolbar redesign work.'],
+    ['ground truth', 'The ground truth here is that the product is at fault.'],
+  ])('catches %s in the scenario', (_term, text) => {
+    expect(checkLeakage('probe', withText('scenario', text))).not.toEqual([])
+  })
+
+  it('catches a leaked term in a test title', () => {
+    const findings = checkLeakage('probe', withText('title', 'board › survives a race on reorder'))
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.message).toContain('title')
+  })
+
+  it('catches a leaked term in the filename', () => {
+    expect(checkLeakage('reorder-is-flaky-under-load', real)[0]?.message).toContain('filename')
+  })
+
+  it('does not fire on "stack trace", which contains "race"', () => {
+    // An unbounded /race/ matches every stack trace in the dataset. A check that
+    // fires on everything gets switched off, which is worse than not having it.
+    expect(
+      checkLeakage('probe', withText('scenario', 'The stack trace embraces the caller.')),
+    ).toEqual([])
+  })
+
+  it('does not fire on the schema key names', () => {
+    // flakinessScore and flakyWithinRun are part of the format, not something a
+    // fixture author chose. Only string values are scanned.
+    expect(JSON.stringify(real)).toContain('flakinessScore')
+    expect(checkLeakage('probe', real)).toEqual([])
+  })
+
+  it('names the path so a finding can be acted on', () => {
+    const findings = checkLeakage('probe', withText('scenario', 'A flaky thing happens.'))
+    expect(findings[0]?.message).toMatch(/^scenario contains/)
+  })
+})
+
+describe('checkComposition', () => {
+  const labels = (counts: Partial<Record<Bucket, number>>): FixtureLabels[] =>
+    Object.entries(counts).flatMap(([bucket, n]) =>
+      Array.from({ length: n ?? 0 }, (_, i) => ({
+        name: `${bucket}-${String(i)}`,
+        owner: 'app_code' as const,
+        determinism: 'intermittent' as const,
+        justification: 'x'.repeat(200),
+        ruleApplied: 'rule-4-default-app-code' as const,
+        provenance: 'synthetic' as const,
+        bucket: bucket as Bucket,
+        lowConfidenceGroundTruth: false,
+      })),
+    )
+
+  it('reports a share for every bucket, including empty ones', () => {
+    const { composition } = checkComposition(labels({ 'hard-quadrant': 4 }))
+    expect(composition).toHaveLength(6)
+    expect(composition.find((c) => c.bucket === 'cross-file-state-leak')?.count).toBe(0)
+  })
+
+  it('does not enforce below the target dataset size', () => {
+    // A half-built dataset is not out of composition, it is unfinished. Failing
+    // on it would train everyone to ignore the check while it is being built.
+    expect(checkComposition(labels({ 'hard-quadrant': 59 })).compositionEnforced).toBe(false)
+  })
+
+  it('enforces once the dataset is large enough for shares to mean anything', () => {
+    expect(checkComposition(labels({ 'hard-quadrant': 60 })).compositionEnforced).toBe(true)
+  })
+
+  it('computes drift against the documented target', () => {
+    const { composition } = checkComposition(labels({ 'hard-quadrant': 10, straightforward: 10 }))
+    const hard = composition.find((c) => c.bucket === 'hard-quadrant')
+    expect(hard?.share).toBeCloseTo(0.5, 5)
+    expect(hard?.drift).toBeCloseTo(0.3, 5)
+  })
+})
+
+describe('runHygiene against a directory', () => {
+  const fixtureDir = (files: Record<string, unknown>): string => {
+    const dir = mkdtempSync(join(tmpdir(), 'sentra-hygiene-'))
+    for (const [file, body] of Object.entries(files)) {
+      writeFileSync(join(dir, file), JSON.stringify(body))
+    }
+    return dir
+  }
+
+  const labels = (name: string, justification = 'x'.repeat(200)) => ({
+    name,
+    owner: 'app_code',
+    determinism: 'deterministic',
+    justification,
+    ruleApplied: 'rule-4-default-app-code',
+    provenance: 'synthetic',
+    bucket: 'straightforward',
+    lowConfidenceGroundTruth: false,
+  })
+
+  it('reports a payload with no labels', () => {
+    const dir = fixtureDir({ 'probe.run.json': { ...real, name: 'probe' } })
+    expect(runHygiene(dir).errors[0]?.message).toContain('no .labels.json')
+  })
+
+  it('reports labels with no payload', () => {
+    const dir = fixtureDir({ 'probe.labels.json': labels('probe') })
+    expect(runHygiene(dir).errors[0]?.message).toContain('no .run.json')
+  })
+
+  it('warns about a justification that parses but does not argue', () => {
+    const dir = fixtureDir({
+      'probe.run.json': { ...real, name: 'probe' },
+      'probe.labels.json': labels('probe', 'x'.repeat(90)),
+    })
+    const report = runHygiene(dir)
+    expect(report.errors).toEqual([])
+    expect(report.warnings[0]?.message).toContain('90 characters')
+  })
+
+  it('does not warn about a justification that makes an argument', () => {
+    const dir = fixtureDir({
+      'probe.run.json': { ...real, name: 'probe' },
+      'probe.labels.json': labels('probe'),
+    })
+    expect(runHygiene(dir).warnings).toEqual([])
+  })
+})
+
+describe('the committed dataset', () => {
+  const report = runHygiene()
+
+  it('has no leakage or pairing problems', () => {
+    expect(report.errors).toEqual([])
+  })
+
+  it('has no thin justifications', () => {
+    expect(report.warnings).toEqual([])
+  })
+
+  it('is still below the size where composition is enforced', () => {
+    // When this flips, the drift check starts failing the build — which is the
+    // point at which the remaining buckets have to be filled in.
+    expect(report.compositionEnforced).toBe(false)
+    expect(report.fixtures).toBe(33)
+  })
+})

--- a/eval/hygiene.ts
+++ b/eval/hygiene.ts
@@ -1,0 +1,215 @@
+import { readdirSync } from 'node:fs'
+import {
+  BucketSchema,
+  pairFixtureFiles,
+  type Bucket,
+  type FixtureLabels,
+  type FixturePayload,
+  LABELS_SUFFIX,
+  PAYLOAD_SUFFIX,
+} from '@sentra/contracts'
+import { DATASET_DIR, loadLabels, loadPayload } from './dataset.js'
+
+/**
+ * Dataset hygiene.
+ *
+ * Label leakage is the quietest way to inflate an accuracy number. A fixture
+ * whose test is titled "should not lose the update when requests overlap", sitting
+ * in the hard quadrant, hands the classifier the answer — and the resulting
+ * metric measures nothing while looking exactly like a metric that does.
+ *
+ * This cannot catch everything. Semantic leakage survives any word list, and a
+ * scenario sentence can give the game away without using a single flagged term.
+ * It catches the careless cases, and running it in CI means the discipline does
+ * not depend on anybody remembering.
+ */
+
+/**
+ * Vocabulary that gives away a label.
+ *
+ * Word-bounded, which is not fussiness: `race` unbounded matches every stack
+ * trace in the dataset, and a check that fires on everything gets switched off.
+ *
+ * Only string **values** are scanned. Schema key names — `flakinessScore`,
+ * `flakyWithinRun` — are part of the format rather than something a fixture
+ * author chose, and flagging them would make the check unusable.
+ */
+const LEAK_TERMS: readonly RegExp[] = [
+  /\bapp_code\b/i,
+  /\btest_code\b/i,
+  /\benvironment\b/i,
+  /\bflaky\b/i,
+  /\bflakiness\b/i,
+  /\brace\b/i,
+  /\bdeterministic\b/i,
+  /\bintermittent\b/i,
+  /\bregression\b/i,
+  /\bstale\b/i,
+  /\bground truth\b/i,
+  /\bhard quadrant\b/i,
+]
+
+/**
+ * Target composition, from docs/eval-methodology.md.
+ *
+ * Drift is only an error once the dataset is large enough for the shares to mean
+ * something. Below that it is reported and not enforced — a half-built dataset
+ * is not out of composition, it is unfinished, and failing on it would train
+ * everyone to ignore the check during exactly the period it is being built.
+ */
+const TARGET_SHARE: Record<Bucket, number> = {
+  'hard-quadrant': 0.2,
+  'misleading-history': 0.1,
+  'environment-as-regression': 0.1,
+  'stale-test': 0.15,
+  'cross-file-state-leak': 0.1,
+  straightforward: 0.25,
+}
+
+const ENFORCE_COMPOSITION_FROM = 60
+const DRIFT_TOLERANCE = 0.1
+
+/** A justification long enough to pass the schema can still be too short to be an argument. */
+const THIN_JUSTIFICATION = 150
+
+export interface Finding {
+  fixture: string
+  message: string
+}
+
+export interface HygieneReport {
+  fixtures: number
+  errors: Finding[]
+  warnings: Finding[]
+  composition: { bucket: Bucket; count: number; share: number; target: number; drift: number }[]
+  compositionEnforced: boolean
+}
+
+/** Every string value in a payload, with a path so a finding can name where it is. */
+function* strings(value: unknown, path: string[] = []): Generator<[string, string]> {
+  if (typeof value === 'string') {
+    yield [path.join('.'), value]
+  } else if (Array.isArray(value)) {
+    for (const [i, item] of value.entries()) yield* strings(item, [...path, String(i)])
+  } else if (value !== null && typeof value === 'object') {
+    for (const [key, item] of Object.entries(value)) yield* strings(item, [...path, key])
+  }
+}
+
+export function checkLeakage(name: string, payload: FixturePayload): Finding[] {
+  const findings: Finding[] = []
+
+  for (const term of LEAK_TERMS) {
+    if (term.test(name)) {
+      findings.push({ fixture: name, message: `filename contains ${String(term)}` })
+    }
+  }
+
+  for (const [path, text] of strings(payload)) {
+    for (const term of LEAK_TERMS) {
+      if (term.test(text)) {
+        findings.push({
+          fixture: name,
+          message: `${path} contains ${String(term)} — "${excerpt(text, term)}"`,
+        })
+      }
+    }
+  }
+
+  return findings
+}
+
+function excerpt(text: string, term: RegExp): string {
+  const at = text.search(term)
+  const from = Math.max(0, at - 25)
+  return `${from > 0 ? '…' : ''}${text.slice(from, at + 45).replace(/\n/g, ' ')}…`
+}
+
+export function checkComposition(
+  labels: FixtureLabels[],
+): Pick<HygieneReport, 'composition' | 'compositionEnforced'> {
+  const total = labels.length
+  const composition = BucketSchema.options.map((bucket) => {
+    const count = labels.filter((l) => l.bucket === bucket).length
+    const share = total === 0 ? 0 : count / total
+    const target = TARGET_SHARE[bucket]
+    return { bucket, count, share, target, drift: share - target }
+  })
+  return { composition, compositionEnforced: total >= ENFORCE_COMPOSITION_FROM }
+}
+
+export function runHygiene(dir: string = DATASET_DIR): HygieneReport {
+  const errors: Finding[] = []
+  const warnings: Finding[] = []
+
+  const paired = pairFixtureFiles(readdirSync(dir))
+  for (const name of paired.missingLabels) {
+    errors.push({ fixture: name, message: `has ${PAYLOAD_SUFFIX} but no ${LABELS_SUFFIX}` })
+  }
+  for (const name of paired.orphanedLabels) {
+    errors.push({ fixture: name, message: `has ${LABELS_SUFFIX} but no ${PAYLOAD_SUFFIX}` })
+  }
+
+  const labels: FixtureLabels[] = []
+  for (const name of paired.names) {
+    const { payload } = loadPayload(name, dir)
+    errors.push(...checkLeakage(name, payload))
+
+    const label = loadLabels(name, dir)
+    labels.push(label)
+
+    if (label.justification.length < THIN_JUSTIFICATION) {
+      warnings.push({
+        fixture: name,
+        message: `justification is ${String(label.justification.length)} characters — long enough to parse, short enough to suggest the tempting alternative was never addressed`,
+      })
+    }
+  }
+
+  const { composition, compositionEnforced } = checkComposition(labels)
+  if (compositionEnforced) {
+    for (const row of composition) {
+      if (Math.abs(row.drift) > DRIFT_TOLERANCE) {
+        errors.push({
+          fixture: row.bucket,
+          message: `share is ${pct(row.share)} against a target of ${pct(row.target)} — drift ${pct(Math.abs(row.drift))} exceeds ${pct(DRIFT_TOLERANCE)}`,
+        })
+      }
+    }
+  }
+
+  return { fixtures: paired.names.length, errors, warnings, composition, compositionEnforced }
+}
+
+const pct = (n: number): string => `${(n * 100).toFixed(0)}%`
+
+function main(): void {
+  const report = runHygiene()
+
+  console.log(`\n  Golden dataset: ${String(report.fixtures)} fixtures\n`)
+  console.log('  bucket                       count   share   target')
+  for (const row of report.composition) {
+    const flag = report.compositionEnforced && Math.abs(row.drift) > DRIFT_TOLERANCE ? ' ←' : ''
+    console.log(
+      `  ${row.bucket.padEnd(28)}${String(row.count).padStart(4)}  ${pct(row.share).padStart(6)}  ${pct(row.target).padStart(6)}${flag}`,
+    )
+  }
+  if (!report.compositionEnforced) {
+    console.log(
+      `\n  Composition is reported but not enforced below ${String(ENFORCE_COMPOSITION_FROM)} fixtures.`,
+    )
+  }
+
+  for (const w of report.warnings) console.log(`\n  warning  ${w.fixture}: ${w.message}`)
+  for (const e of report.errors) console.error(`\n  error    ${e.fixture}: ${e.message}`)
+
+  if (report.errors.length > 0) {
+    console.error(
+      `\n  ${String(report.errors.length)} problem(s). See eval/golden-dataset/README.md.\n`,
+    )
+    process.exit(1)
+  }
+  console.log('\n  No leakage or pairing problems found.\n')
+}
+
+if (process.argv[1]?.endsWith('hygiene.ts') === true) main()

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "docs:status:check": "tsx scripts/status-banner.ts --check",
     "eval": "node scripts/pending.mjs eval",
     "eval:ablation": "node scripts/pending.mjs eval:ablation",
+    "eval:lint": "tsx eval/hygiene.ts",
     "flakemetry:analyze": "node scripts/pending.mjs flakemetry:analyze",
     "format": "prettier --write .",
     "format:check": "prettier --check .",


### PR DESCRIPTION
Closes #23

## What changed

`npm run eval:lint` checks the dataset for label leakage, orphaned files, thin justifications and composition drift. It runs in the always-on `Repository hygiene` CI job.

```
  Golden dataset: 33 fixtures

  bucket                       count   share   target
  hard-quadrant                 10     30%     20%
  misleading-history             4     12%     10%
  environment-as-regression      4     12%     10%
  stale-test                     7     21%     15%
  cross-file-state-leak          0      0%     10%
  straightforward                8     24%     25%

  Composition is reported but not enforced below 60 fixtures.

  No leakage or pairing problems found.
```

## Why

Up to now the leak check was an ad-hoc script run by hand while authoring #20, #21 and #22. It caught one real leak — a bucket name in a filename — which is exactly the argument for it being in the build rather than in someone's shell history.

## Decisions worth reviewing

**Terms are word-bounded.** Not fussiness. An unbounded `/race/` matches every stack trace in the dataset (`trace` contains `race`), and a check that fires on everything gets switched off — which is worse than not having it. There is a test for `"The stack trace embraces the caller."` producing no findings.

**Only string values are scanned, never keys.** `flakinessScore` and `flakyWithinRun` are part of the format, not something a fixture author chose. Flagging them would make the check unusable, and the naive implementation flags them on every single fixture.

**Composition drift is reported always, enforced only from 60 fixtures.** A half-built dataset is not *out of* composition, it is *unfinished*. Failing the build on it would train everyone to ignore the check during exactly the period the dataset is being built — and then it would be off when it started to matter.

The gap stays visible in the table on every run, and a test asserts the dataset is still below the enforcement line. **The day that test flips is the day the empty buckets have to be filled** — currently `cross-file-state-leak` at 0%.

**The justification warning is 150 characters, not the schema's 80.** Parsing and arguing are different bars and the schema can only enforce the first. A justification that clears 80 and not 150 has stated a verdict without addressing the alternative, which is the thing the field exists for.

## How it was verified

281 assertions. Both directions on every check — a leaked term caught in `scenario`, in a test title and in a filename; `stack trace` and the schema keys deliberately *not* caught; orphans in both directions; a 90-character justification warned about and a 200-character one not.

End to end, with a leak planted in a real fixture:

```
error  export-now-includes-archived-rows: scenario contains /\bapp_code\b/i — "…ally a regression in the app_code.…"
error  export-now-includes-archived-rows: scenario contains /\bflaky\b/i — "A flaky export test that is really a regression…"
error  export-now-includes-archived-rows: scenario contains /\bregression\b/i — "…rt test that is really a regression in the app_code.…"

3 problem(s). See eval/golden-dataset/README.md.
```

Findings name the field path and quote the surrounding text, because a finding that says only "leak detected" costs more to act on than to ignore.

## Checklist

- [x] Title is a valid Conventional Commit
- [x] Linked to exactly one issue with `Closes #N`
- [x] `npm run lint && npm run format:check && npm run typecheck && npm run test:unit` clean
- [x] Tests cover both directions, including the false positives worth avoiding
- [x] Runs in CI

## Notes for the reviewer

It runs on every push rather than only on changes under `eval/golden-dataset/`. A leaked term arrives just as easily through an edit to the term list itself, and the check takes under a second.

The composition targets are duplicated from `docs/eval-methodology.md` into a constant rather than parsed out of the markdown. Parsing prose to drive a build gate is a worse failure mode than a stale constant — the constant is at least visible in review, and `BucketSchema` guarantees every bucket has an entry.

**This is the last piece of dataset infrastructure.** #25 through #27 turn 33 fixtures and two classifiers into `eval/report.md`.