### PR TITLE
feat(eval): add confusion matrices, quadrants and grouped breakdowns

### DIFF
--- a/docs/eval-methodology.md
+++ b/docs/eval-methodology.md
@@ -110,6 +110,40 @@ a prose justification for the label, and the rules from
 `mutated` (a captured run with an injected defect). Metrics are broken down by provenance —
 if the agent only performs on synthetic fixtures, that is visible.
 
+### Evidence the buckets do what they claim
+
+A bucket that says it "punishes diff-only reasoning" is a claim, not a fact, until something is
+measured against it. Scoring the baseline per bucket is that measurement:
+
+| Bucket                      |   n | Joint  | `owner` | `determinism` |
+| --------------------------- | --: | ------ | ------- | ------------- |
+| `straightforward`           |   8 | 100.0% | 100.0%  | 100.0%        |
+| `hard-quadrant`             |  10 | 30.0%  | 60.0%   | 70.0%         |
+| `stale-test`                |   7 | 0.0%   | 0.0%    | 100.0%        |
+| `misleading-history`        |   4 | 0.0%   | 75.0%   | 0.0%          |
+| `environment-as-regression` |   4 | 25.0%  | 25.0%   | 100.0%        |
+
+Each adversarial bucket defeats the baseline **on the axis it was built to attack, and only that
+axis**:
+
+- `stale-test` targets diff-only reasoning about ownership. Owner drops to 0%; determinism stays
+  at 100%.
+- `misleading-history` targets flakiness-score-only reasoning about stability. Determinism drops
+  to 0%; owner stays at a respectable 75%.
+- `environment-as-regression` targets diff-only reasoning again, from the other direction, and
+  takes owner to 25% while determinism is untouched.
+
+That orthogonality is the part worth noticing. Buckets that all failed together would mean the
+fixtures were simply hard, or simply badly written. Failing on precisely the intended axis is what
+distinguishes an adversarial dataset from a difficult one.
+
+`straightforward` at 100% is the control on the control: it says the baseline is a working
+classifier rather than a broken one, so the failures above are properties of the fixtures rather
+than of the code being measured.
+
+The full confusion matrices and quadrant table are regenerated into `eval/report.md`; the numbers
+here are pinned in `eval/confusion.test.ts`.
+
 ## 3. Reported uncertainty
 
 Two independent sources of noise, both measured.

--- a/eval/confusion.test.ts
+++ b/eval/confusion.test.ts
@@ -1,0 +1,388 @@
+import type { Determinism, FixtureLabels, Owner } from '@sentra/contracts'
+import { format } from 'prettier'
+import { describe, expect, it } from 'vitest'
+import { classifyWithBaseline } from './baseline.js'
+import {
+  confusionMatrix,
+  partitionByGroundTruthConfidence,
+  quadrantBreakdown,
+  renderBreakdown,
+  renderBreakdownSections,
+  renderConfusionMatrix,
+  renderQuadrantTable,
+  scoreBy,
+  type ScoredFixture,
+} from './confusion.js'
+import { loadAllPayloads, loadLabels } from './dataset.js'
+import type { Judgement } from './metrics.js'
+
+const judge = (
+  actual: [Owner, Determinism],
+  predicted: [Owner, Determinism],
+  name = 'f',
+): Judgement => ({
+  name,
+  actual: { owner: actual[0], determinism: actual[1] },
+  predicted: { owner: predicted[0], determinism: predicted[1] },
+})
+
+describe('confusionMatrix orientation', () => {
+  /**
+   * Deliberately asymmetric: one fixture that is `app_code` and was called
+   * `test_code`, and nothing in the opposite cell. A transposed implementation
+   * passes every symmetric test ever written, and inverts precision and recall
+   * while producing a table that looks entirely reasonable.
+   */
+  const judgements = [
+    judge(['app_code', 'deterministic'], ['test_code', 'deterministic'], 'a'),
+    judge(['app_code', 'deterministic'], ['app_code', 'deterministic'], 'b'),
+  ]
+  const matrix = confusionMatrix(judgements, 'owner')
+
+  it('indexes counts as [actual][predicted]', () => {
+    const actualAppCode = matrix.labels.indexOf('app_code')
+    const predictedTestCode = matrix.labels.indexOf('test_code')
+    expect(matrix.counts[actualAppCode]?.[predictedTestCode]).toBe(1)
+    expect(matrix.counts[predictedTestCode]?.[actualAppCode]).toBe(0)
+  })
+
+  it('totals rows by support and columns by prediction count', () => {
+    expect(matrix.rowTotals).toEqual([2, 0, 0])
+    expect(matrix.columnTotals).toEqual([1, 1, 0])
+    expect(matrix.total).toBe(2)
+  })
+
+  it('covers every fixture exactly once', () => {
+    const cells = matrix.counts.flat().reduce((a, b) => a + b, 0)
+    expect(cells).toBe(matrix.total)
+  })
+
+  it('has one row and column per schema value, present or not', () => {
+    expect(confusionMatrix([], 'owner').labels).toHaveLength(3)
+    expect(confusionMatrix([], 'determinism').labels).toHaveLength(2)
+  })
+})
+
+describe('rendering a confusion matrix', () => {
+  const rendered = renderConfusionMatrix(
+    confusionMatrix(
+      [
+        judge(['app_code', 'deterministic'], ['app_code', 'deterministic'], 'a'),
+        judge(['test_code', 'deterministic'], ['app_code', 'deterministic'], 'b'),
+      ],
+      'owner',
+    ),
+  )
+
+  it('says which axis is which, in the table itself', () => {
+    // A reader who takes the transposed reading gets a plausible, wrong answer.
+    expect(rendered).toContain('actual ↓ / predicted →')
+    expect(rendered).toMatch(/Rows are ground truth/)
+  })
+
+  it('bolds the diagonal so the error shape is visible before the numbers', () => {
+    expect(rendered).toContain('**1**')
+  })
+
+  it('carries row and column totals', () => {
+    expect(rendered).toContain('**total**')
+    expect(rendered).toContain('**2**')
+  })
+})
+
+describe('quadrant breakdown', () => {
+  const judgements = [
+    ...Array.from({ length: 3 }, (_, i) =>
+      judge(['app_code', 'intermittent'], ['app_code', 'intermittent'], `hit${String(i)}`),
+    ),
+    judge(['app_code', 'intermittent'], ['app_code', 'deterministic'], 'miss'),
+    judge(['test_code', 'deterministic'], ['test_code', 'deterministic'], 'other'),
+  ]
+  const rows = quadrantBreakdown(judgements)
+  const hard = rows.find((r) => r.hard)
+
+  it('reports all six cells whether or not they have fixtures', () => {
+    expect(rows).toHaveLength(6)
+    expect(rows.filter((r) => r.support === 0)).not.toHaveLength(0)
+  })
+
+  it('flags exactly one quadrant as hard', () => {
+    expect(rows.filter((r) => r.hard)).toHaveLength(1)
+    expect(hard).toMatchObject({ owner: 'app_code', determinism: 'intermittent' })
+  })
+
+  it('counts a quadrant hit only when both axes land in it', () => {
+    // The `miss` fixture is app_code and intermittent, and the classifier got
+    // the owner right. It is still not a hit.
+    expect(hard).toMatchObject({ support: 4, correct: 3 })
+  })
+
+  it('renders the hard quadrant in bold with a legend', () => {
+    const rendered = renderQuadrantTable(rows)
+    expect(rendered).toContain('**`app_code` + `intermittent`**')
+    expect(rendered).toContain('hard quadrant')
+  })
+
+  it('prints n/a for a quadrant with no fixtures rather than 0%', () => {
+    // 0% would read as failing cases that do not exist.
+    expect(renderQuadrantTable(rows)).toContain('n/a')
+  })
+})
+
+describe('grouped breakdowns', () => {
+  const judgements = [
+    judge(['app_code', 'intermittent'], ['app_code', 'intermittent'], 'a'),
+    judge(['test_code', 'deterministic'], ['app_code', 'deterministic'], 'b'),
+    judge(['test_code', 'deterministic'], ['test_code', 'deterministic'], 'c'),
+  ]
+
+  it('scores each group independently', () => {
+    const groups = scoreBy(judgements, (j) => (j.name === 'a' ? 'first' : 'second'))
+    expect(groups.map((g) => g.group)).toEqual(['first', 'second'])
+    expect(groups[0]?.metrics.joint.point).toBe(1)
+    expect(groups[1]?.metrics.joint.point).toBe(0.5)
+  })
+
+  it('sorts groups so the report does not churn between runs', () => {
+    const groups = scoreBy(judgements, (j) => ({ a: 'zeta', b: 'alpha', c: 'mid' })[j.name] ?? '')
+    expect(groups.map((g) => g.group)).toEqual(['alpha', 'mid', 'zeta'])
+  })
+
+  it('replaces a single-group table with a sentence explaining why', () => {
+    // One row is not a breakdown; it restates the headline in a layout that
+    // looks like analysis.
+    const rendered = renderBreakdown(
+      'provenance',
+      scoreBy(judgements, () => 'synthetic'),
+      3,
+    )
+    expect(rendered).not.toContain('|')
+    expect(rendered).toContain('`synthetic`')
+    expect(rendered).toContain('repeat the headline')
+  })
+
+  it('renders a table once the dimension has more than one value', () => {
+    const rendered = renderBreakdown(
+      'bucket',
+      scoreBy(judgements, (j) => (j.name === 'a' ? 'hard-quadrant' : 'stale-test')),
+      3,
+    )
+    expect(rendered).toContain('| bucket')
+    expect(rendered).toContain('`hard-quadrant`')
+  })
+
+  it('says so plainly when there is nothing to break down', () => {
+    expect(renderBreakdown('provenance', [], 0)).toContain('No fixtures')
+  })
+})
+
+// ---------------------------------------------------------------------------
+
+const labelsFor = (over: Partial<FixtureLabels> = {}): FixtureLabels => ({
+  name: 'f',
+  owner: 'app_code',
+  determinism: 'intermittent',
+  justification: 'x'.repeat(200),
+  ruleApplied: 'rule-4-default-app-code',
+  provenance: 'synthetic',
+  bucket: 'hard-quadrant',
+  lowConfidenceGroundTruth: false,
+  ...over,
+})
+
+describe('low-confidence ground truth', () => {
+  const fixtures: ScoredFixture[] = [
+    {
+      judgement: judge(['app_code', 'intermittent'], ['app_code', 'intermittent'], 'solid'),
+      labels: labelsFor(),
+    },
+    {
+      judgement: judge(['app_code', 'intermittent'], ['test_code', 'deterministic'], 'arguable'),
+      labels: labelsFor({
+        name: 'arguable',
+        lowConfidenceGroundTruth: true,
+        justification: `Either reading is defensible here. ${'x'.repeat(150)}`,
+      }),
+    },
+  ]
+
+  it('keeps arguable fixtures out of the headline set', () => {
+    const { headline, lowConfidence } = partitionByGroundTruthConfidence(fixtures)
+    expect(headline.map((f) => f.judgement.name)).toEqual(['solid'])
+    expect(lowConfidence.map((f) => f.judgement.name)).toEqual(['arguable'])
+  })
+
+  it('scores them separately rather than dropping them', () => {
+    // Excluded from the headline is not the same as unreported. A disputed label
+    // must not be able to quietly improve the number.
+    const rendered = renderBreakdownSections(fixtures)
+    expect(rendered).toContain('`arguable`')
+    expect(rendered).toContain('Either reading is defensible here')
+    expect(rendered).toContain('Joint accuracy on these')
+  })
+
+  it('treats an empty exclusion list as a fact about the dataset, not a success', () => {
+    const rendered = renderBreakdownSections(
+      fixtures.filter((f) => !f.labels.lowConfidenceGroundTruth),
+    )
+    expect(rendered).toContain('No fixture is currently marked')
+    expect(rendered).toContain('may simply be avoiding the hard cases')
+  })
+
+  it('counts the excluded fixture out of the breakdown totals too', () => {
+    // Excluding from the headline has to mean excluding everywhere the headline
+    // is decomposed, or the sections would not add up to it.
+    const rendered = renderBreakdownSections(fixtures)
+    expect(rendered).toContain('The only fixture has one provenance')
+  })
+})
+
+// ---------------------------------------------------------------------------
+
+const dataset: ScoredFixture[] = loadAllPayloads().map(({ name, payload }) => {
+  const labels = loadLabels(name)
+  const predicted = classifyWithBaseline(payload)
+  return {
+    judgement: {
+      name,
+      predicted: { owner: predicted.owner, determinism: predicted.determinism },
+      actual: { owner: labels.owner, determinism: labels.determinism },
+    },
+    labels,
+  }
+})
+const judgements = dataset.map((f) => f.judgement)
+
+describe('the baseline against the committed dataset', () => {
+  it('pins the owner confusion matrix', () => {
+    // Rows app_code / test_code / environment, columns the same.
+    expect(confusionMatrix(judgements, 'owner').counts).toEqual([
+      [17, 4, 0],
+      [8, 0, 0],
+      [3, 0, 1],
+    ])
+  })
+
+  it('pins the determinism confusion matrix', () => {
+    expect(confusionMatrix(judgements, 'determinism').counts).toEqual([
+      [17, 4],
+      [3, 9],
+    ])
+  })
+
+  it('shows the whole `test_code` row collapsing into `app_code`', () => {
+    // Eight fixtures, every one called app_code. This is the single most
+    // informative cell in the report and accuracy alone never shows it.
+    const matrix = confusionMatrix(judgements, 'owner')
+    const row = matrix.counts[matrix.labels.indexOf('test_code')]
+    expect(row).toEqual([8, 0, 0])
+  })
+
+  it('scores 3 of 10 on the hard quadrant', () => {
+    // The project's thesis number. The baseline being poor here is the dataset
+    // working, not the control being unfair.
+    const hard = quadrantBreakdown(judgements).find((r) => r.hard)
+    expect(hard).toMatchObject({ support: 10, correct: 3 })
+    expect(hard?.accuracy.point).toBeCloseTo(0.3, 10)
+  })
+
+  it('has an empty quadrant, so the n/a path is exercised by real data', () => {
+    const empty = quadrantBreakdown(judgements).filter((r) => r.support === 0)
+    expect(empty.map((r) => `${r.owner}+${r.determinism}`)).toEqual(['test_code+intermittent'])
+  })
+
+  const byBucket = scoreBy(judgements, (j) => {
+    const labels = dataset.find((f) => f.judgement.name === j.name)?.labels
+    return labels?.bucket ?? 'unknown'
+  })
+  const bucket = (name: string) => byBucket.find((g) => g.group === name)?.metrics
+
+  it('covers every bucket the dataset currently has', () => {
+    expect(byBucket.map((g) => g.group)).toEqual([
+      'environment-as-regression',
+      'hard-quadrant',
+      'misleading-history',
+      'stale-test',
+      'straightforward',
+    ])
+  })
+
+  /**
+   * These are the numbers docs/eval-methodology.md publishes as evidence that the
+   * buckets do what they claim. Pinning them here is what makes that claim
+   * checkable rather than asserted — and each assertion below is really a claim
+   * about the *dataset*, not about the baseline.
+   */
+  it('passes every straightforward case, which is the control on the control', () => {
+    // A baseline that failed these would be broken, and every failure below
+    // would say nothing about the fixtures.
+    expect(bucket('straightforward')?.joint.point).toBe(1)
+  })
+
+  it('is defeated by stale-test on owner alone, the axis that bucket attacks', () => {
+    expect(bucket('stale-test')?.owner.accuracy.point).toBe(0)
+    expect(bucket('stale-test')?.determinism.accuracy.point).toBe(1)
+  })
+
+  it('is defeated by misleading-history on determinism alone', () => {
+    // The mirror image of the previous case. Both buckets failing on both axes
+    // would mean the fixtures were merely hard; failing on precisely the
+    // intended axis is what makes them adversarial.
+    expect(bucket('misleading-history')?.determinism.accuracy.point).toBe(0)
+    expect(bucket('misleading-history')?.owner.accuracy.point).toBeCloseTo(0.75, 10)
+  })
+
+  it('is defeated by environment-as-regression on owner, leaving determinism intact', () => {
+    expect(bucket('environment-as-regression')?.owner.accuracy.point).toBeCloseTo(0.25, 10)
+    expect(bucket('environment-as-regression')?.determinism.accuracy.point).toBe(1)
+  })
+
+  it('scores 30% joint on the hard quadrant bucket', () => {
+    expect(bucket('hard-quadrant')?.joint.point).toBeCloseTo(0.3, 10)
+    expect(bucket('hard-quadrant')?.owner.accuracy.point).toBeCloseTo(0.6, 10)
+  })
+
+  it('declines to print a provenance breakdown while every fixture is synthetic', () => {
+    const rendered = renderBreakdownSections(dataset)
+    expect(rendered).toContain('All 33 fixtures share one provenance')
+    expect(rendered).toContain('### By difficulty bucket')
+  })
+})
+
+describe('the rendered markdown', () => {
+  const report = [
+    '#### `owner`',
+    '',
+    renderConfusionMatrix(confusionMatrix(judgements, 'owner')),
+    '',
+    '#### `determinism`',
+    '',
+    renderConfusionMatrix(confusionMatrix(judgements, 'determinism')),
+    '',
+    '### Per quadrant',
+    '',
+    renderQuadrantTable(quadrantBreakdown(judgements)),
+    '',
+    renderBreakdownSections(dataset),
+    '',
+  ].join('\n')
+
+  it('is already formatted the way Prettier would format it', async () => {
+    // eval/report.md is generated and then checked by `npm run format:check`.
+    // Emitting anything Prettier would rewrite turns every regeneration into a
+    // CI failure, so the renderer matches its padding rather than hoping.
+    expect(await format(report, { parser: 'markdown' })).toBe(report)
+  })
+
+  it('pads columns by code point, which is what Prettier counts', async () => {
+    // The header contains ↓ and →. Measuring with .length mis-pads every row in
+    // any table whose header has one, and the file fails its own format check.
+    //
+    // A bare table is not a whole document, so the one permitted difference is
+    // the trailing newline Prettier ends a file with. Asserting that exact
+    // difference rather than trimming keeps the padding claim intact.
+    const withArrows = renderConfusionMatrix(confusionMatrix(judgements, 'owner'))
+    expect(withArrows).toContain('↓')
+    expect(await format(withArrows, { parser: 'markdown' })).toBe(`${withArrows}\n`)
+  })
+})

--- a/eval/confusion.ts
+++ b/eval/confusion.ts
@@ -1,0 +1,377 @@
+import {
+  DeterminismSchema,
+  OwnerSchema,
+  type Determinism,
+  type FixtureLabels,
+  type Owner,
+} from '@sentra/contracts'
+import { formatProportion, proportion, score, type Judgement, type Metrics } from './metrics.js'
+
+/**
+ * Structure behind the headline.
+ *
+ * Aggregate accuracy hides the shape of the errors, and the shape is what tells
+ * you whether a classifier is usable. Two classifiers at 85% — one whose
+ * mistakes are spread evenly, one that never once predicts `environment` — are
+ * different artefacts, and only the matrix distinguishes them. The baseline in
+ * this repository is the second kind, and the matrix is how that became
+ * visible.
+ *
+ * Unlike `metrics.ts`, this module does know about the fixture format. Scoring
+ * is a pure function of label pairs; *reporting* has to say which fixtures the
+ * numbers came from, and provenance and bucket live on `FixtureLabels`. Holding
+ * ground truth is exactly this layer's job — the leakage discipline is about
+ * never handing labels to a classifier, not about never reading them.
+ */
+
+// ---------------------------------------------------------------------------
+// Confusion matrices
+// ---------------------------------------------------------------------------
+
+export interface ConfusionMatrix {
+  axis: string
+  labels: readonly string[]
+  /**
+   * `counts[actual][predicted]`.
+   *
+   * Row-is-truth is stated everywhere it could be misread, including in the
+   * rendered header, because the transposed reading inverts precision and
+   * recall and produces a table that looks entirely reasonable.
+   */
+  counts: number[][]
+  /** Per actual class — the support. */
+  rowTotals: number[]
+  /** Per predicted class — how often the classifier reached for it. */
+  columnTotals: number[]
+  total: number
+}
+
+export function confusionMatrix(
+  judgements: Judgement[],
+  axis: 'owner' | 'determinism',
+): ConfusionMatrix {
+  const labels: readonly string[] =
+    axis === 'owner' ? OwnerSchema.options : DeterminismSchema.options
+
+  const counts = labels.map((actual) =>
+    labels.map(
+      (predicted) =>
+        judgements.filter((j) => j.actual[axis] === actual && j.predicted[axis] === predicted)
+          .length,
+    ),
+  )
+
+  return {
+    axis,
+    labels,
+    counts,
+    rowTotals: counts.map(sum),
+    columnTotals: labels.map((_, column) => sum(counts.map((row) => row[column] ?? 0))),
+    total: judgements.length,
+  }
+}
+
+export function renderConfusionMatrix(matrix: ConfusionMatrix): string {
+  const header = ['actual ↓ / predicted →', ...matrix.labels.map(code), '**total**']
+
+  const rows = matrix.labels.map((label, r) => [
+    code(label),
+    // The diagonal is the correct cell. Bolding it means the reader sees the
+    // shape of the errors before reading a single number.
+    ...matrix.labels.map((_, c) => {
+      const value = String(matrix.counts[r]?.[c] ?? 0)
+      return r === c ? `**${value}**` : value
+    }),
+    String(matrix.rowTotals[r] ?? 0),
+  ])
+
+  rows.push([
+    '**total**',
+    ...matrix.columnTotals.map((n) => String(n)),
+    `**${String(matrix.total)}**`,
+  ])
+
+  return [
+    `Rows are ground truth, columns are what the classifier said; the bold diagonal is correct.`,
+    '',
+    table(header, rows, ['left', ...matrix.labels.map(() => 'right' as const), 'right']),
+  ].join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Quadrants
+// ---------------------------------------------------------------------------
+
+export interface QuadrantRow {
+  owner: Owner
+  determinism: Determinism
+  /** `app_code + intermittent` — the one the project exists for. */
+  hard: boolean
+  /** Fixtures whose ground truth is this quadrant. */
+  support: number
+  /** Of those, how many the classifier placed in the same quadrant. */
+  correct: number
+  accuracy: ReturnType<typeof proportion>
+}
+
+export function quadrantBreakdown(judgements: Judgement[]): QuadrantRow[] {
+  const rows: QuadrantRow[] = []
+
+  for (const owner of OwnerSchema.options) {
+    for (const determinism of DeterminismSchema.options) {
+      const inQuadrant = judgements.filter(
+        (j) => j.actual.owner === owner && j.actual.determinism === determinism,
+      )
+      const correct = inQuadrant.filter(
+        (j) => j.predicted.owner === owner && j.predicted.determinism === determinism,
+      ).length
+
+      rows.push({
+        owner,
+        determinism,
+        hard: owner === 'app_code' && determinism === 'intermittent',
+        support: inQuadrant.length,
+        correct,
+        accuracy: proportion(correct, inQuadrant.length),
+      })
+    }
+  }
+
+  return rows
+}
+
+export function renderQuadrantTable(rows: QuadrantRow[]): string {
+  const body = rows.map((row) => {
+    const name = `${code(row.owner)} + ${code(row.determinism)}`
+    return [
+      row.hard ? `**${name}**` : name,
+      String(row.support),
+      String(row.correct),
+      // An empty quadrant prints n/a rather than 0%, which would read as a
+      // failure on cases that do not exist.
+      formatProportion(row.accuracy, { withN: false }),
+    ]
+  })
+
+  return [
+    table(['quadrant', 'support', 'correct', 'accuracy'], body, [
+      'left',
+      'right',
+      'right',
+      'right',
+    ]),
+    '',
+    'The bold row is the hard quadrant — an `app_code` defect that does not reproduce on rerun.',
+    'It is the case this project exists for, so it is reported on its own rather than averaged',
+    'into the headline, where ten fixtures out of thirty-three would be invisible.',
+  ].join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Grouped breakdowns
+// ---------------------------------------------------------------------------
+
+export interface GroupedMetrics {
+  group: string
+  metrics: Metrics
+}
+
+/** Score each group separately. Groups are returned in sorted order for a stable report. */
+export function scoreBy(judgements: Judgement[], key: (j: Judgement) => string): GroupedMetrics[] {
+  return scoreGroups(collect(judgements, key, (j) => j))
+}
+
+function collect<T>(
+  items: readonly T[],
+  key: (item: T) => string,
+  toJudgement: (item: T) => Judgement,
+): Map<string, Judgement[]> {
+  const groups = new Map<string, Judgement[]>()
+  for (const item of items) {
+    const k = key(item)
+    groups.set(k, [...(groups.get(k) ?? []), toJudgement(item)])
+  }
+  return groups
+}
+
+/** Sorted, so regenerating the report produces no diff when nothing changed. */
+function scoreGroups(groups: Map<string, Judgement[]>): GroupedMetrics[] {
+  return [...groups.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([group, members]) => ({ group, metrics: score(members) }))
+}
+
+/**
+ * A breakdown table, or a sentence saying why there is not one.
+ *
+ * A single-group breakdown is not a breakdown — it restates the headline in a
+ * layout that looks like analysis. Saying so is more useful than printing it,
+ * and it self-heals: the table appears as soon as the dimension has more than
+ * one value.
+ */
+export function renderBreakdown(
+  dimension: string,
+  groups: GroupedMetrics[],
+  total: number,
+): string {
+  if (groups.length === 0) return `No fixtures, so no ${dimension} breakdown.`
+
+  const only = groups[0]
+  if (groups.length === 1 && only !== undefined) {
+    const subject = total === 1 ? 'The only fixture has' : `All ${String(total)} fixtures share`
+    return (
+      `${subject} one ${dimension} (${code(only.group)}), so this breakdown would repeat the ` +
+      `headline. It appears here once the dataset has more than one.`
+    )
+  }
+
+  return table(
+    [dimension, 'n', 'joint', 'owner', 'determinism'],
+    groups.map((g) => [
+      code(g.group),
+      String(g.metrics.n),
+      formatProportion(g.metrics.joint, { withN: false }),
+      formatProportion(g.metrics.owner.accuracy, { withN: false }),
+      formatProportion(g.metrics.determinism.accuracy, { withN: false }),
+    ]),
+    ['left', 'right', 'right', 'right', 'right'],
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Fixture-aware assembly
+// ---------------------------------------------------------------------------
+
+export interface ScoredFixture {
+  judgement: Judgement
+  labels: FixtureLabels
+}
+
+export interface Partitioned {
+  /** Everything the headline is computed from. */
+  headline: ScoredFixture[]
+  /**
+   * Fixtures whose ground truth is genuinely arguable.
+   *
+   * Excluded from the headline and reported on their own, rather than quietly
+   * resolved in the project's favour — docs/eval-methodology.md promises this,
+   * and a promise nothing enforces is a preference.
+   */
+  lowConfidence: ScoredFixture[]
+}
+
+export function partitionByGroundTruthConfidence(fixtures: ScoredFixture[]): Partitioned {
+  return {
+    headline: fixtures.filter((f) => !f.labels.lowConfidenceGroundTruth),
+    lowConfidence: fixtures.filter((f) => f.labels.lowConfidenceGroundTruth),
+  }
+}
+
+/** Every section that depends on knowing which fixture is which. */
+export function renderBreakdownSections(fixtures: ScoredFixture[]): string {
+  const { headline, lowConfidence } = partitionByGroundTruthConfidence(fixtures)
+
+  // Grouped straight off the fixtures rather than looked up by name from the
+  // judgements. The labels travel with the judgement they belong to, so there is
+  // no lookup that could miss and no guard branch that could never fire.
+  const by = (pick: (labels: FixtureLabels) => string): GroupedMetrics[] =>
+    scoreGroups(
+      collect(
+        headline,
+        (f) => pick(f.labels),
+        (f) => f.judgement,
+      ),
+    )
+
+  return [
+    '### By provenance',
+    '',
+    renderBreakdown(
+      'provenance',
+      by((l) => l.provenance),
+      headline.length,
+    ),
+    '',
+    '### By difficulty bucket',
+    '',
+    renderBreakdown(
+      'bucket',
+      by((l) => l.bucket),
+      headline.length,
+    ),
+    '',
+    '### Excluded from the headline',
+    '',
+    renderLowConfidence(lowConfidence),
+  ].join('\n')
+}
+
+function renderLowConfidence(fixtures: ScoredFixture[]): string {
+  if (fixtures.length === 0) {
+    return (
+      'No fixture is currently marked `lowConfidenceGroundTruth`. That is a statement about the ' +
+      'dataset, not a target — docs/eval-methodology.md expects roughly 10% of a finished dataset ' +
+      'to be genuinely arguable, and a dataset with none may simply be avoiding the hard cases.'
+    )
+  }
+
+  const metrics = score(fixtures.map((f) => f.judgement))
+  return [
+    `${String(fixtures.length)} fixture(s) have ground truth the author considers arguable. They ` +
+      'are excluded from every figure above and scored here instead, so a disputed label cannot ' +
+      'quietly improve the headline.',
+    '',
+    `Joint accuracy on these: ${formatProportion(metrics.joint)}`,
+    '',
+    ...fixtures.map((f) => `- \`${f.judgement.name}\` — ${f.labels.justification.split('.')[0]}.`),
+  ].join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Markdown
+// ---------------------------------------------------------------------------
+
+type Align = 'left' | 'right'
+
+/**
+ * A markdown table padded the way Prettier pads them.
+ *
+ * Generated markdown lands in a file the format check reads, so emitting
+ * something Prettier would rewrite turns every report regeneration into a CI
+ * failure. Matching its output means the file is stable the moment it is
+ * written — asserted by a test that runs the real formatter over the result.
+ */
+function table(headers: string[], rows: string[][], align: Align[]): string {
+  const widths = headers.map((header, i) =>
+    Math.max(displayWidth(header), ...rows.map((row) => displayWidth(row[i] ?? '')), 3),
+  )
+
+  const line = (cells: string[]): string =>
+    `| ${cells.map((cell, i) => pad(cell, widths[i] ?? 0, align[i] ?? 'left')).join(' | ')} |`
+
+  const divider = `| ${widths
+    .map((width, i) =>
+      (align[i] ?? 'left') === 'right' ? `${'-'.repeat(width - 1)}:` : '-'.repeat(width),
+    )
+    .join(' | ')} |`
+
+  return [line(headers), divider, ...rows.map(line)].join('\n')
+}
+
+const pad = (cell: string, width: number, align: Align): string => {
+  const padding = ' '.repeat(Math.max(0, width - displayWidth(cell)))
+  return align === 'right' ? padding + cell : cell + padding
+}
+
+/**
+ * Prettier measures table cells in code points, not UTF-16 units.
+ *
+ * Every arrow and en dash in this report is outside the BMP-adjacent range that
+ * makes the two agree, so using `.length` mis-pads any row containing one and
+ * the file fails its own format check.
+ */
+const displayWidth = (cell: string): number => [...cell].length
+
+const code = (value: string): string => `\`${value}\``
+
+const sum = (xs: number[]): number => xs.reduce((a, b) => a + b, 0)

--- a/eval/index.ts
+++ b/eval/index.ts
@@ -10,3 +10,4 @@
 export * from './dataset.js'
 export * from './baseline.js'
 export * from './metrics.js'
+export * from './confusion.js'

--- a/wiki/Evaluation-Methodology.md
+++ b/wiki/Evaluation-Methodology.md
@@ -85,6 +85,30 @@ labelled after the fact), `mutated` (a real run with an injected defect). Metric
 provenance, so a classifier that only performs on invented failures is visible rather than
 flattered.
 
+### Evidence the buckets do what they claim
+
+"Punishes diff-only reasoning" is a claim, not a fact, until something is measured against it.
+Scoring the baseline per bucket is that measurement:
+
+| Bucket                      |   n | Joint  | `owner` | `determinism` |
+| --------------------------- | --: | ------ | ------- | ------------- |
+| `straightforward`           |   8 | 100.0% | 100.0%  | 100.0%        |
+| `hard-quadrant`             |  10 | 30.0%  | 60.0%   | 70.0%         |
+| `stale-test`                |   7 | 0.0%   | 0.0%    | 100.0%        |
+| `misleading-history`        |   4 | 0.0%   | 75.0%   | 0.0%          |
+| `environment-as-regression` |   4 | 25.0%  | 25.0%   | 100.0%        |
+
+Each adversarial bucket defeats the baseline **on the axis it was built to attack, and only that
+axis**. `stale-test` takes owner to 0% and leaves determinism at 100%. `misleading-history` is the
+mirror image — determinism to 0%, owner still at 75%.
+
+That orthogonality is the point. Buckets that all failed together would mean the fixtures were
+merely hard, or badly written. Failing on precisely the intended axis is what separates an
+adversarial dataset from a difficult one.
+
+`straightforward` at 100% is the control on the control: the baseline is a working classifier, so
+the failures above are properties of the fixtures rather than of the code being measured.
+
 ## 3. Reported uncertainty
 
 Two independent sources of noise, both measured rather than ignored.


### PR DESCRIPTION
Closes #26.

`eval/confusion.ts` renders the structure the headline hides. Aggregate accuracy cannot tell apart two classifiers at the same score — one whose errors are spread evenly, one that never reaches for a class at all.

The baseline turns out to be the second kind, and the matrix is what made it visible:

| actual ↓ / predicted → | `app_code` | `test_code` | `environment` | **total** |
| ---------------------- | ---------: | ----------: | ------------: | --------: |
| `app_code`             |     **17** |           4 |             0 |        21 |
| `test_code`            |          8 |       **0** |             0 |         8 |
| `environment`          |          3 |           0 |         **1** |         4 |
| **total**              |         28 |           4 |             1 |    **33** |

The entire `test_code` row — all eight fixtures — collapses into the `app_code` column. No aggregate number says that.

## Per quadrant

| quadrant                        | support | correct |          accuracy |
| ------------------------------- | ------: | ------: | ----------------: |
| `app_code` + `deterministic`    |      11 |       8 | 72.7% [43.4–90.3] |
| **`app_code` + `intermittent`** |      10 |       3 | 30.0% [10.8–60.3] |
| `test_code` + `deterministic`   |       8 |       0 |   0.0% [0.0–32.4] |
| `test_code` + `intermittent`    |       0 |       0 |               n/a |
| `environment` + `deterministic` |       2 |       1 |  50.0% [9.5–90.5] |
| `environment` + `intermittent`  |       2 |       0 |   0.0% [0.0–65.8] |

The hard quadrant is bold and reported on its own, because averaging ten fixtures out of thirty-three into a headline is how the project's actual thesis would become invisible.

## The buckets demonstrably work

This is the result I did not expect to be so clean. Scoring per bucket:

| Bucket                      |   n | Joint  | `owner` | `determinism` |
| --------------------------- | --: | ------ | ------- | ------------- |
| `straightforward`           |   8 | 100.0% | 100.0%  | 100.0%        |
| `hard-quadrant`             |  10 | 30.0%  | 60.0%   | 70.0%         |
| `stale-test`                |   7 | 0.0%   | 0.0%    | 100.0%        |
| `misleading-history`        |   4 | 0.0%   | 75.0%   | 0.0%          |
| `environment-as-regression` |   4 | 25.0%  | 25.0%   | 100.0%        |

Each adversarial bucket defeats the baseline **on the axis it was built to attack, and only that axis**. `stale-test` targets diff-only reasoning about ownership: owner to 0%, determinism untouched at 100%. `misleading-history` targets flakiness-score-only reasoning about stability and is the exact mirror image: determinism to 0%, owner still at 75%.

That orthogonality is the part that matters. Buckets failing together would mean the fixtures were merely hard, or badly written. Failing on precisely the intended axis is what separates an adversarial dataset from a difficult one — and `straightforward` at 100% is the control on the control, confirming the baseline is a working classifier so the failures above are properties of the fixtures.

## Decisions worth flagging in review

**Rows are truth, columns are prediction** — stated in the rendered header, not only in the type. The transposed reading inverts precision and recall and produces a table that looks entirely reasonable. The test uses a deliberately asymmetric case that a transposed implementation fails.

**An empty quadrant prints `n/a`, not `0%`.** `test_code + intermittent` has no fixtures; 0% would read as failing cases that do not exist. Real data exercises that path, not just a constructed case.

**A single-group breakdown is replaced by a sentence.** Every fixture is currently `synthetic`, so a provenance table would be one row restating the headline in a layout that looks like analysis. It says so instead, and the table appears by itself once the dimension gains a second value.

**No low-confidence fixtures is reported as a fact, not a pass.** The methodology expects ~10% of a finished dataset to be genuinely arguable, so a dataset with none may be avoiding the hard cases. The section says exactly that.

**Generated markdown matches Prettier's own padding**, verified by running the real formatter over the rendered report inside a test. `eval/report.md` lands in a tree the format check reads, so emitting anything Prettier would rewrite turns every report regeneration into a CI failure. Cell widths are measured in **code points**, not UTF-16 units — the header arrows otherwise mis-pad every row in the table.

## Scope

`eval/report.md` itself, and the CLI that writes it, are #27. This PR provides the sections; nothing writes a file yet.

## Verification

`npx eslint .`, `npx tsc --build`, `npx prettier --check .`, `npm run eval:lint`, `npm run docs:status:check` all clean. **526 unit tests pass**, up from 491.
