### PR TITLE
feat(eval): score classifiers with joint accuracy and Wilson intervals

### DIFF
--- a/docs/eval-methodology.md
+++ b/docs/eval-methodology.md
@@ -56,6 +56,37 @@ This has two good outcomes and no bad one. If the agent wins, there is evidence 
 cost. If the baseline wins, that is a genuinely interesting finding that goes in the README, and
 the project demonstrates something rarer than a working classifier: a willingness to measure.
 
+### What it scores today
+
+Against the 33 committed fixtures, with 95% Wilson intervals:
+
+| Metric                | Baseline              | Macro-F1 |
+| --------------------- | --------------------- | -------- |
+| **Joint** (both axes) | **36.4% [22.2–53.4]** | —        |
+| `owner`               | 54.5% [38.0–70.2]     | 0.36     |
+| `determinism`         | 78.8% [62.2–89.3]     | 0.77     |
+
+Three things in that table are worth reading carefully, because they are the reason the metrics are
+shaped this way.
+
+**Joint accuracy is 18pp below the `owner` axis and 42pp below `determinism`.** Reporting either
+axis alone would describe a classifier that half works; 36.4% is how often it produces an answer a
+developer could act on without checking.
+
+**`test_code` has an F1 of exactly 0.** The baseline never once identifies a test-code failure —
+support 8, four predictions, none correct. Accuracy hides this completely; macro-F1 is what makes
+it visible, which is the argument for reporting both.
+
+**A classifier that answers `app_code` unconditionally beats it on `owner` accuracy**, 63.6%
+against 54.5%, because 21 of 33 fixtures are `app_code`. That is not a defect in the baseline — it
+is the adversarial dataset doing its job. The constant classifier's macro-F1 is 0.26 against the
+baseline's 0.36, so the baseline is genuinely better; accuracy alone simply cannot say so. And the
+two intervals overlap heavily, so at n=33 neither result is evidence of a difference at all. That
+is the honest reading, and it is also the argument for growing the dataset to 60.
+
+Every number above is pinned in `eval/metrics.test.ts`. A change to the rules or to the dataset
+fails the suite with the old and new values side by side.
+
 ## 2. An adversarial dataset
 
 `eval/golden-dataset/` targets **≥60 fixtures**, hand-labelled, with this composition:

--- a/eval/index.ts
+++ b/eval/index.ts
@@ -3,9 +3,10 @@
  *
  * Golden-dataset evaluation: the baseline heuristic, the metrics, and the harness that scores a classifier against ground truth.
  *
- * The implementation lands in M2; this file exists so the
- * workspace, its TypeScript project reference and its public entry point are
- * in place before anything depends on them.
+ * The harness and report writer land later in M2; the pieces below are the ones
+ * that exist.
  */
 
-export {}
+export * from './dataset.js'
+export * from './baseline.js'
+export * from './metrics.js'

--- a/eval/metrics.test.ts
+++ b/eval/metrics.test.ts
@@ -1,0 +1,415 @@
+import type { Determinism, Owner } from '@sentra/contracts'
+import { describe, expect, it } from 'vitest'
+import { classifyWithBaseline } from './baseline.js'
+import { loadAllPayloads, loadLabels } from './dataset.js'
+import {
+  formatProportion,
+  marginOfError,
+  proportion,
+  score,
+  wilsonInterval,
+  Z_95,
+  type Judgement,
+} from './metrics.js'
+
+/**
+ * The interval maths is checked two ways, because a formula transcribed wrongly
+ * still produces plausible numbers and every downstream check would pass.
+ *
+ * First against published reference values. Second — and this is the one that
+ * would catch a subtle algebra slip — against an independent derivation: Wilson
+ * is the set of p the score test does not reject, which is the root interval of
+ * `p²(n + z²) − p(2np̂ + z²) + np̂² = 0`. That route shares no arithmetic with
+ * the closed form under test.
+ */
+function wilsonViaQuadraticRoots(successes: number, n: number, z = Z_95): [number, number] {
+  const p = successes / n
+  const z2 = z * z
+  const a = n + z2
+  const b = -(2 * n * p + z2)
+  const c = n * p * p
+  const root = Math.sqrt(b * b - 4 * a * c)
+  return [(-b - root) / (2 * a), (-b + root) / (2 * a)]
+}
+
+describe('wilsonInterval against published values', () => {
+  // Brown, Cai & DasGupta (2001) give (0.018, 0.404) for 1 success in 10 —
+  // the worked example for why the normal approximation is unusable at n=10.
+  it('matches the 1-of-10 reference', () => {
+    const { lower, upper } = wilsonInterval(1, 10)
+    expect(lower).toBeCloseTo(0.017876, 6)
+    expect(upper).toBeCloseTo(0.40415, 5)
+  })
+
+  // Zero events in 20 trials. The one-sided rule of three approximates the upper
+  // bound as 3/20 = 0.15; Wilson's two-sided bound is a little above it.
+  it('matches the 0-of-20 reference', () => {
+    const { lower, upper } = wilsonInterval(0, 20)
+    expect(lower).toBe(0)
+    expect(upper).toBeCloseTo(0.161125, 6)
+  })
+
+  it('matches the 90-of-100 reference', () => {
+    const { lower, upper } = wilsonInterval(90, 100)
+    expect(lower).toBeCloseTo(0.825634, 6)
+    expect(upper).toBeCloseTo(0.944771, 6)
+  })
+
+  it('is symmetric about 0.5 at p = 0.5', () => {
+    const { lower, upper } = wilsonInterval(50, 100)
+    expect(lower).toBeCloseTo(0.403832, 6)
+    expect(upper).toBeCloseTo(0.596168, 6)
+    expect(lower + upper).toBeCloseTo(1, 12)
+  })
+})
+
+describe('wilsonInterval against an independent derivation', () => {
+  const cases: [number, number][] = []
+  for (const n of [1, 2, 3, 5, 10, 33, 60, 100, 997]) {
+    for (const k of [0, 1, Math.floor(n / 3), Math.floor(n / 2), n - 1, n]) {
+      if (k >= 0 && k <= n) cases.push([k, n])
+    }
+  }
+
+  it.each(cases)('agrees with the quadratic roots at %i/%i', (k, n) => {
+    const closedForm = wilsonInterval(k, n)
+    const [lower, upper] = wilsonViaQuadraticRoots(k, n)
+    expect(closedForm.lower).toBeCloseTo(Math.max(0, lower), 12)
+    expect(closedForm.upper).toBeCloseTo(Math.min(1, upper), 12)
+  })
+
+  it.each(cases)('brackets the point estimate at %i/%i', (k, n) => {
+    const { lower, upper } = wilsonInterval(k, n)
+    expect(lower).toBeLessThanOrEqual(k / n)
+    expect(upper).toBeGreaterThanOrEqual(k / n)
+  })
+
+  it.each(cases)('stays inside [0, 1] at %i/%i', (k, n) => {
+    const { lower, upper } = wilsonInterval(k, n)
+    expect(lower).toBeGreaterThanOrEqual(0)
+    expect(upper).toBeLessThanOrEqual(1)
+  })
+})
+
+describe('why Wilson and not the normal approximation', () => {
+  it('does not claim a proportion above certainty where the normal one does', () => {
+    // 57 of 60 is inside the range this project will report on. The textbook
+    // interval puts the upper bound at 100.5%, which is the whole argument.
+    const normalUpper = 57 / 60 + Z_95 * Math.sqrt(((57 / 60) * (3 / 60)) / 60)
+    expect(normalUpper).toBeGreaterThan(1)
+    expect(wilsonInterval(57, 60).upper).toBeLessThanOrEqual(1)
+    expect(wilsonInterval(57, 60).upper).toBeCloseTo(0.98285, 5)
+  })
+
+  it('still says something at the edges, where the normal one says nothing', () => {
+    // p̂(1-p̂) is 0 at both edges, so the normal interval has zero width and
+    // asserts certainty from a handful of observations.
+    expect(wilsonInterval(0, 10).upper).toBeCloseTo(0.277533, 6)
+    expect(wilsonInterval(10, 10).lower).toBeCloseTo(0.722467, 6)
+  })
+
+  it('narrows as the sample grows', () => {
+    const widths = [10, 30, 100, 1000].map((n) => {
+      const { lower, upper } = wilsonInterval(Math.round(n * 0.9), n)
+      return upper - lower
+    })
+    for (let i = 1; i < widths.length; i++) {
+      expect(widths[i]).toBeLessThan(widths[i - 1] ?? Infinity)
+    }
+  })
+})
+
+describe('degenerate inputs', () => {
+  it('treats an empty sample as unconstrained, not as zero', () => {
+    // [0, 0] would read as "measured 0%". The truth is "measured nothing".
+    expect(wilsonInterval(0, 0)).toEqual({ lower: 0, upper: 1 })
+    expect(proportion(0, 0).point).toBe(0)
+    expect(proportion(0, 0).interval).toEqual({ lower: 0, upper: 1 })
+  })
+
+  it('pins the lower bound at exactly 0 when nothing succeeded', () => {
+    // Arithmetic can land a few ulps below; a negative probability in a report
+    // destroys confidence in every other number on the page.
+    for (const n of [1, 7, 60, 1000]) expect(wilsonInterval(0, n).lower).toBe(0)
+  })
+
+  it('pins the upper bound at exactly 1 when everything succeeded', () => {
+    for (const n of [1, 7, 60, 1000]) expect(wilsonInterval(n, n).upper).toBe(1)
+  })
+
+  it.each([
+    ['a fractional count', 1.5, 10],
+    ['a fractional sample', 1, 10.5],
+    ['more successes than trials', 11, 10],
+    ['a negative count', -1, 10],
+    ['a negative sample', 0, -1],
+  ])('refuses %s', (_case, successes, n) => {
+    expect(() => wilsonInterval(successes, n)).toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+
+const judge = (
+  actual: [Owner, Determinism],
+  predicted: [Owner, Determinism],
+  name = 'f',
+): Judgement => ({
+  name,
+  actual: { owner: actual[0], determinism: actual[1] },
+  predicted: { owner: predicted[0], determinism: predicted[1] },
+})
+
+describe('per-class precision, recall and F1', () => {
+  /**
+   * Worked by hand so the expected numbers come from the definitions rather
+   * than from running the code and recording whatever it said.
+   *
+   *   #  actual       predicted
+   *   1  app_code     app_code     ✓
+   *   2  app_code     app_code     ✓
+   *   3  app_code     test_code    ✗
+   *   4  test_code    app_code     ✗
+   *   5  test_code    test_code    ✓
+   *   6  environment  app_code     ✗
+   *
+   *   app_code     support 3, predicted 4, TP 2 → P 0.5,  R 0.667, F1 0.571
+   *   test_code    support 2, predicted 2, TP 1 → P 0.5,  R 0.5,   F1 0.5
+   *   environment  support 1, predicted 0, TP 0 → P 0/0,  R 0,     F1 0
+   */
+  const judgements: Judgement[] = [
+    judge(['app_code', 'deterministic'], ['app_code', 'deterministic'], '1'),
+    judge(['app_code', 'deterministic'], ['app_code', 'deterministic'], '2'),
+    judge(['app_code', 'deterministic'], ['test_code', 'deterministic'], '3'),
+    judge(['test_code', 'deterministic'], ['app_code', 'deterministic'], '4'),
+    judge(['test_code', 'deterministic'], ['test_code', 'deterministic'], '5'),
+    judge(['environment', 'deterministic'], ['app_code', 'deterministic'], '6'),
+  ]
+
+  const owner = score(judgements).owner
+  const classOf = (label: string) => owner.classes.find((c) => c.label === label)
+
+  it('counts support and predictions separately', () => {
+    expect(classOf('app_code')).toMatchObject({ support: 3, predictedCount: 4, truePositives: 2 })
+    expect(classOf('test_code')).toMatchObject({ support: 2, predictedCount: 2, truePositives: 1 })
+    expect(classOf('environment')).toMatchObject({
+      support: 1,
+      predictedCount: 0,
+      truePositives: 0,
+    })
+  })
+
+  it('divides precision by predictions and recall by support', () => {
+    expect(classOf('app_code')?.precision.point).toBeCloseTo(0.5, 10)
+    expect(classOf('app_code')?.recall.point).toBeCloseTo(2 / 3, 10)
+  })
+
+  it('computes F1 as the harmonic mean', () => {
+    expect(classOf('app_code')?.f1).toBeCloseTo(0.5714285714, 9)
+    expect(classOf('test_code')?.f1).toBeCloseTo(0.5, 10)
+  })
+
+  it('reports a never-predicted class as found-nothing rather than as an error', () => {
+    // Precision is 0/0. Reporting 0 is a convention; the interval is what stays
+    // honest, because no predictions is no evidence, not evidence of being wrong.
+    const environment = classOf('environment')
+    expect(environment?.precision.point).toBe(0)
+    expect(environment?.precision.n).toBe(0)
+    expect(environment?.precision.interval).toEqual({ lower: 0, upper: 1 })
+    expect(environment?.recall.point).toBe(0)
+    expect(environment?.f1).toBe(0)
+  })
+
+  it('macro-averages over every class present in the truth', () => {
+    expect(owner.macroF1).toBeCloseTo((0.5714285714 + 0.5 + 0) / 3, 9)
+    expect(owner.macroF1Over).toEqual(['app_code', 'test_code', 'environment'])
+    expect(owner.macroF1Excluded).toEqual([])
+  })
+
+  it('accuracy counts whole fixtures', () => {
+    expect(owner.accuracy).toMatchObject({ successes: 3, n: 6 })
+  })
+})
+
+describe('macro-F1 when a class is missing from the dataset', () => {
+  const judgements = [
+    judge(['app_code', 'intermittent'], ['app_code', 'intermittent']),
+    judge(['test_code', 'intermittent'], ['test_code', 'intermittent']),
+  ]
+
+  it('leaves the absent class out and names it', () => {
+    // Including it would contribute an F1 of 0 and report a gap in the dataset
+    // as a failure of the classifier.
+    const owner = score(judgements).owner
+    expect(owner.macroF1).toBe(1)
+    expect(owner.macroF1Excluded).toEqual(['environment'])
+  })
+
+  it('still lists the absent class in the per-class table', () => {
+    // Excluded from the average, not hidden — the row is how a reader sees the
+    // dataset has no fixtures for it.
+    expect(score(judgements).owner.classes.map((c) => c.label)).toContain('environment')
+  })
+})
+
+describe('joint accuracy', () => {
+  it('is the headline: both axes right on the same fixture', () => {
+    const judgements = [
+      judge(['app_code', 'intermittent'], ['app_code', 'intermittent']),
+      judge(['app_code', 'intermittent'], ['app_code', 'deterministic']),
+      judge(['app_code', 'intermittent'], ['test_code', 'intermittent']),
+    ]
+    const m = score(judgements)
+    expect(m.owner.accuracy.successes).toBe(2)
+    expect(m.determinism.accuracy.successes).toBe(2)
+    expect(m.joint.successes).toBe(1)
+  })
+
+  it('is strictly lower when the two axes fail on different fixtures', () => {
+    // The case that makes reporting axes alone flattering: 67% and 67% here, but
+    // only one fixture in three is actually usable.
+    const m = score([
+      judge(['app_code', 'intermittent'], ['app_code', 'intermittent']),
+      judge(['app_code', 'intermittent'], ['test_code', 'intermittent']),
+      judge(['app_code', 'intermittent'], ['app_code', 'deterministic']),
+    ])
+    expect(m.joint.point).toBeLessThan(m.owner.accuracy.point)
+    expect(m.joint.point).toBeLessThan(m.determinism.accuracy.point)
+  })
+
+  it('equals the axes when every error lands on the same fixture', () => {
+    const m = score([
+      judge(['app_code', 'intermittent'], ['app_code', 'intermittent']),
+      judge(['app_code', 'intermittent'], ['test_code', 'deterministic']),
+    ])
+    expect(m.joint.point).toBe(m.owner.accuracy.point)
+  })
+
+  it('never exceeds either axis, over many random label sets', () => {
+    // An invariant, not a sample: if this ever fails, joint accuracy is being
+    // computed as something other than the conjunction.
+    const owners: Owner[] = ['app_code', 'test_code', 'environment']
+    const determinisms: Determinism[] = ['deterministic', 'intermittent']
+    let seed = 7
+    const next = (max: number): number => {
+      seed = (seed * 1103515245 + 12345) % 2147483648
+      return seed % max
+    }
+
+    for (let trial = 0; trial < 200; trial++) {
+      const judgements = Array.from({ length: 1 + next(20) }, () =>
+        judge(
+          [owners[next(3)] ?? 'app_code', determinisms[next(2)] ?? 'deterministic'],
+          [owners[next(3)] ?? 'app_code', determinisms[next(2)] ?? 'deterministic'],
+        ),
+      )
+      const m = score(judgements)
+      expect(m.joint.point).toBeLessThanOrEqual(m.owner.accuracy.point)
+      expect(m.joint.point).toBeLessThanOrEqual(m.determinism.accuracy.point)
+    }
+  })
+
+  it('handles an empty judgement set without dividing by zero', () => {
+    const m = score([])
+    expect(m.n).toBe(0)
+    expect(m.joint.interval).toEqual({ lower: 0, upper: 1 })
+    expect(m.owner.macroF1).toBe(0)
+    expect(Number.isNaN(m.owner.macroF1)).toBe(false)
+  })
+})
+
+describe('presentation', () => {
+  it('renders a proportion with its interval', () => {
+    expect(formatProportion(proportion(90, 100))).toBe('90.0% [82.6–94.5] n=100')
+  })
+
+  it('refuses to print a point estimate for an empty sample', () => {
+    // "0.0%" is a claim. An empty sample does not support one.
+    expect(formatProportion(proportion(0, 0))).toBe('n/a (n=0)')
+    expect(formatProportion(proportion(0, 0), { withN: false })).toBe('n/a')
+  })
+
+  it('reports the margin a reader looks for', () => {
+    // 30 of 33 is ±10.2pp — the number that tells a reader a 3pp movement
+    // between runs means nothing at this dataset size.
+    expect(marginOfError(proportion(30, 33))).toBeCloseTo(10.216, 3)
+  })
+})
+
+describe('the baseline scored against the committed dataset', () => {
+  const metrics = score(
+    loadAllPayloads().map(({ name, payload }) => {
+      const labels = loadLabels(name)
+      return {
+        name,
+        predicted: classifyWithBaseline(payload),
+        actual: { owner: labels.owner, determinism: labels.determinism },
+      }
+    }),
+  )
+
+  /**
+   * These numbers are pinned, not asserted loosely, so a change to either the
+   * baseline rules or the dataset arrives as a failure with a number in it. When
+   * one of these breaks, the question to answer in the PR is which of the two
+   * moved and whether the movement was intended.
+   */
+  it('records joint accuracy, the headline metric', () => {
+    expect(metrics.n).toBe(33)
+    expect(metrics.joint.successes).toBe(12)
+    expect(metrics.joint.point).toBeCloseTo(0.3636, 4)
+  })
+
+  it('shows joint accuracy well below either axis', () => {
+    // 54.5% and 78.8% look like a classifier that half works. 36.4% is how often
+    // it produces an answer a developer could act on, and it is the only one of
+    // the three that says so.
+    expect(metrics.owner.accuracy.successes).toBe(18)
+    expect(metrics.determinism.accuracy.successes).toBe(26)
+    expect(metrics.joint.point).toBeLessThan(metrics.owner.accuracy.point - 0.15)
+  })
+
+  it('reports an interval wide enough to forbid reading small movements', () => {
+    // ±15.6pp at n=33. Any comparison of two runs that differ by less than a
+    // third of the dataset is noise, and the interval is what says so out loud.
+    expect(marginOfError(metrics.joint)).toBeGreaterThan(15)
+    expect(metrics.joint.interval.lower).toBeCloseTo(0.2217, 3)
+    expect(metrics.joint.interval.upper).toBeCloseTo(0.5342, 3)
+  })
+
+  it('never finds a single test_code fixture, which accuracy alone hides', () => {
+    // The 7 stale-test fixtures all carry a real product diff, so the baseline
+    // calls them app_code — documented in docs/eval-methodology.md and left
+    // deliberately unfixed. The consequence is a class with F1 exactly 0.
+    const testCode = metrics.owner.classes.find((c) => c.label === 'test_code')
+    expect(testCode).toMatchObject({ support: 8, predictedCount: 4, truePositives: 0 })
+    expect(testCode?.f1).toBe(0)
+  })
+
+  it('is beaten on owner accuracy by answering "app_code" every time', () => {
+    // 21 of 33 fixtures are app_code, so the constant classifier scores 63.6%
+    // against the baseline's 54.5%. This is not a defect in the baseline — it is
+    // the adversarial dataset working as intended, and it is the clearest
+    // argument for why macro-F1 is reported next to accuracy: the constant
+    // classifier's macro-F1 is 0.26 against the baseline's 0.36.
+    const alwaysAppCode = score(
+      loadAllPayloads().map(({ name }) => {
+        const labels = loadLabels(name)
+        return {
+          name,
+          predicted: { owner: 'app_code' as const, determinism: 'deterministic' as const },
+          actual: { owner: labels.owner, determinism: labels.determinism },
+        }
+      }),
+    )
+    expect(alwaysAppCode.owner.accuracy.point).toBeGreaterThan(metrics.owner.accuracy.point)
+    expect(alwaysAppCode.owner.macroF1).toBeLessThan(metrics.owner.macroF1)
+  })
+
+  it('has overlapping intervals against that constant classifier, so neither wins', () => {
+    // The honest reading of the previous test. 54.5% [38.0–70.2] against
+    // 63.6% [46.6–77.8] is not evidence of a difference at n=33, and reporting
+    // the point estimates alone would invite exactly that claim.
+    expect(metrics.owner.accuracy.interval.upper).toBeGreaterThan(0.636)
+  })
+})

--- a/eval/metrics.ts
+++ b/eval/metrics.ts
@@ -1,0 +1,284 @@
+import { DeterminismSchema, OwnerSchema, type Determinism, type Owner } from '@sentra/contracts'
+
+/**
+ * Scoring a classifier against ground truth.
+ *
+ * Three decisions here are the difference between a number that means something
+ * and a number that only looks like it does.
+ *
+ * **Joint accuracy is the headline.** A fixture counts as correct only when both
+ * axes are right. Reporting `owner` and `determinism` separately and letting a
+ * reader take the higher one is the most natural way to accidentally flatter a
+ * classifier — a model that is 80% on each axis can be anywhere from 60% to 80%
+ * jointly, and the difference is exactly the cases where it got half the answer.
+ *
+ * **Every proportion carries a Wilson interval.** With 33 fixtures a point
+ * estimate is close to noise, and publishing one alone invites reading a 3pp
+ * move as progress.
+ *
+ * **Nothing is rounded here.** Rounding is a presentation decision and happens
+ * in the formatter, so a macro-average is not computed from already-rounded
+ * parts.
+ *
+ * What these intervals do *not* say is worth stating, because a confidence
+ * interval on a hand-built dataset is easy to over-read. The golden dataset is
+ * stratified by design — the bucket shares in docs/eval-methodology.md are
+ * targets, not the result of sampling anything. So an interval here answers
+ * "how much would this number move if the same process produced a different set
+ * of fixtures", not "how would this classifier do on CI failures in general".
+ * The second question is not one this dataset can answer, and
+ * docs/limitations-and-guardrails.md says so.
+ *
+ * Fixtures marked `lowConfidenceGroundTruth` are excluded from headline metrics
+ * and reported separately. That is a filter the caller applies, because this
+ * module deliberately knows nothing about the fixture format — it scores pairs
+ * of labels. The report writer in #27 owns that partition.
+ */
+
+// ---------------------------------------------------------------------------
+// Proportions and intervals
+// ---------------------------------------------------------------------------
+
+/** Two-sided 95%. `qnorm(0.975)`. */
+export const Z_95 = 1.959963984540054
+
+export interface Interval {
+  lower: number
+  upper: number
+}
+
+export interface Proportion {
+  successes: number
+  n: number
+  /**
+   * `successes / n`, and `0` when `n` is `0`.
+   *
+   * At `n = 0` this field carries no information and the interval — the full
+   * `[0, 1]` — is the honest statement. Formatters must not print a point
+   * estimate for an empty sample; `formatProportion` prints `n/a`.
+   */
+  point: number
+  interval: Interval
+}
+
+/**
+ * Wilson score interval for a binomial proportion.
+ *
+ * Wilson rather than the normal approximation `p̂ ± z·√(p̂(1-p̂)/n)`, which at the
+ * sizes this project reports is not a stylistic preference. At n = 60 the normal
+ * interval's upper bound crosses 1.0 once accuracy passes about 0.94 — it claims
+ * a proportion can exceed certainty. Publishing that in a document whose entire
+ * argument is statistical honesty would undo the argument.
+ *
+ * It also degrades gracefully at the edges, where the normal approximation
+ * collapses to a zero-width interval: 0 successes in 20 trials gives `[0, 0.161]`
+ * here, against the normal approximation's `[0, 0]`.
+ *
+ * The interval is the set of p for which the score test does not reject at
+ * level z — equivalently the roots of `p²(n + z²) − p(2np̂ + z²) + np̂² = 0`.
+ * The closed form below is algebraically identical; the test suite checks it
+ * against those roots computed independently.
+ */
+export function wilsonInterval(successes: number, n: number, z: number = Z_95): Interval {
+  if (!Number.isInteger(successes) || !Number.isInteger(n)) {
+    throw new Error(`wilsonInterval needs whole counts, got ${successes}/${n}`)
+  }
+  if (n < 0 || successes < 0 || successes > n) {
+    throw new Error(`wilsonInterval needs 0 <= successes <= n, got ${successes}/${n}`)
+  }
+
+  // No observations constrain nothing. Returning [0, 0] would read as "measured
+  // zero" when the truth is "measured nothing".
+  if (n === 0) return { lower: 0, upper: 1 }
+
+  const p = successes / n
+  const z2 = z * z
+  const denominator = 1 + z2 / n
+  const centre = (p + z2 / (2 * n)) / denominator
+  const halfWidth = (z / denominator) * Math.sqrt((p * (1 - p)) / n + z2 / (4 * n * n))
+
+  // The edges are set exactly rather than computed. Both are algebraic
+  // identities — at p̂ = 1 the half-width is z²/(2n·denominator), which is
+  // precisely what is left over from 1 − centre — but in floating point they
+  // come out a few ulps off, and `Math.min(1, …)` does not catch a value that
+  // drifted *inwards*. A reported upper bound of 0.9999999999999998, or a lower
+  // bound of 2.8e-17, is the kind of detail that makes a reader stop trusting
+  // every other number on the page.
+  return {
+    lower: successes === 0 ? 0 : clamp(centre - halfWidth),
+    upper: successes === n ? 1 : clamp(centre + halfWidth),
+  }
+}
+
+const clamp = (n: number): number => Math.min(1, Math.max(0, n))
+
+export function proportion(successes: number, n: number, z: number = Z_95): Proportion {
+  return {
+    successes,
+    n,
+    point: n === 0 ? 0 : successes / n,
+    interval: wilsonInterval(successes, n, z),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-class and per-axis
+// ---------------------------------------------------------------------------
+
+export interface ClassMetrics {
+  label: string
+  /** How many fixtures genuinely are this class. */
+  support: number
+  /** How many the classifier called this class. */
+  predictedCount: number
+  truePositives: number
+  /** Of the ones it called this class, how many were. Denominator is `predictedCount`. */
+  precision: Proportion
+  /** Of the ones that are this class, how many it found. Denominator is `support`. */
+  recall: Proportion
+  /** Harmonic mean of the two point estimates. `0` when both are `0`. */
+  f1: number
+}
+
+export interface AxisMetrics {
+  axis: string
+  accuracy: Proportion
+  /**
+   * Unweighted mean F1 across classes.
+   *
+   * Reported alongside accuracy because the class distribution is not uniform:
+   * `app_code` is roughly two thirds of the dataset, so a classifier that
+   * answered `app_code` unconditionally would post a respectable accuracy while
+   * being useless. Macro-F1 gives the rare classes equal weight and makes that
+   * strategy look as bad as it is.
+   */
+  macroF1: number
+  /** Classes the macro average was taken over — those with at least one fixture. */
+  macroF1Over: string[]
+  /**
+   * Classes left out for having no fixtures at all.
+   *
+   * A class absent from the dataset would otherwise contribute an F1 of 0 and
+   * drag the average down, which would report a gap in the *dataset* as a
+   * failure of the *classifier*. Naming them keeps that visible rather than
+   * silently narrowing the denominator.
+   */
+  macroF1Excluded: string[]
+  classes: ClassMetrics[]
+}
+
+export interface Metrics {
+  n: number
+  /**
+   * Both axes correct on the same fixture — the headline metric.
+   *
+   * Always less than or equal to either axis alone, which the test suite pins as
+   * an invariant rather than trusting it to stay true.
+   */
+  joint: Proportion
+  owner: AxisMetrics
+  determinism: AxisMetrics
+}
+
+/** One fixture's outcome. Carries no fixture format, only the two labels. */
+export interface Judgement {
+  name: string
+  predicted: { owner: Owner; determinism: Determinism }
+  actual: { owner: Owner; determinism: Determinism }
+}
+
+export function score(judgements: Judgement[], z: number = Z_95): Metrics {
+  const jointCorrect = judgements.filter(
+    (j) => j.predicted.owner === j.actual.owner && j.predicted.determinism === j.actual.determinism,
+  ).length
+
+  return {
+    n: judgements.length,
+    joint: proportion(jointCorrect, judgements.length, z),
+    owner: axisMetrics('owner', judgements, OwnerSchema.options, z),
+    determinism: axisMetrics('determinism', judgements, DeterminismSchema.options, z),
+  }
+}
+
+function axisMetrics(
+  axis: 'owner' | 'determinism',
+  judgements: Judgement[],
+  labels: readonly string[],
+  z: number,
+): AxisMetrics {
+  const correct = judgements.filter((j) => j.predicted[axis] === j.actual[axis]).length
+
+  const classes = labels.map((label): ClassMetrics => {
+    const support = judgements.filter((j) => j.actual[axis] === label).length
+    const predictedCount = judgements.filter((j) => j.predicted[axis] === label).length
+    const truePositives = judgements.filter(
+      (j) => j.predicted[axis] === label && j.actual[axis] === label,
+    ).length
+
+    const precision = proportion(truePositives, predictedCount, z)
+    const recall = proportion(truePositives, support, z)
+
+    return {
+      label,
+      support,
+      predictedCount,
+      truePositives,
+      precision,
+      recall,
+      f1: f1Of(precision, recall),
+    }
+  })
+
+  const counted = classes.filter((c) => c.support > 0)
+
+  return {
+    axis,
+    accuracy: proportion(correct, judgements.length, z),
+    macroF1: counted.length === 0 ? 0 : mean(counted.map((c) => c.f1)),
+    macroF1Over: counted.map((c) => c.label),
+    macroF1Excluded: classes.filter((c) => c.support === 0).map((c) => c.label),
+    classes,
+  }
+}
+
+/**
+ * Harmonic mean of precision and recall.
+ *
+ * Zero when both are zero, which is the convention rather than a derivation —
+ * the harmonic mean is undefined there. It is the right convention because the
+ * alternatives are worse: `NaN` poisons every average downstream, and `1` would
+ * reward a class the classifier never found and never guessed.
+ *
+ * A class the classifier never predicts has precision `0/0`, reported as `0` by
+ * the same convention in `proportion`. Its interval is still `[0, 1]`, which is
+ * the part that stays honest — no predictions means no evidence, not evidence of
+ * being wrong.
+ */
+function f1Of(precision: Proportion, recall: Proportion): number {
+  const sum = precision.point + recall.point
+  return sum === 0 ? 0 : (2 * precision.point * recall.point) / sum
+}
+
+const mean = (xs: number[]): number => xs.reduce((a, b) => a + b, 0) / xs.length
+
+// ---------------------------------------------------------------------------
+// Presentation
+// ---------------------------------------------------------------------------
+
+/**
+ * `"87.9% [76.0–94.5] n=33"`.
+ *
+ * An empty sample prints `n/a` rather than `0.0%`, because `0.0%` is a claim and
+ * an empty sample does not support one.
+ */
+export function formatProportion(p: Proportion, { withN = true } = {}): string {
+  if (p.n === 0) return withN ? 'n/a (n=0)' : 'n/a'
+  const pct = (x: number): string => (x * 100).toFixed(1)
+  const body = `${pct(p.point)}% [${pct(p.interval.lower)}–${pct(p.interval.upper)}]`
+  return withN ? `${body} n=${String(p.n)}` : body
+}
+
+/** Half the interval's width, in percentage points — the "±" a reader looks for. */
+export function marginOfError(p: Proportion): number {
+  return ((p.interval.upper - p.interval.lower) / 2) * 100
+}

--- a/wiki/Evaluation-Methodology.md
+++ b/wiki/Evaluation-Methodology.md
@@ -18,14 +18,18 @@ something.
 
 ## 1. A non-LLM baseline
 
-A deliberately simple heuristic — roughly thirty lines — classifies the same fixtures:
+A deliberately simple heuristic — roughly sixty lines — classifies the same fixtures:
 
 ```
 no assertion reached (crash / bind / install)   → environment
-diff touches the file under test                → app_code
-locator or timeout error                        → test_code
+the commit changes any non-test source file     → app_code
+locator or timeout error, not a value           → test_code
 otherwise                                       → app_code
 ```
+
+The second rule says **any** changed non-test source path, not "the file under test". A heuristic
+cannot map a test to the implementation it exercises, and the looser wording pointed in two
+opposite directions at once.
 
 Every agent number is reported next to it, and the **delta** is the headline, not the absolute.
 
@@ -36,6 +40,31 @@ something rarer than a working classifier.
 The baseline has a second job: on fork pull requests there is no API key, so it is the only
 classifier available. That forces it to be good enough for a human to read, which also makes it a
 fair control rather than a straw man.
+
+### What it scores today
+
+Against the 33 committed fixtures, with 95% Wilson intervals:
+
+| Metric                | Baseline              | Macro-F1 |
+| --------------------- | --------------------- | -------- |
+| **Joint** (both axes) | **36.4% [22.2–53.4]** | —        |
+| `owner`               | 54.5% [38.0–70.2]     | 0.36     |
+| `determinism`         | 78.8% [62.2–89.3]     | 0.77     |
+
+Joint accuracy sits 18pp below the `owner` axis and 42pp below `determinism` — reporting either
+axis alone would describe a classifier that half works.
+
+`test_code` has an F1 of exactly **0**: the baseline never once identifies a test-code failure.
+Accuracy hides that; macro-F1 is what makes it visible.
+
+And a classifier that answers `app_code` unconditionally beats it on `owner` accuracy — 63.6%
+against 54.5%, because 21 of 33 fixtures are `app_code`. That is the adversarial dataset doing its
+job rather than a defect in the baseline: on macro-F1 the constant classifier scores 0.26 against
+the baseline's 0.36. The intervals overlap heavily, so at n=33 neither result is evidence of a
+difference — which is the argument for growing the dataset to 60.
+
+Every number here is pinned in `eval/metrics.test.ts`, so a change to the rules or the dataset
+fails the build with the old and new values side by side.
 
 ## 2. An adversarial dataset
 


### PR DESCRIPTION
Closes #25.

`eval/metrics.ts` turns a list of (predicted, actual) label pairs into the numbers this project intends to publish. It knows nothing about the fixture format — it scores pairs of labels — so the same module will score the agent, the baseline, and any ablation variant without a special case for each.

## Joint accuracy is the headline

Both axes correct on the **same** fixture. A classifier that is 80% on each axis can be anywhere from 60% to 80% jointly, and the gap is precisely the fixtures where it got half the answer right. Reporting the axes separately and letting a reader take the higher one is the easiest way to flatter a classifier without writing anything false.

An invariant test asserts `joint ≤ min(owner, determinism)` across 200 randomised label sets — if joint accuracy is ever computed as something other than the conjunction, that fails.

## Wilson, and why it is not a stylistic preference

At n=60 the normal approximation's upper bound crosses 1.0 once accuracy passes about 0.94 — it claims a proportion can exceed certainty. A test pins that at 57/60, where the textbook interval reaches **100.5%** and Wilson reaches 98.3%. Publishing the former in a document whose entire argument is statistical honesty would undo the argument.

Wilson also stays informative at the edges, where the normal interval collapses to zero width because `p̂(1-p̂)` is 0 — asserting certainty from a handful of observations. Zero successes in 20 trials gives `[0, 0.161]` here against `[0, 0]`.

## The interval maths is checked two ways

A mistranscribed formula still produces plausible numbers, and every downstream assertion would pass. So:

1. **Against published values.** 1-of-10 gives `[0.018, 0.404]` — the Brown, Cai & DasGupta (2001) worked example. Plus 0-of-20, 90-of-100, and symmetry at p=0.5.
2. **Against an independent derivation.** Wilson is the set of p the score test does not reject, which is the root interval of `p²(n + z²) − p(2np̂ + z²) + np̂²`. The test computes those roots directly and compares, over a 45-case sweep from n=1 to n=997. That route shares no arithmetic with the closed form under test.

Writing the second one found a real defect. At p=0 and p=1 the bounds are exactly 0 and 1 algebraically, but in floating point they land a few ulps **inside** the range, where `Math.min(1, …)` does not catch them. The first draft reported an upper bound of `0.9999999999999998`. Both edges are now set exactly, and there is a test for each.

## Degenerate cases, decided rather than defaulted

| Case | Behaviour | Why |
| --- | --- | --- |
| `n = 0` | interval `[0, 1]`, `formatProportion` prints `n/a` | "measured nothing" is not "measured zero", and `0.0%` is a claim an empty sample cannot support |
| `p = 0` / `p = 1` | bound pinned exactly to 0 / 1 | algebraic identity; a reported `2.8e-17` makes a reader distrust every other number on the page |
| precision `0/0` | point `0`, interval `[0, 1]` | no predictions is no evidence, not evidence of being wrong |
| `P + R = 0` | F1 `0` | `NaN` poisons downstream averages; `1` would reward a class never found and never guessed |
| class with no fixtures | excluded from macro-F1, listed in `macroF1Excluded` and still shown in the per-class table | otherwise a gap in the *dataset* is reported as a failure of the *classifier* |

## First real numbers

Scoring the existing baseline over the 33 committed fixtures, now pinned in `eval/metrics.test.ts`:

| Metric | Baseline | Macro-F1 |
| --- | --- | --- |
| **Joint** | **36.4% [22.2–53.4]** | — |
| `owner` | 54.5% [38.0–70.2] | 0.36 |
| `determinism` | 78.8% [62.2–89.3] | 0.77 |

Two findings I would rather record than smooth over:

**`test_code` has an F1 of exactly 0.** Support 8, four predictions, none correct — the baseline never once identifies a test-code failure. Accuracy hides this completely. This is the concrete argument for reporting macro-F1 next to it.

**A classifier that answers `app_code` unconditionally beats the baseline on owner accuracy** — 63.6% against 54.5%, because 21 of 33 fixtures are `app_code`. That is the adversarial dataset doing its job rather than a defect in the control: on macro-F1 the constant classifier scores 0.26 against the baseline's 0.36, so the baseline is genuinely better and accuracy alone cannot say so. And both intervals overlap heavily, so at n=33 neither result is evidence of a difference at all. That is the honest reading, and it is the argument for growing the dataset to 60.

## What the intervals do not claim

Stated in the module header, because a confidence interval on a hand-built dataset is easy to over-read. The golden dataset is stratified by design — the bucket shares are targets, not the result of sampling. So an interval here answers "how much would this move if the same process produced a different set of fixtures", not "how would this generalise to CI failures in general". The second question is not one this dataset can answer.

## Scope

Deliberately not here: confusion matrices and per-quadrant breakdown (#26), the CLI and `eval/report.md` (#27). The `lowConfidenceGroundTruth` partition is a caller-side filter, so this module stays free of the fixture format; #27 owns it.

## Also fixed

The wiki's baseline pseudocode still carried the wording `docs/eval-methodology.md` had already corrected as ambiguous — "diff touches the file under test", which points at the spec and the implementation simultaneously — and said thirty lines where the implementation is sixty.

## Verification

`npx eslint .`, `npx tsc --build`, `npm run eval:lint`, `npm run docs:status:check` all clean. **489 unit tests pass**, up from 290.
