### PR TITLE
chore(eval): drop the test-path list nothing read

### DIFF
--- a/eval/baseline.ts
+++ b/eval/baseline.ts
@@ -73,21 +73,19 @@ const CONFIDENCE = {
   noHistory: 0.3,
 } as const
 
-/** Paths in the diff, split into product source and test source. */
-function changedPaths(diff: string): { product: string[]; test: string[] } {
-  const paths = [...diff.matchAll(/^diff --git a\/(\S+) b\/\S+$/gm)].map((m) => m[1] ?? '')
-  return {
-    product: paths.filter(
+/** Product-source paths in the diff. Test and non-code paths are dropped. */
+function changedProductPaths(diff: string): string[] {
+  return [...diff.matchAll(/^diff --git a\/(\S+) b\/\S+$/gm)]
+    .map((m) => m[1] ?? '')
+    .filter(
       (p) => p !== '' && SOURCE_EXTENSION.test(p) && !TEST_PATH.test(p) && !NOT_PRODUCT.test(p),
-    ),
-    test: paths.filter((p) => p !== '' && TEST_PATH.test(p)),
-  }
+    )
 }
 
 export function classifyWithBaseline(payload: FixturePayload): Classification {
   const { result, signal } = payload.subject
   const message = `${result.error?.message ?? ''}\n${result.error?.stack ?? ''}`
-  const changed = changedPaths(payload.diff ?? '')
+  const changedProduct = changedProductPaths(payload.diff ?? '')
 
   const evidence: string[] = []
   let owner: Classification['owner']
@@ -100,11 +98,11 @@ export function classifyWithBaseline(payload: FixturePayload): Classification {
     ownerConfidence = CONFIDENCE.infrastructure
     ownerReason = 'the failure names an infrastructure error, so no assertion was reached'
     evidence.push(firstLine(message))
-  } else if (changed.product.length > 0) {
+  } else if (changedProduct.length > 0) {
     owner = 'app_code'
     ownerConfidence = CONFIDENCE.productDiff
     ownerReason = 'the commit changes product source'
-    evidence.push(`diff touches ${changed.product.slice(0, 3).join(', ')}`)
+    evidence.push(`diff touches ${changedProduct.slice(0, 3).join(', ')}`)
   } else if (LOCATOR_OR_WAIT.test(message)) {
     owner = 'test_code'
     ownerConfidence = CONFIDENCE.locator


### PR DESCRIPTION
Closes #118

## What changed

`changedPaths` returned `{ product, test }`; `test` was computed on every call and read nowhere. It is now `changedProductPaths`, returning an array.

## Why

ESLint does not catch this — an unused object property is not an unused variable — so it would have survived until someone read the function and wondered what the second field was for. In a module whose entire argument is that it is small enough to audit in one sitting, an unexplained field is a real cost.

## How it was verified

All 284 assertions pass **unchanged**. That is the interesting part: no test needed editing, which is what distinguishes dead weight from behaviour. Logic is still 55 lines.

## Checklist

- [x] Title is a valid Conventional Commit
- [x] Linked to exactly one issue with `Closes #N`
- [x] `npm run lint && npm run format:check && npm run typecheck && npm run test:unit` clean
- [x] No behaviour change — no test touched

## Notes for the reviewer

The rename is the substantive half. `changedPaths` returning only product paths would have been a smaller diff and a worse name — the next reader would reasonably assume it returns *all* changed paths and use it accordingly.

Found by the audit, not by a linter. Worth noting there is no rule that would catch the next one.