### PR TITLE
chore(deps): hold @types/node to the Node major the project runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,14 @@ updates:
       - dependency-name: 'lint-staged'
         update-types: ['version-update:semver-major']
 
+      # @types/node is versioned by Node major, so its major has to track
+      # engines.node rather than the newest release. @types/node@26 declares
+      # node:ffi and node:quic, which Node 22 does not have — importing them
+      # would type-check and then throw. Held until the runtime floor moves;
+      # tests/unit/node-floor.test.ts fails if the two ever disagree.
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
+
   - package-ecosystem: github-actions
     directory: '/'
     schedule:

--- a/tests/unit/node-floor.test.ts
+++ b/tests/unit/node-floor.test.ts
@@ -20,7 +20,10 @@ import { describe, expect, it } from 'vitest'
 const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const read = (file: string): string => readFileSync(join(root, file), 'utf8')
 
-const packageJson = JSON.parse(read('package.json')) as { engines: { node: string } }
+const packageJson = JSON.parse(read('package.json')) as {
+  engines: { node: string }
+  devDependencies: Record<string, string>
+}
 
 /** `">=22.13"` → `"22.13"`. The comparator is fixed; only the version travels. */
 const declaredFloor = (): string => {
@@ -68,5 +71,30 @@ describe('the documented Node floor', () => {
     const [major = 0, minor = 0] = floor.split('.').map(Number)
     expect(major).toBeGreaterThanOrEqual(22)
     if (major === 22) expect(minor).toBeGreaterThanOrEqual(13)
+  })
+})
+
+describe('@types/node tracks the runtime, not the newest release', () => {
+  /**
+   * DefinitelyTyped versions `@types/node` by Node major, so the types describe
+   * one specific runtime's API surface. Taking a newer major than the project
+   * runs is not a harmless upgrade — it is the compiler agreeing to calls that
+   * do not exist.
+   *
+   * Concretely: `@types/node@26` declares `node:ffi` and `node:quic`, neither of
+   * which Node 22 has. Under those types an import from `node:quic` type-checks
+   * cleanly and throws `ERR_UNKNOWN_BUILTIN_MODULE` at runtime — the compiler
+   * turned from a check into a rubber stamp, silently.
+   */
+  const range = packageJson.devDependencies['@types/node']
+
+  it('is declared at all', () => {
+    expect(range).toBeDefined()
+  })
+
+  it('has the same major as engines.node', () => {
+    const typesMajor = /(\d+)/.exec(range ?? '')?.[1]
+    const runtimeMajor = declaredFloor().split('.')[0]
+    expect(typesMajor).toBe(runtimeMajor)
   })
 })


### PR DESCRIPTION
Rejects #127 and makes the rejection enforceable.

## The proposal

Dependabot offered `@types/node` 22.20.1 → **26.1.2**. CI was green, so it looked like an ordinary bump.

## Why not

DefinitelyTyped versions `@types/node` by **Node major** — the package describes one specific runtime's API surface, not "the latest types". This project declares `engines.node: ">=22.13"` and CI runs Node 22. Taking types four majors ahead does not add safety; it removes it, because the compiler starts agreeing to calls that do not exist.

That is measurable rather than theoretical. Diffing the module declarations between the two versions:

```
$ comm -13 <(ls @types/node@22.20.1/*.d.ts) <(ls @types/node@26.1.2/*.d.ts)
ffi.d.ts
quic.d.ts
```

Neither `node:ffi` nor `node:quic` exists in Node 22. Under `@types/node@26`, this type-checks cleanly:

```ts
import { QuicEndpoint } from 'node:quic'
```

and throws `ERR_UNKNOWN_BUILTIN_MODULE` at runtime — on the exact Node version `engines.node` promises to support. A typechecker that passes code which cannot run is worse than no typechecker, because it is trusted.

## What this PR does

Holds the major until the runtime floor moves, with the reason written next to the ignore entry rather than left for someone to rediscover in six months. Minor and patch updates on the 22 line still flow normally, and 22.20.1 is already current.

A comment is not a constraint, so `tests/unit/node-floor.test.ts` now asserts the `@types/node` major and the `engines.node` major agree. Verified by mutation — setting the range to `^26` fails with `expected '26' to be '22'`.

This sits alongside the Node floor checks added in #125 because it is the same class of problem: several places claiming a runtime version, and nothing making them agree.

## Verification

`npx eslint .`, `npx tsc --build`, `npx prettier --check .` clean. **491 unit tests pass**, up from 489.
