### PR TITLE
chore(ci): enforce unit coverage floors

### DIFF
--- a/docs/branching-strategy.md
+++ b/docs/branching-strategy.md
@@ -103,7 +103,7 @@ with an eval delta in the PR body. Prompts are code.
 
 **Requirements before merge**
 
-1. Green CI: lint, typecheck, unit, e2e, contract.
+1. Green CI: lint, typecheck, unit (including coverage floors), e2e, contract.
 2. Eval gate green when the PR touches `agents/`, `eval/`, or `prompts/`.
 3. PR description follows the template, links its issue, and states how the change was verified.
 4. Prompt/agent changes include the before/after eval table in the description.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,12 @@ export default defineConfig({
       reporter: ['text-summary', 'lcov'],
       reportsDirectory: 'coverage',
       exclude: ['**/dist/**', '**/*.config.*', 'scripts/**', 'tests/**'],
+      thresholds: {
+        statements: 87, // 91.89% when the floor was introduced.
+        branches: 77, // 83.63% when the floor was introduced.
+        functions: 90, // 95.55% when the floor was introduced.
+        lines: 88, // 92.42% when the floor was introduced.
+      },
     },
   },
 })


### PR DESCRIPTION
Closes #123

## What changed

Vitest now enforces global coverage floors a few points below the measured baseline, with the introduction baseline recorded beside each value. The branching guide also names coverage floors among merge requirements.

## Why

CI already measured coverage but could not block a regression. These thresholds turn that existing signal into the repository's normal gates-over-promises contract without chasing 100% or setting floors exactly at today's numbers.

## How it was verified

```bash
npm run lint
npm run typecheck
npm run format:check
npm run test:unit -- --coverage
```

All checks passed. Unit coverage ran 15 files / 491 tests and measured:

- statements: 91.89% (floor 87%)
- branches: 83.63% (floor 77%)
- functions: 95.55% (floor 90%)
- lines: 92.42% (floor 88%)

For the required failing-direction proof, I temporarily added uncovered exported functions locally and reran the same coverage command. All 491 tests still passed, but the command exited 1 because function coverage fell to 86%, below the 90% floor. That temporary mutation was then removed.

## Checklist

- [x] Title is a valid Conventional Commit with a documented scope
- [x] Linked to exactly one issue with `Closes #123`
- [x] `npm run lint && npm run typecheck` clean
- [x] The gate was verified in both passing and failing directions
- [x] Merge-requirement documentation was updated
- [x] Under 400 changed lines

## Notes for the reviewer

The floors intentionally leave 4–6 points of headroom from the introduction baseline. Review is most useful on whether that buffer is appropriately conservative for this repository.
