### PR TITLE
chore(release): regenerate the changelog and state when that happens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,34 @@ commitlint because a well-formed history needs them, but they are not release no
 
 ### Features
 
+- **agents:** add Classification, RootCause and FixSuggestion schemas ([#106](https://github.com/AKogut/ai-flaky-test-triage/pull/106))
 - **ci:** define the npm script contract ([#98](https://github.com/AKogut/ai-flaky-test-triage/pull/98))
+- **dataset:** add the golden-dataset fixture and label format ([#107](https://github.com/AKogut/ai-flaky-test-triage/pull/107))
+- **dataset:** add the golden-dataset hygiene lint ([#115](https://github.com/AKogut/ai-flaky-test-triage/pull/115))
+- **dataset:** author the 10 hard-quadrant fixtures ([#111](https://github.com/AKogut/ai-flaky-test-triage/pull/111))
+- **dataset:** author the 15 baseline golden-dataset fixtures ([#109](https://github.com/AKogut/ai-flaky-test-triage/pull/109))
+- **dataset:** author the 8 adversarial fixtures ([#114](https://github.com/AKogut/ai-flaky-test-triage/pull/114))
+- **eval:** add TestRun domain types and Zod schemas ([#102](https://github.com/AKogut/ai-flaky-test-triage/pull/102))
+- **eval:** add the non-LLM baseline classifier ([#110](https://github.com/AKogut/ai-flaky-test-triage/pull/110))
+- **eval:** normalise Playwright JSON reporter output ([#103](https://github.com/AKogut/ai-flaky-test-triage/pull/103))
+- **eval:** normalise Vitest JSON reporter output ([#104](https://github.com/AKogut/ai-flaky-test-triage/pull/104))
+- **flakemetry:** add FlakySignal and analysis.json schemas ([#105](https://github.com/AKogut/ai-flaky-test-triage/pull/105))
+- **release:** generate the changelog from Conventional Commits ([#100](https://github.com/AKogut/ai-flaky-test-triage/pull/100))
+
+### Fixes
+
+- **docs:** stop the wiki claiming unbuilt commands work ([#120](https://github.com/AKogut/ai-flaky-test-triage/pull/120))
+- **eval:** stop the baseline reading documentation as product source ([#113](https://github.com/AKogut/ai-flaky-test-triage/pull/113))
 
 ### Documentation
 
 - add architecture, taxonomy, evaluation methodology and ADRs ([cac77dc](https://github.com/AKogut/ai-flaky-test-triage/commit/cac77dcee2b2df2e4e6329e93df80dd2a066a5d7))
 - add wiki source pages and publish script ([98dccc8](https://github.com/AKogut/ai-flaky-test-triage/commit/98dccc82265c4dd5fbf128d6838126320082d63a))
+- derive the README status banner from ROADMAP.md ([#101](https://github.com/AKogut/ai-flaky-test-triage/pull/101))
+
+### Tests
+
+- **eval:** pin the reporter contract to committed real output ([#108](https://github.com/AKogut/ai-flaky-test-triage/pull/108))
 <!-- changelog:end -->
 
 ---

--- a/docs/branching-strategy.md
+++ b/docs/branching-strategy.md
@@ -136,8 +136,17 @@ covered by a test; is it the smallest change that works.
 Pre-1.0, the public surface is the CLI script contract and the `analysis.json` / fixture schemas.
 `v1.0.0` ships when the Definition of Done in the README is met end to end.
 
-Releases are cut from `main` by tagging. `CHANGELOG.md` is generated from Conventional Commits and
-committed as part of the release. GitHub Releases carry the changelog section plus the current
+Releases are cut from `main` by tagging. `CHANGELOG.md` is generated from Conventional Commits by
+`npm run changelog`.
+
+**When it is regenerated: at every milestone close, and at every release.** Deliberately not on
+every merge — that would make every open pull request conflict on `CHANGELOG.md`, and the cure
+would be worse than a file a few commits behind. Deliberately not never, either: "not per merge"
+without a stated alternative decays into "not at all", which is exactly what happened between M0
+and M2 (#117).
+
+`npm run changelog:check` fails when the committed file is behind `main`. It is run by hand at
+those two moments rather than in per-PR CI, for the same conflict reason. GitHub Releases carry the changelog section plus the current
 `eval/report.md` headline numbers — **the accuracy of the classifier is part of the release
 notes.**
 


### PR DESCRIPTION
Closes #117

## What changed

`CHANGELOG.md` regenerated — `npm run changelog:check` passes on `main` again — and `docs/branching-strategy.md` now names *when* regeneration happens.

## Why

The file had stopped at roughly #100 and contradicted its own header, which claims it is generated from `main`.

## The actual defect was the missing half of a decision

#11 decided not to regenerate on every merge, and that decision is still correct: it would make every open pull request conflict on `CHANGELOG.md`, and the cure would be worse than a file a few commits behind.

But "not per merge" was never turned into "at some specific moment", so it became "not at all" — visible between M0 and M2, where fourteen merged pull requests left no trace. A negative decision without a positive counterpart decays by default.

The documented moments are **milestone close** and **release**. Both are points where one person is already touching `main` deliberately and no pull requests are mid-flight, which is precisely the condition that makes the conflict argument not apply.

## How it was verified

```
$ npm run changelog:check
CHANGELOG.md is up to date
```

The regenerated Unreleased section carries 13 features, the fixes from #113 and #116, and correctly hides the `build`/`chore`/`ci` commits — the behaviour #11 specified, now exercised against 20 merged pull requests rather than the four it was written with.

284 assertions unchanged.

## Checklist

- [x] Title is a valid Conventional Commit
- [x] Linked to exactly one issue with `Closes #N`
- [x] `npm run lint && npm run format:check && npm run typecheck && npm run test:unit` clean
- [x] `docs/branching-strategy.md` updated

## Notes for the reviewer

Still not wired into per-PR CI, and the reason is now written down next to the rule rather than living in a pull-request description nobody will find. #87 makes it part of the release step.

This is the last of the four audit findings that were worth fixing now. The remaining two — no coverage floor, and the classifier's input type being named after the fixture format — are filed against the milestones where the work already lives.