### PR TITLE
docs(ci): write down who can merge and gate CI for outside contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,27 @@ format via a Husky hook, so a malformed message fails locally rather than in rev
 Open the PR as a **draft** early. CI runs, the eval delta appears, and the work is still cheap to
 change.
 
+## Who can merge, and what happens to an outside PR
+
+Merging requires write access, of which there is exactly one holder. `main` rejects direct pushes,
+requires a pull request, and requires four passing checks. An approving review from an account
+without write access does not make a pull request mergeable — this is a GitHub setting, not a
+house rule, so it cannot drift.
+
+You can still open a pull request from a fork, and it is welcome. Two things to expect:
+
+1. **CI waits for approval.** Workflows on fork pull requests need a maintainer to start them,
+   every time. That is deliberately stricter than GitHub's default, which only asks for the first
+   one and then lets subsequent runs through — including runs of a workflow file the same pull
+   request changed.
+2. **No secrets, by design.** Fork pull requests get no `ANTHROPIC_API_KEY`, so the agent stage is
+   skipped and the pipeline runs the baseline heuristic instead. The comment says so rather than
+   pretending. The reasoning, including why `pull_request_target` is not used, is in
+   [ADR-0007](docs/adr/0007-no-github-app-no-pull-request-target.md).
+
+Neither is a judgement about the contribution. Approving a workflow run means reading a diff before
+it executes, which is the only point at which reading it helps.
+
 ## What a good PR looks like
 
 - Under ~400 changed lines.

--- a/docs/branching-strategy.md
+++ b/docs/branching-strategy.md
@@ -120,11 +120,51 @@ because release notes are generated from `main`'s history.
 **Draft PRs** are opened early and deliberately — CI runs, the eval delta becomes visible while
 the work is still cheap to change.
 
+### Who can merge
+
+Write access, and nothing else. GitHub enforces it; there is no repository convention here that
+could quietly drift.
+
+|                                    |                                                                                         |
+| ---------------------------------- | --------------------------------------------------------------------------------------- |
+| Accounts with write access         | one — [@AKogut](https://github.com/AKogut)                                              |
+| Direct pushes to `main`            | rejected; a pull request is required                                                    |
+| Required status checks             | `Repository hygiene`, `PR title convention`, `Static analysis`, `Unit & contract tests` |
+| Branch must be current with `main` | yes                                                                                     |
+| Merge strategy                     | squash only                                                                             |
+
+Approval from anyone without write access does not make a pull request mergeable. This is worth
+stating explicitly because the reverse — a repository where the rule is a norm rather than a
+setting — looks identical from the outside.
+
+The still-skipping jobs (`E2E tests`, `Evaluation gate`, `Flakiness analysis & triage`) are
+deliberately **not** required yet. A required check that never reports leaves every pull request
+waiting for a status that will not arrive. Each is added to the required set by the milestone that
+makes it run.
+
+### Outside pull requests
+
+The repository is public and forking cannot be disabled for public repositories, so anyone can
+open a pull request. That is fine, and [ADR-0007](adr/0007-no-github-app-no-pull-request-target.md)
+treats it as a supported path rather than an accident.
+
+Two things happen to such a pull request, and they answer different questions:
+
+**Whether CI runs at all.** Workflows on a fork pull request require explicit maintainer approval,
+every time — the Actions approval policy is `all_external_contributors`, not GitHub's default of
+`first_time_contributors`. Under the default, a second pull request from the same account runs
+without approval, including one that edits the workflow files themselves. Approving a run is a
+deliberate act of reading the diff first.
+
+**What it can reach once running.** Nothing secret. Fork pull requests receive no secrets, so the
+agent stage cannot run and the pipeline degrades to the baseline heuristic, saying so plainly in
+its comment. `pull_request_target`, the usual workaround, is not used anywhere in this repository —
+the reasoning is in ADR-0007.
+
 ## Review
 
 Single maintainer, so `CODEOWNERS` self-assignment is a routing mechanism rather than a gate.
-The self-review checklist in the PR template is the real control. External contributions require
-maintainer approval.
+The self-review checklist in the PR template is the real control.
 
 Reviews focus, in order, on: does the eval move; is the guardrail still enforced; is the change
 covered by a test; is it the smallest change that works.

--- a/tests/unit/node-floor.test.ts
+++ b/tests/unit/node-floor.test.ts
@@ -1,12 +1,13 @@
+import { execSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 /**
- * The minimum Node version is stated in four places: `engines.node`, which is the
- * only one a package manager reads, and three prose copies a human reads first —
- * the README badge, CONTRIBUTING, and the wiki's requirements line.
+ * The minimum Node version is stated in five places: `engines.node`, which is the
+ * only one a package manager reads, and four prose copies a human reads first —
+ * the README badge, CONTRIBUTING, and two wiki pages.
  *
  * These drifted the moment ESLint 10 raised the real floor from 22 to 22.13. The
  * failure is quiet in the worst way: the docs keep promising a version that no
@@ -15,7 +16,18 @@ import { describe, expect, it } from 'vitest'
  *
  * `engines.node` is the source of truth here because it is the copy that has
  * consequences.
+ *
+ * The list below started with three files and missed `wiki/Contributing.md`,
+ * which then sat on the stale number while the check reported green. A guard
+ * that enumerates its targets by hand is only as good as the enumeration, so
+ * anything new that states a Node version belongs in `PROSE_COPIES`.
  */
+const PROSE_COPIES = [
+  'README.md',
+  'CONTRIBUTING.md',
+  'wiki/Getting-Started.md',
+  'wiki/Contributing.md',
+] as const
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const read = (file: string): string => readFileSync(join(root, file), 'utf8')
@@ -41,21 +53,30 @@ const declaredFloor = (): string => {
 describe('the documented Node floor', () => {
   const floor = declaredFloor()
 
-  it.each([
-    ['README.md', () => read('README.md')],
-    ['CONTRIBUTING.md', () => read('CONTRIBUTING.md')],
-    ['wiki/Getting-Started.md', () => read('wiki/Getting-Started.md')],
-  ])('%s states the version from engines.node', (_file, load) => {
-    expect(load()).toContain(floor)
+  it.each(PROSE_COPIES)('%s states the version from engines.node', (file) => {
+    expect(read(file)).toContain(floor)
   })
 
-  it('no prose copy still claims the superseded bare major', () => {
+  it.each(PROSE_COPIES)('%s does not still claim the superseded bare major', (file) => {
     // `Node ≥ 22` reads as correct and is not — 22.0 through 22.12 fail to install.
     // Matching the major with nothing after it is what catches a half-done update.
-    const stale = /Node\s*(?:≥|>=)\s*22(?!\.)/
-    for (const file of ['README.md', 'CONTRIBUTING.md', 'wiki/Getting-Started.md']) {
-      expect(read(file)).not.toMatch(stale)
-    }
+    expect(read(file)).not.toMatch(/Node\s*(?:≥|>=)\s*22(?!\.)/)
+  })
+
+  it('checks every copy that exists, not a subset someone remembered', () => {
+    // The original list missed one wiki page, which then held the stale number
+    // while this suite reported green. Anything stating a Node version has to be
+    // in PROSE_COPIES, so the search runs over the tracked files rather than
+    // trusting the list to be complete.
+    //
+    // Both spellings count. README states the floor only inside a shields.io URL,
+    // where `>=` is percent-encoded — searching for prose alone would miss the
+    // one copy most readers see first.
+    const statesAVersion = /Node\s*(?:≥|>=)\s*\d|node-%3E%3D\d/
+    const stated = execSync('git ls-files "*.md"', { cwd: root, encoding: 'utf8' })
+      .split('\n')
+      .filter((file) => file !== '' && statesAVersion.test(read(file)))
+    expect(stated.sort()).toEqual([...PROSE_COPIES].sort())
   })
 
   it('the badge encodes the same floor', () => {

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -22,7 +22,26 @@ npm install
 npm run demo     # no API key needed
 ```
 
-Node ≥ 22. A key is only required for live model calls.
+Node ≥ 22.13. A key is only required for live model calls.
+
+## Who can merge, and what happens to an outside pull request
+
+Merging requires write access, of which there is exactly one holder. `main` rejects direct pushes,
+requires a pull request, and requires four passing checks. An approving review from an account
+without write access does not make a pull request mergeable — a GitHub setting rather than a house
+rule, so it cannot drift.
+
+Pull requests from a fork are welcome. Two things to expect:
+
+1. **CI waits for approval.** Workflows on fork pull requests need a maintainer to start them,
+   every time — deliberately stricter than GitHub's default, which asks only for the first and then
+   lets later runs through, including runs of a workflow file the same pull request changed.
+2. **No secrets, by design.** Fork pull requests receive no API key, so the agent stage is skipped
+   and the baseline heuristic runs instead. The comment says so rather than pretending. See
+   [Decision Records](Decision-Records) — ADR-0007.
+
+Neither is a judgement about the contribution. Approving a run means reading the diff before it
+executes, which is the only moment at which reading it helps.
 
 ## Picking something up
 


### PR DESCRIPTION
Closes #132.

Three things were being conflated under "only contributors", and only one turned out to be a real gap.

## Who can merge — already enforced, documented nowhere

`main` rejects direct pushes, requires a pull request, requires four passing checks, and merging requires write access. Exactly one account has it. An approving review from anyone else does not make a PR mergeable.

None of that could drift — it is a GitHub setting, not a norm. But a reader had no way to know that, and a repository where the rule is *only* a norm looks identical from the outside. So it is now written down, with the mechanism named:

| | |
| --- | --- |
| Accounts with write access | one |
| Direct pushes to `main` | rejected |
| Required status checks | `Repository hygiene`, `PR title convention`, `Static analysis`, `Unit & contract tests` |
| Branch must be current with `main` | yes |
| Merge strategy | squash only |

Including why the three still-skipping jobs are deliberately *not* required: a required check that never reports leaves every PR waiting on a status that will not arrive.

## Who can open a PR — cannot be restricted

The repository is public, and `allow_forking: false` is only available to organisation-owned private repositories. Anyone can fork and open a pull request. Per ADR-0007 that is a supported path, not an accident.

## Whose code CI runs — the actual gap, now closed

The Actions approval policy was `first_time_contributors`, GitHub's default for public repositories. That means the **first** pull request from an account waits for approval and **every later one runs unattended** — including one that edits the workflow files themselves.

Now set to `all_external_contributors`:

```
$ gh api repos/AKogut/ai-flaky-test-triage/actions/permissions/fork-pr-contributor-approval
{"approval_policy":"all_external_contributors"}
```

Every fork run is started deliberately, after somebody has read the diff.

This **complements ADR-0007 rather than reopening it.** The ADR governs what a fork PR can reach once running — no secrets, baseline heuristic only, no `pull_request_target`. This governs who decides that it runs at all. Fork contributions remain welcome and the degraded pipeline still works.

The line it replaces in `docs/branching-strategy.md` was *"External contributions require maintainer approval"* — which named no mechanism and was therefore unfalsifiable.

## A hole in the guard from #129

While editing these files I found `wiki/Contributing.md` still saying **"Node ≥ 22"**.

That is exactly the failure the node-floor check added in #129 exists to prevent — and it was in the check itself. The test enumerated three prose copies by hand and never knew about the fourth, so it reported green over a stale number.

The list is now verified against `git ls-files`, so a fifth copy cannot appear unnoticed:

```ts
const stated = execSync('git ls-files "*.md"', ...)
  .filter((file) => statesAVersion.test(read(file)))
expect(stated.sort()).toEqual([...PROSE_COPIES].sort())
```

Writing that found a second thing immediately: it failed on its first run because **README states the floor only inside a shields.io URL**, where `>=` is percent-encoded as `%3E%3D`. A prose-only search would have missed the copy most readers see first. Both spellings are matched now.

## Verification

`npx eslint .`, `npx tsc --build`, `npx prettier --check .`, `npm run docs:status:check` all clean. **531 unit tests pass**, up from 526.

Wiki is republished after merge.
