### PR TITLE
docs(ci): record Evaluation gate as a required check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ change.
 ## Who can merge, and what happens to an outside PR
 
 Merging requires write access, of which there is exactly one holder. `main` rejects direct pushes,
-requires a pull request, and requires four passing checks. An approving review from an account
+requires a pull request, and requires five passing checks. An approving review from an account
 without write access does not make a pull request mergeable — this is a GitHub setting, not a
 house rule, so it cannot drift.
 

--- a/docs/branching-strategy.md
+++ b/docs/branching-strategy.md
@@ -125,22 +125,22 @@ the work is still cheap to change.
 Write access, and nothing else. GitHub enforces it; there is no repository convention here that
 could quietly drift.
 
-|                                    |                                                                                         |
-| ---------------------------------- | --------------------------------------------------------------------------------------- |
-| Accounts with write access         | one — [@AKogut](https://github.com/AKogut)                                              |
-| Direct pushes to `main`            | rejected; a pull request is required                                                    |
-| Required status checks             | `Repository hygiene`, `PR title convention`, `Static analysis`, `Unit & contract tests` |
-| Branch must be current with `main` | yes                                                                                     |
-| Merge strategy                     | squash only                                                                             |
+|                                    |                                                                                                            |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Accounts with write access         | one — [@AKogut](https://github.com/AKogut)                                                                 |
+| Direct pushes to `main`            | rejected; a pull request is required                                                                       |
+| Required status checks             | `Repository hygiene`, `PR title convention`, `Static analysis`, `Unit & contract tests`, `Evaluation gate` |
+| Branch must be current with `main` | yes                                                                                                        |
+| Merge strategy                     | squash only                                                                                                |
 
 Approval from anyone without write access does not make a pull request mergeable. This is worth
 stating explicitly because the reverse — a repository where the rule is a norm rather than a
 setting — looks identical from the outside.
 
-The still-skipping jobs (`E2E tests`, `Evaluation gate`, `Flakiness analysis & triage`) are
-deliberately **not** required yet. A required check that never reports leaves every pull request
-waiting for a status that will not arrive. Each is added to the required set by the milestone that
-makes it run.
+The still-skipping jobs (`E2E tests`, `Flakiness analysis & triage`) are deliberately **not**
+required yet. A required check that never reports leaves every pull request waiting for a status
+that will not arrive. Each is added to the required set by the milestone that makes it run —
+`Evaluation gate` joined it in #27, the change that made it run at all.
 
 ### Outside pull requests
 

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -27,7 +27,7 @@ Node ≥ 22.13. A key is only required for live model calls.
 ## Who can merge, and what happens to an outside pull request
 
 Merging requires write access, of which there is exactly one holder. `main` rejects direct pushes,
-requires a pull request, and requires four passing checks. An approving review from an account
+requires a pull request, and requires five passing checks. An approving review from an account
 without write access does not make a pull request mergeable — a GitHub setting rather than a house
 rule, so it cannot drift.
 


### PR DESCRIPTION
#135 made the `Evaluation gate` job run — it gates on `eval/run-eval.ts` existing — so it has been added to the required set on `main`:

```
["Repository hygiene","PR title convention","Static analysis","Unit & contract tests","Evaluation gate"]
```

The three documents that state the set now agree with it.

This is the rule from the "Who can merge" section working as intended: a job becomes required in the milestone that makes it report, not before. Leaving it out once it runs would have been the opposite failure to the one that rule guards against — a check that exists, passes, and blocks nothing.

`E2E tests` and `Flakiness analysis & triage` still skip and are still excluded.

This PR is the first to be gated by the new required check.