### PR TITLE
fix(docs): stop the wiki claiming unbuilt commands work

### DIFF
--- a/scripts/status-banner.ts
+++ b/scripts/status-banner.ts
@@ -20,6 +20,21 @@ import { readFileSync, writeFileSync } from 'node:fs'
 const START = '<!-- status:start -->'
 const END = '<!-- status:end -->'
 
+/**
+ * Every page that carries a status banner.
+ *
+ * The wiki needs one for the same reason the README does, and more urgently: it
+ * is the more public surface, and it described unbuilt commands in the present
+ * tense until #116. One generator, so the two cannot disagree about what exists.
+ */
+const TARGETS: readonly { file: string; variant: Variant }[] = [
+  { file: 'README.md', variant: 'readme' },
+  { file: 'wiki/Home.md', variant: 'wiki' },
+  { file: 'wiki/Getting-Started.md', variant: 'wiki' },
+]
+
+export type Variant = 'readme' | 'wiki'
+
 const REPO = 'https://github.com/AKogut/ai-flaky-test-triage'
 
 export type MilestoneStatus = 'done' | 'in progress' | 'planned'
@@ -92,7 +107,7 @@ export function parseRoadmap(markdown: string): Milestone[] {
   return milestones
 }
 
-export function renderBanner(milestones: Milestone[]): string {
+export function renderBanner(milestones: Milestone[], variant: Variant = 'readme'): string {
   const done = milestones.filter((m) => m.status === 'done')
   const active = milestones.find((m) => m.status === 'in progress')
   const total = milestones.length
@@ -114,7 +129,12 @@ export function renderBanner(milestones: Milestone[]): string {
     `> Current exit criterion: ${active.exitCriterion}`,
     `>`,
     `> Progress is tracked as [milestones](${REPO}/milestones), not dates.`,
-    `> Commands marked 🚧 in the script table are not implemented yet and say so when run.`,
+    variant === 'readme'
+      ? `> Commands marked 🚧 in the script table are not implemented yet and say so when run.`
+      : `> Commands marked 🚧 below are not implemented yet. Running one names the milestone it`,
+    ...(variant === 'readme'
+      ? []
+      : [`> arrives in rather than failing with a missing-script error.`]),
   ].join('\n')
 }
 
@@ -131,20 +151,29 @@ function main(): void {
   const milestones = parseRoadmap(readFileSync('ROADMAP.md', 'utf8'))
   if (milestones.length === 0) throw new Error('ROADMAP.md: no milestones parsed')
 
-  const readme = readFileSync('README.md', 'utf8')
-  const next = splice(readme, renderBanner(milestones))
+  const check = process.argv.includes('--check')
+  const stale: string[] = []
 
-  if (process.argv.includes('--check')) {
-    if (next !== readme) {
-      console.error('README status banner is out of date with ROADMAP.md. Run: npm run docs:status')
+  for (const { file, variant } of TARGETS) {
+    const current = readFileSync(file, 'utf8')
+    const next = splice(current, renderBanner(milestones, variant))
+    if (next === current) continue
+    if (check) stale.push(file)
+    else writeFileSync(file, next)
+  }
+
+  if (check) {
+    if (stale.length > 0) {
+      console.error(
+        `Status banner is out of date with ROADMAP.md in: ${stale.join(', ')}. Run: npm run docs:status`,
+      )
       process.exit(1)
     }
-    console.log(`README status banner is up to date (${String(milestones.length)} milestones)`)
+    console.log(`Status banners are up to date (${String(milestones.length)} milestones)`)
     return
   }
 
-  writeFileSync('README.md', next)
-  console.log('README status banner regenerated')
+  console.log(`Status banners regenerated in ${String(TARGETS.length)} files`)
 }
 
 if (process.argv[1]?.endsWith('status-banner.ts') === true) main()

--- a/tests/unit/status-banner.test.ts
+++ b/tests/unit/status-banner.test.ts
@@ -94,10 +94,26 @@ describe('splice', () => {
   })
 })
 
-describe('the committed README', () => {
-  it('matches what generation produces', () => {
-    const readme = readFileSync(join(root, 'README.md'), 'utf8')
-    const banner = renderBanner(parseRoadmap(readFileSync(join(root, 'ROADMAP.md'), 'utf8')))
-    expect(splice(readme, banner)).toBe(readme)
+describe('the committed pages', () => {
+  const milestones = parseRoadmap(readFileSync(join(root, 'ROADMAP.md'), 'utf8'))
+
+  it.each([
+    ['README.md', 'readme'],
+    ['wiki/Home.md', 'wiki'],
+    ['wiki/Getting-Started.md', 'wiki'],
+  ] as const)('%s matches what generation produces', (file, variant) => {
+    const page = readFileSync(join(root, file), 'utf8')
+    expect(splice(page, renderBanner(milestones, variant))).toBe(page)
+  })
+
+  it('marks every unimplemented pipeline command in the wiki quickstart (#116)', () => {
+    // The wiki described npm run demo in the present tense while it was a
+    // placeholder. It is the more public of the two surfaces, so it needs the
+    // README's convention rather than an exemption from it.
+    const page = readFileSync(join(root, 'wiki/Getting-Started.md'), 'utf8')
+    for (const command of ['npm run demo', 'npm run dev', 'npm run eval', 'npm test']) {
+      const line = page.split('\n').find((l) => l.includes(command) && l.includes('🚧'))
+      expect(line, `${command} is described without a 🚧 marker`).toBeTruthy()
+    }
   })
 })

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,8 +1,20 @@
 # Getting Started
 
+<!-- status:start -->
+
+> **Project status: M2 — Golden dataset, baseline & eval harness.**
+> 2 of 11 milestones complete.
+> Current exit criterion: `npm run eval` scores the baseline heuristic on ≥30 labelled fixtures and writes a report with per-axis accuracy, intervals, and both confusion matrices — with no model involved.
+>
+> Progress is tracked as [milestones](https://github.com/AKogut/ai-flaky-test-triage/milestones), not dates.
+> Commands marked 🚧 below are not implemented yet. Running one names the milestone it
+> arrives in rather than failing with a missing-script error.
+
+<!-- status:end -->
+
 ## Requirements
 
-Node ≥ 22. Nothing else. No Docker, no database, no API key for the default path.
+Node ≥ 22. Nothing else. No Docker, no database, and no API key for anything that works today.
 
 ## Clone and run
 
@@ -10,20 +22,38 @@ Node ≥ 22. Nothing else. No Docker, no database, no API key for the default pa
 git clone https://github.com/AKogut/ai-flaky-test-triage.git
 cd ai-flaky-test-triage
 npm install
-npm run demo
+npm run help
 ```
 
-`npm run demo` runs the entire pipeline — flakiness analysis, triage, root cause, fix suggestion,
-report generation — against a bundled fixture run, using **recorded model responses**. No network
-call is made and no credentials are needed.
+`npm run help` prints every pipeline command, what it does, and — for the ones that do not exist
+yet — which milestone it arrives in. It is the honest version of `npm run` on a project that is
+still being built.
 
-It finishes in well under a minute and writes a `report.md` that is the same document a real pull
-request would receive.
+### What runs today
 
-### What replay mode does and does not prove
+```bash
+npm run test:unit     # the full suite, including the dataset's own tests
+npm run eval:lint     # golden-dataset composition and label-leakage check
+npm run typecheck
+```
 
-It proves the pipeline works end to end: parsing, analysis, orchestration, schema validation,
-report assembly. It does **not** prove what the model would say today, because the responses were
+### What does not, and why it is described anyway
+
+```bash
+npm run demo          # 🚧 M3 · #39
+```
+
+The intent: run the entire pipeline — flakiness analysis, triage, root cause, fix suggestion,
+report generation — against a bundled fixture run, using **recorded model responses**, with no
+network call and no credentials.
+
+That is the claim the Definition of Done rests on, which is why it is written down before it is
+built rather than after. Running it today prints the milestone it arrives in and exits.
+
+#### What replay mode will and will not prove
+
+It will prove the pipeline works end to end: parsing, analysis, orchestration, schema validation,
+report assembly. It will **not** prove what the model would say today, because the responses were
 recorded earlier. The demo says so in its own output rather than implying a live classification
 just happened.
 
@@ -32,7 +62,7 @@ Rationale: [ADR-0005](https://github.com/AKogut/ai-flaky-test-triage/blob/main/d
 ## Check the classifier's accuracy yourself
 
 ```bash
-npm run eval
+npm run eval        # 🚧 M2 · #27
 cat eval/report.md
 ```
 
@@ -50,8 +80,8 @@ suspicious outcome.
 ```bash
 cp .env.example .env
 # add ANTHROPIC_API_KEY
-npm test          # runs the suite, writes results.json
-npm run analyze   # flakemetry + agents, writes report.md
+npm test          # 🚧 M5 · #50 — runs the suite, writes results.json
+npm run analyze   # 🚧 M8 · #71 — flakemetry + agents, writes report.md
 ```
 
 `npm test` deliberately includes tests that fail intermittently. That is the point — they are the
@@ -61,7 +91,7 @@ happens to their output.
 ## Running the demo application
 
 ```bash
-npm run dev
+npm run dev        # 🚧 M4 · #48
 ```
 
 TaskFlow is a small task board: create, edit, delete, complete, filter, drag-to-reorder. It exists
@@ -71,7 +101,7 @@ product, and it is deliberately not good software.
 To reproduce a specific race:
 
 ```bash
-SENTRA_CHAOS=<seed> npm run dev
+SENTRA_CHAOS=<seed> npm run dev   # 🚧 M4 · #47
 ```
 
 Seeded latency injection makes a particular interleaving reproducible, which is how the

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -2,6 +2,18 @@
 
 **An AI triage layer for CI test failures — packaged as a pipeline step, not a service.**
 
+<!-- status:start -->
+
+> **Project status: M2 — Golden dataset, baseline & eval harness.**
+> 2 of 11 milestones complete.
+> Current exit criterion: `npm run eval` scores the baseline heuristic on ≥30 labelled fixtures and writes a report with per-axis accuracy, intervals, and both confusion matrices — with no model involved.
+>
+> Progress is tracked as [milestones](https://github.com/AKogut/ai-flaky-test-triage/milestones), not dates.
+> Commands marked 🚧 below are not implemented yet. Running one names the milestone it
+> arrives in rather than failing with a missing-script error.
+
+<!-- status:end -->
+
 Flaky-test detectors tell you _which_ tests are unstable. They do not tell you what to do about it.
 After every red CI run somebody still has to open the trace, read the stack, look at the diff, and
 decide: is this a real bug, a badly written test, or the runner having a bad day? Sentra automates

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -7,6 +7,12 @@ happens to be logged in.
 
 **Do not edit the wiki in the browser.** The next publish overwrites it.
 
+`Home.md` and `Getting-Started.md` carry a status banner generated from `ROADMAP.md` by
+`npm run docs:status`, the same generator the README uses. Do not hand-edit the block between the
+`<!-- status:start -->` markers; CI checks it. Commands that are not implemented yet are marked
+🚧 with the milestone and issue they arrive in — the wiki is the more public surface of the two,
+so it gets the stricter convention, not an exemption from it.
+
 ## Publishing
 
 ```bash


### PR DESCRIPTION
Closes #116

## What changed

The wiki now carries the same status banner as the README, generated from `ROADMAP.md` by the same script, and marks unimplemented commands 🚧 with the milestone and issue they arrive in.

## Why

`wiki/Getting-Started.md` said, in the present tense:

> `npm run demo` runs the entire pipeline — flakiness analysis, triage, root cause, fix suggestion, report generation — against a bundled fixture run, using recorded model responses. No network call is made and no credentials are needed.

None of that exists. The README marks the same command 🚧; the wiki had no such convention, so the claim was honest in one place and false in the more public one — and false about precisely the claim the Definition of Done rests on.

## Decisions worth reviewing

**One generator, three pages.** `scripts/status-banner.ts` now writes `README.md`, `wiki/Home.md` and `wiki/Getting-Started.md`. The alternative — a hand-written note on the wiki — is how the two surfaces disagreed in the first place. The wiki variant of the banner differs by one sentence, because it refers to markers on the page rather than to the README's script table.

**The demo section is kept, not deleted.** Deleting it until M3 would be honest and would lose the explanation of what replay mode is and, more importantly, **what it will not prove** — that it demonstrates the pipeline's plumbing, not what the model would say today. That paragraph is the reason the section is worth having. It is now framed as stated intent with the milestone attached.

**Leads with what runs today.** `npm run help`, `npm run test:unit`, `npm run eval:lint`, `npm run typecheck` — real commands, at the top, before anything aspirational. A reader who tries the first thing on the page should have it work.

## How it was verified

284 assertions. Two new:

- all three pages match what generation produces, so `docs:status:check` cannot pass locally and fail in CI
- every unimplemented pipeline command in the wiki quickstart carries a 🚧 marker — so the next command added without one fails rather than shipping

## Checklist

- [x] Title is a valid Conventional Commit
- [x] Linked to exactly one issue with `Closes #N`
- [x] `npm run lint && npm run format:check && npm run typecheck && npm run test:unit` clean
- [x] `wiki/README.md` documents the new convention

## Notes for the reviewer

The published wiki still has the old text until `./scripts/publish-wiki.sh` runs. I will publish immediately after this merges — the repository is the source of truth, but the stale claim is live right now, which is the part that actually matters.

Found by the audit rather than by a reader, which is the uncomfortable part: nothing in CI could have caught it, because the wiki was outside every check. It is inside them now.