### PR TITLE
feat(eval): gate merges on evaluation thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,22 +243,53 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+
+      # The gate measures a regression against the metrics recorded on main, so
+      # that ref has to exist locally. checkout fetches one commit by default.
+      - name: Fetch main for comparison
+        run: git fetch --no-tags --depth=1 origin main:refs/remotes/origin/main || true
+
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - run: npm ci
+
+      # This job is a required check, so it must report on every pull request —
+      # a required check that skips leaves the PR waiting for a status that
+      # never arrives. It therefore always runs, and this flag decides how much
+      # work it does rather than whether it runs at all. Today the whole thing
+      # is free: no model, no network. From M3 the flag is what stops a
+      # docs-only change from spending money on a model.
+      - name: Did anything the evaluation depends on change?
+        id: scope
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if git diff --name-only origin/main...HEAD \
+             | grep -Eq '^(agents|eval|prompts)/'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No change under agents/, eval/ or prompts/ — from M3 the model run is skipped here."
+          fi
+
       - name: Run golden-dataset evaluation
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # No key (fork PR) → replay mode against committed cassettes.
           SENTRA_REPLAY: ${{ secrets.ANTHROPIC_API_KEY == '' && '1' || '' }}
+          SENTRA_EVAL_SCOPE_CHANGED: ${{ steps.scope.outputs.changed }}
         run: npm run eval -- --gate
+
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: eval-report
-          path: eval/report.md
+          path: |
+            eval/report.md
+            eval/metrics.json
           retention-days: 30
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,12 +242,12 @@ jobs:
     if: needs.hygiene.outputs.has-eval == 'true'
     runs-on: ubuntu-latest
     steps:
+      # Full history. The gate measures a regression against the metrics
+      # recorded on main, and the scope check needs a merge base — neither is
+      # computable from the single commit checkout fetches by default.
       - uses: actions/checkout@v7
-
-      # The gate measures a regression against the metrics recorded on main, so
-      # that ref has to exist locally. checkout fetches one commit by default.
-      - name: Fetch main for comparison
-        run: git fetch --no-tags --depth=1 origin main:refs/remotes/origin/main || true
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -261,14 +261,32 @@ jobs:
       # work it does rather than whether it runs at all. Today the whole thing
       # is free: no model, no network. From M3 the flag is what stops a
       # docs-only change from spending money on a model.
+      # Fails safe: anything other than a confidently empty diff reports
+      # "changed". Guessing wrong in that direction wastes a run; guessing wrong
+      # the other way silently skips the evaluation on a change that needed it,
+      # which is the failure nobody notices. An earlier version defaulted the
+      # other way and reported "nothing changed" on a pull request that rewrote
+      # eval/ — the merge base was unreachable from a depth-1 checkout, the diff
+      # came back empty, and the check believed it.
       - name: Did anything the evaluation depends on change?
         id: scope
         run: |
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
-          if git diff --name-only origin/main...HEAD \
-             | grep -Eq '^(agents|eval|prompts)/'; then
+
+          base='${{ github.event.pull_request.base.sha }}'
+          if ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Base commit $base unreachable — assuming the evaluation is in scope."
+            exit 0
+          fi
+
+          changed_files=$(git diff --name-only "$base" HEAD)
+          if [ -z "$changed_files" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Empty diff against the base — assuming the evaluation is in scope."
+          elif printf '%s\n' "$changed_files" | grep -Eq '^(agents|eval|prompts)/'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ npm-debug.log*
 yarn-error.log*
 .eslintcache
 /eval/report-all.md
+/eval/metrics-all.json

--- a/docs/eval-methodology.md
+++ b/docs/eval-methodology.md
@@ -193,19 +193,45 @@ bin, producing a reliability curve and an **Expected Calibration Error**. Two co
 
 ## CI gate
 
-`npm run eval` runs on every PR that touches `agents/`, `eval/`, or `prompts/`. It fails when:
+`npm run eval -- --gate` runs on every pull request. It does two things: verifies the committed
+report and metrics match a fresh run, and holds those numbers to the thresholds below. The values
+live in `eval/gate.ts`, one file, each with the reason it has the value it does.
 
-| Condition                                                             | Threshold      |
-| --------------------------------------------------------------------- | -------------- |
-| Joint accuracy lower bound drops below the recorded main-branch value | −5pp           |
-| Joint accuracy lower bound below absolute floor                       | 0.65           |
-| Agent fails to beat the baseline on joint accuracy                    | any regression |
-| Self-consistency below floor                                          | 0.80           |
-| Hard-quadrant recall below floor                                      | 0.50           |
-| Cost per fixture rises sharply                                        | +50%           |
+| Condition                                                           | Threshold      | Active |
+| ------------------------------------------------------------------- | -------------- | ------ |
+| Joint accuracy lower bound drops below the value recorded on `main` | −5pp           | yes    |
+| Joint accuracy lower bound below absolute floor                     | 0.65           | M3     |
+| Agent fails to beat the baseline on joint accuracy                  | any regression | M3     |
+| Self-consistency below floor                                        | 0.80           | M3     |
+| Hard-quadrant accuracy lower bound below floor                      | 0.50           | M3     |
+| Cost per fixture rises sharply                                      | +50%           | M3     |
 
-Thresholds start permissive and ratchet as the dataset grows. A gate that blocks on noise gets
-disabled by whoever is on call, so the initial values are chosen to be survivable.
+**Comparisons use interval lower bounds, never point estimates.** At n=22 a point estimate moves
+several percentage points between two classifiers that are indistinguishable, so gating on it
+would fire on the dice. The lower bound fires when the evidence supports a regression.
+
+**Five of the six are targets for the agent, not descriptions of the baseline.** The baseline's
+joint accuracy lower bound is 0.197 against a floor of 0.65; its hard-quadrant lower bound is 0.097
+against 0.50. Enabling those today would make `main` permanently red on facts everybody already
+knows, and a permanently red gate is one people learn to merge past. They are implemented, printed
+in every run with the current distance to the target, and each names the condition that switches it
+on.
+
+That leaves one active check, plus freshness. It is the one that matters today: nothing may make
+the classifier measurably worse than what is recorded on `main`.
+
+Thresholds start permissive and ratchet as the dataset grows. Ratcheting means editing `gate.ts` in
+a reviewable commit — the gate has no runtime override, because a gate you can wave through at 3am
+is not a gate.
+
+### Why the job always runs
+
+The gate is a required status check. A required check that skips leaves a pull request waiting
+forever for a status that never arrives, so the job runs on every PR regardless of what changed.
+Whether anything under `agents/`, `eval/` or `prompts/` changed is detected and exported as
+`SENTRA_EVAL_SCOPE_CHANGED`; today the whole evaluation is free — no model, no network — so it runs
+either way. From M3 that flag is what stops a documentation-only change from paying for a model
+run.
 
 ## Ablation study
 
@@ -276,6 +302,12 @@ report itself.
 `--slice=all` counts as a consultation. It reads the held-out fixtures just as surely as asking for
 them by name, and a rule that only caught `--slice=holdout` would be bypassed by choosing the more
 innocuous-sounding flag.
+
+The log counts **runs, not insights**, and over-counts deliberately. Regenerating the held-out
+report after a formatting change teaches nobody anything and in a strict sense should not spend
+budget — but the tool cannot tell that from a real consultation, and any flag meaning "this one
+does not count" is a flag for never counting. Erring towards over-counting costs an occasional
+early warning; erring the other way costs the mechanism.
 
 ## Threats to validity
 

--- a/eval/gate.test.ts
+++ b/eval/gate.test.ts
@@ -1,0 +1,284 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import {
+  MetricsSnapshotSchema,
+  readReferenceSnapshot,
+  renderGateReport,
+  runGate,
+  snapshot,
+  THRESHOLDS,
+  type MetricsSnapshot,
+} from './gate.js'
+import { quadrantBreakdown } from './confusion.js'
+import { DEFAULTS, evaluate, METRICS_PATHS } from './run-eval.js'
+
+const at = (lower: number, over: Partial<MetricsSnapshot> = {}): MetricsSnapshot => ({
+  version: 1,
+  classifier: 'baseline',
+  slice: 'dev',
+  datasetRevision: 'abcd',
+  n: 22,
+  joint: { point: lower + 0.1, lower, upper: lower + 0.3 },
+  owner: { point: 0.5, lower: 0.3, upper: 0.7, macroF1: 0.4 },
+  determinism: { point: 0.8, lower: 0.6, upper: 0.9, macroF1: 0.8 },
+  hardQuadrant: { point: 0.33, lower: 0.1, upper: 0.7, support: 6, correct: 2 },
+  selfConsistency: null,
+  costPerFixtureUsd: null,
+  ...over,
+})
+
+const check = (report: ReturnType<typeof runGate>, id: string) =>
+  report.checks.find((c) => c.id === id)
+
+describe('joint accuracy regression', () => {
+  it('passes an unchanged classifier', () => {
+    const report = runGate({ current: at(0.2), reference: at(0.2) })
+    expect(check(report, 'joint-accuracy-regression')?.status).toBe('pass')
+    expect(report.failed).toBe(false)
+  })
+
+  it('passes an improvement', () => {
+    expect(
+      check(runGate({ current: at(0.4), reference: at(0.2) }), 'joint-accuracy-regression')?.status,
+    ).toBe('pass')
+  })
+
+  it('tolerates a drop inside the allowance', () => {
+    // Deliberately wide. At n=22 the interval is ±19pp, so a tighter bound would
+    // fire on fixtures being added rather than on the classifier changing.
+    const justInside = 0.3 - THRESHOLDS.jointAccuracyRegressionPp
+    expect(
+      check(runGate({ current: at(justInside), reference: at(0.3) }), 'joint-accuracy-regression')
+        ?.status,
+    ).toBe('pass')
+  })
+
+  it('fails a drop past the allowance', () => {
+    const report = runGate({
+      current: at(0.3 - THRESHOLDS.jointAccuracyRegressionPp - 0.001),
+      reference: at(0.3),
+    })
+    expect(check(report, 'joint-accuracy-regression')?.status).toBe('fail')
+    expect(report.failed).toBe(true)
+  })
+
+  it('compares lower bounds, not point estimates', () => {
+    // A classifier whose point estimate rose while its lower bound collapsed has
+    // got noisier, not better, and that is exactly what this gate is for.
+    const current = at(0.1, { joint: { point: 0.9, lower: 0.1, upper: 0.99 } })
+    const reference = at(0.3, { joint: { point: 0.4, lower: 0.3, upper: 0.5 } })
+    expect(check(runGate({ current, reference }), 'joint-accuracy-regression')?.status).toBe('fail')
+  })
+
+  it('names both values and the threshold', () => {
+    // A failure that does not say what it compared sends the reader to run the
+    // evaluation again by hand to find out.
+    const detail = check(
+      runGate({ current: at(0.1), reference: at(0.3) }),
+      'joint-accuracy-regression',
+    )?.detail
+    expect(detail).toContain('10.0pp now')
+    expect(detail).toContain('30.0pp on main')
+    expect(detail).toContain('allowed down to 25.0pp')
+  })
+
+  it('skips when main has no recorded metrics', () => {
+    // The first run, and any branch older than this feature.
+    expect(
+      check(runGate({ current: at(0.2), reference: null }), 'joint-accuracy-regression')?.status,
+    ).toBe('skipped')
+  })
+
+  it('skips rather than comparing across slices', () => {
+    // A dev number against a held-out one would fire on the slice changing.
+    const report = runGate({ current: at(0.2), reference: at(0.9, { slice: 'holdout' }) })
+    expect(check(report, 'joint-accuracy-regression')?.status).toBe('skipped')
+    expect(report.failed).toBe(false)
+  })
+})
+
+describe('thresholds that are agent targets', () => {
+  it.each(['joint-accuracy-floor', 'hard-quadrant-floor'])(
+    '%s is skipped for the baseline, with the distance still shown',
+    (id) => {
+      // Enabling these today would make main permanently red on a fact everybody
+      // knows, and a permanently red gate is one people learn to merge past.
+      const result = check(runGate({ current: at(0.2), reference: null }), id)
+      expect(result?.status).toBe('skipped')
+      expect(result?.detail).toContain('target for the agent')
+      expect(result?.detail).toContain('Enforced from M3')
+    },
+  )
+
+  it('enforces the joint floor once the agent is the classifier', () => {
+    const below = at(0.2, { classifier: 'agent' })
+    const above = at(THRESHOLDS.jointAccuracyFloor, { classifier: 'agent' })
+    expect(
+      check(runGate({ current: below, reference: null }), 'joint-accuracy-floor')?.status,
+    ).toBe('fail')
+    expect(
+      check(runGate({ current: above, reference: null }), 'joint-accuracy-floor')?.status,
+    ).toBe('pass')
+  })
+
+  it('enforces the hard-quadrant floor once the agent is the classifier', () => {
+    const current = at(0.9, {
+      classifier: 'agent',
+      hardQuadrant: { point: 0.6, lower: 0.55, upper: 0.9, support: 6, correct: 4 },
+    })
+    expect(check(runGate({ current, reference: null }), 'hard-quadrant-floor')?.status).toBe('pass')
+  })
+
+  it('skips the hard quadrant when the slice contains none of it', () => {
+    const current = at(0.9, {
+      classifier: 'agent',
+      hardQuadrant: { point: 0, lower: 0, upper: 1, support: 0, correct: 0 },
+    })
+    expect(check(runGate({ current, reference: null }), 'hard-quadrant-floor')?.status).toBe(
+      'skipped',
+    )
+  })
+})
+
+describe('beating the baseline', () => {
+  it('is not asked of the baseline itself', () => {
+    expect(check(runGate({ current: at(0.2), reference: null }), 'beats-baseline')?.status).toBe(
+      'skipped',
+    )
+  })
+
+  it('fails an agent that scores below the control', () => {
+    // Any regression against the control blocks: the delta is the result this
+    // project reports, so an agent that loses to sixty lines of heuristic has
+    // nothing to publish.
+    const report = runGate({
+      current: at(0.2, { classifier: 'agent' }),
+      reference: null,
+      baseline: at(0.3),
+    })
+    expect(check(report, 'beats-baseline')?.status).toBe('fail')
+  })
+
+  it('passes an agent that matches the control exactly', () => {
+    const report = runGate({
+      current: at(0.3, { classifier: 'agent' }),
+      reference: null,
+      baseline: at(0.3),
+    })
+    expect(check(report, 'beats-baseline')?.status).toBe('pass')
+  })
+})
+
+describe('checks waiting on a model', () => {
+  it('skips self-consistency while nothing is sampled', () => {
+    const result = check(runGate({ current: at(0.2), reference: null }), 'self-consistency')
+    expect(result?.status).toBe('skipped')
+    expect(result?.detail).toContain('#36')
+  })
+
+  it('fails an unstable classifier once stability is measured', () => {
+    const current = at(0.9, { selfConsistency: THRESHOLDS.selfConsistencyFloor - 0.01 })
+    expect(check(runGate({ current, reference: null }), 'self-consistency')?.status).toBe('fail')
+  })
+
+  it('skips cost while there is none', () => {
+    expect(check(runGate({ current: at(0.2), reference: null }), 'cost-per-fixture')?.status).toBe(
+      'skipped',
+    )
+  })
+
+  it('fails a sharp cost rise', () => {
+    const current = at(0.9, { costPerFixtureUsd: 0.016 })
+    const reference = at(0.9, { costPerFixtureUsd: 0.01 })
+    expect(check(runGate({ current, reference }), 'cost-per-fixture')?.status).toBe('fail')
+  })
+
+  it('allows a rise inside the allowance', () => {
+    const current = at(0.9, { costPerFixtureUsd: 0.01 * (1 + THRESHOLDS.costIncrease) })
+    const reference = at(0.9, { costPerFixtureUsd: 0.01 })
+    expect(check(runGate({ current, reference }), 'cost-per-fixture')?.status).toBe('pass')
+  })
+})
+
+describe('the report', () => {
+  it('covers every threshold in the methodology table', () => {
+    expect(
+      runGate({ current: at(0.2), reference: null })
+        .checks.map((c) => c.id)
+        .sort(),
+    ).toEqual([
+      'beats-baseline',
+      'cost-per-fixture',
+      'hard-quadrant-floor',
+      'joint-accuracy-floor',
+      'joint-accuracy-regression',
+      'self-consistency',
+    ])
+  })
+
+  it('lists skipped checks rather than hiding them', () => {
+    // A gate that silently omits what it did not check reads as a gate that
+    // checked everything.
+    const rendered = renderGateReport(runGate({ current: at(0.2), reference: null }))
+    expect(rendered.match(/skip/g)).toHaveLength(6)
+  })
+
+  it('tells a reader what to do when a threshold is crossed', () => {
+    const rendered = renderGateReport(runGate({ current: at(0.1), reference: at(0.3) }))
+    expect(rendered).toContain('FAIL')
+    expect(rendered).toContain('eval/gate.ts')
+    expect(rendered).toContain('reviewable')
+  })
+
+  it('says nothing extra when everything passes', () => {
+    expect(renderGateReport(runGate({ current: at(0.3), reference: at(0.3) }))).not.toContain(
+      'FAIL',
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+
+describe('the snapshot', () => {
+  const evaluation = evaluate(DEFAULTS)
+  const current = snapshot(
+    evaluation.metrics,
+    quadrantBreakdown(evaluation.fixtures.map((f) => f.judgement)),
+    { classifier: 'baseline', slice: 'dev', datasetRevision: evaluation.datasetRevision },
+  )
+
+  it('validates against its own schema', () => {
+    expect(MetricsSnapshotSchema.safeParse(current).success).toBe(true)
+  })
+
+  it('carries the hard quadrant separately from the headline', () => {
+    expect(current.hardQuadrant.support).toBeGreaterThan(0)
+    expect(current.hardQuadrant.point).not.toBe(current.joint.point)
+  })
+
+  it('records nulls rather than zeros for what is not measured', () => {
+    // Zero self-consistency and zero cost are claims. Absent is the truth, and
+    // the gate skips on null while it would fail on zero.
+    expect(current.selfConsistency).toBeNull()
+    expect(current.costPerFixtureUsd).toBeNull()
+  })
+
+  it('matches the file on disk, so the gate reads current numbers', () => {
+    // The report has its own freshness check; this is the same guarantee for the
+    // half the gate actually parses. A stale snapshot would let a regression
+    // compare against itself and pass.
+    expect(JSON.parse(readFileSync(METRICS_PATHS.dev, 'utf8'))).toEqual(current)
+  })
+})
+
+describe('reading a reference', () => {
+  it('returns null for a ref that has no snapshot', () => {
+    expect(
+      readReferenceSnapshot(METRICS_PATHS.dev, 'refs/tags/definitely-not-a-real-ref'),
+    ).toBeNull()
+  })
+
+  it('returns null for a path that does not exist on the ref', () => {
+    expect(readReferenceSnapshot('eval/no-such-file.json', 'HEAD')).toBeNull()
+  })
+})

--- a/eval/gate.ts
+++ b/eval/gate.ts
@@ -1,0 +1,430 @@
+import { execFileSync } from 'node:child_process'
+import { z } from 'zod'
+import type { Metrics } from './metrics.js'
+import type { QuadrantRow } from './confusion.js'
+
+/**
+ * The merge gate.
+ *
+ * It exists to stop a plausible-sounding prompt change from quietly making
+ * things worse. It also has to survive contact with reality: a gate that fires
+ * on noise gets switched off by whoever is on call at the time, and a gate that
+ * is off is worse than one that never existed, because everybody still believes
+ * it is there.
+ *
+ * Three properties follow from that.
+ *
+ * **Comparisons use interval lower bounds, never point estimates.** At n=22 a
+ * point estimate moves several percentage points between two classifiers that
+ * are indistinguishable. Gating on the lower bound means the gate fires when the
+ * evidence supports a regression, not when the dice do.
+ *
+ * **Thresholds start permissive.** The methodology says so, and the numbers here
+ * are the ones from its table rather than tighter guesses.
+ *
+ * **A check that cannot mean anything yet is skipped out loud.** Several
+ * thresholds in the methodology are targets for the finished agent, and the
+ * baseline misses them by a wide margin — the joint-accuracy floor of 0.65
+ * against a measured lower bound of 0.197, the hard-quadrant floor of 0.50
+ * against 0.097. Enabling those today would make `main` permanently red, which
+ * teaches everyone to merge past a red gate. They are implemented, listed in
+ * every run's output, and report the condition that will switch them on.
+ */
+
+export type Classifier = 'baseline' | 'agent'
+
+/**
+ * Every threshold from the table in docs/eval-methodology.md, in one place.
+ *
+ * Changing a number here changes what is allowed to merge, so each carries the
+ * reason it has the value it does. Ratcheting means editing this file in a
+ * reviewable commit, not adjusting a constant at a call site.
+ */
+export const THRESHOLDS = {
+  /**
+   * How far joint accuracy's lower bound may fall below the value recorded on
+   * `main` before the merge is blocked.
+   *
+   * 5pp is wide. It is meant to be: at n=22 the interval itself is ±19pp, so a
+   * tighter bound would fire on fixtures being added rather than on the
+   * classifier changing. It tightens as the dataset grows towards 60.
+   */
+  jointAccuracyRegressionPp: 0.05,
+
+  /**
+   * Absolute floor on joint accuracy's lower bound.
+   *
+   * A target for the agent, not a description of the baseline. Below roughly
+   * two thirds, a classification is not worth the developer attention it costs
+   * to read.
+   */
+  jointAccuracyFloor: 0.65,
+
+  /**
+   * Floor on accuracy within `app_code + intermittent`.
+   *
+   * The quadrant the project exists for. A classifier that scores well overall
+   * by getting the easy quadrants right has not done the job, so this is gated
+   * separately rather than averaged into the headline.
+   */
+  hardQuadrantFloor: 0.5,
+
+  /**
+   * Floor on how often the same fixture gets the same label across samples.
+   *
+   * A classifier that is accurate on average and unstable per fixture cannot be
+   * trusted at the level of an individual pull request comment, which is the
+   * only level at which anyone reads it.
+   */
+  selfConsistencyFloor: 0.8,
+
+  /** Proportional rise in cost per fixture that blocks a merge. */
+  costIncrease: 0.5,
+} as const
+
+// ---------------------------------------------------------------------------
+// The snapshot the gate compares
+// ---------------------------------------------------------------------------
+
+export interface Interval {
+  point: number
+  lower: number
+  upper: number
+}
+
+/**
+ * The machine-readable half of a run, committed next to the report.
+ *
+ * Separate from `report.md` because the gate has to read the values recorded on
+ * `main`, and parsing prose for numbers is a way of turning a formatting change
+ * into a silent gate failure.
+ */
+export interface MetricsSnapshot {
+  version: 1
+  classifier: Classifier
+  slice: string
+  datasetRevision: string
+  n: number
+  joint: Interval
+  owner: Interval & { macroF1: number }
+  determinism: Interval & { macroF1: number }
+  hardQuadrant: Interval & { support: number; correct: number }
+  /** Null until sampling exists — the baseline is deterministic (#36). */
+  selfConsistency: number | null
+  /** Null until a model is involved (#30). */
+  costPerFixtureUsd: number | null
+}
+
+const IntervalSchema = z.object({
+  point: z.number().min(0).max(1),
+  lower: z.number().min(0).max(1),
+  upper: z.number().min(0).max(1),
+})
+
+export const MetricsSnapshotSchema = z
+  .object({
+    version: z.literal(1),
+    classifier: z.enum(['baseline', 'agent']),
+    slice: z.string(),
+    datasetRevision: z.string(),
+    n: z.number().int().nonnegative(),
+    joint: IntervalSchema,
+    owner: IntervalSchema.extend({ macroF1: z.number() }),
+    determinism: IntervalSchema.extend({ macroF1: z.number() }),
+    hardQuadrant: IntervalSchema.extend({
+      support: z.number().int().nonnegative(),
+      correct: z.number().int().nonnegative(),
+    }),
+    selfConsistency: z.number().min(0).max(1).nullable(),
+    costPerFixtureUsd: z.number().nonnegative().nullable(),
+  })
+  .strict()
+
+/**
+ * The values recorded on another git ref, or null when that ref has none.
+ *
+ * A missing file is an ordinary state — the first run, or a branch older than
+ * this feature — and yields null so the comparison is skipped rather than
+ * failed. A file that exists but does not parse is a different thing entirely
+ * and throws: silently treating a corrupt reference as "no reference" would
+ * disable the gate exactly when something is wrong.
+ */
+export function readReferenceSnapshot(path: string, ref = 'origin/main'): MetricsSnapshot | null {
+  let raw: string
+  try {
+    raw = execFileSync('git', ['show', `${ref}:${path}`], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+  } catch {
+    return null
+  }
+
+  const parsed = MetricsSnapshotSchema.safeParse(JSON.parse(raw))
+  if (!parsed.success) {
+    throw new Error(
+      `${ref}:${path} exists but is not a valid metrics snapshot: ` +
+        `${parsed.error.issues[0]?.path.join('.') ?? ''} ${parsed.error.issues[0]?.message ?? ''}`,
+    )
+  }
+  return parsed.data
+}
+
+const interval = (p: { point: number; interval: { lower: number; upper: number } }): Interval => ({
+  point: p.point,
+  lower: p.interval.lower,
+  upper: p.interval.upper,
+})
+
+export function snapshot(
+  metrics: Metrics,
+  quadrants: readonly QuadrantRow[],
+  context: { classifier: Classifier; slice: string; datasetRevision: string },
+): MetricsSnapshot {
+  const hard = quadrants.find((q) => q.hard)
+
+  return {
+    version: 1,
+    classifier: context.classifier,
+    slice: context.slice,
+    datasetRevision: context.datasetRevision,
+    n: metrics.n,
+    joint: interval(metrics.joint),
+    owner: { ...interval(metrics.owner.accuracy), macroF1: metrics.owner.macroF1 },
+    determinism: {
+      ...interval(metrics.determinism.accuracy),
+      macroF1: metrics.determinism.macroF1,
+    },
+    hardQuadrant: {
+      ...interval(hard?.accuracy ?? { point: 0, interval: { lower: 0, upper: 1 } }),
+      support: hard?.support ?? 0,
+      correct: hard?.correct ?? 0,
+    },
+    selfConsistency: null,
+    costPerFixtureUsd: null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Checks
+// ---------------------------------------------------------------------------
+
+export type CheckStatus = 'pass' | 'fail' | 'skipped'
+
+export interface CheckResult {
+  id: string
+  /** What is being gated, in the words the report uses. */
+  metric: string
+  status: CheckStatus
+  /** Names both values and the threshold, so the failure is actionable without a rerun. */
+  detail: string
+}
+
+export interface GateInput {
+  current: MetricsSnapshot
+  /** The values recorded on `main`, or null on the first run and on `main` itself. */
+  reference: MetricsSnapshot | null
+  /** Present once both classifiers are scored — the delta is the project's headline. */
+  baseline?: MetricsSnapshot | null
+}
+
+export interface GateReport {
+  checks: CheckResult[]
+  failed: boolean
+}
+
+const pp = (n: number): string => `${(n * 100).toFixed(1)}pp`
+
+export function runGate(input: GateInput): GateReport {
+  const checks = [
+    jointRegression(input),
+    jointFloor(input),
+    hardQuadrantFloor(input),
+    beatsBaseline(input),
+    selfConsistency(input),
+    cost(input),
+  ]
+  return { checks, failed: checks.some((c) => c.status === 'fail') }
+}
+
+function jointRegression({ current, reference }: GateInput): CheckResult {
+  const id = 'joint-accuracy-regression'
+  const metric = 'joint accuracy (lower bound) against main'
+
+  if (reference === null) {
+    return { id, metric, status: 'skipped', detail: 'no metrics recorded on main to compare with' }
+  }
+  if (reference.slice !== current.slice) {
+    // Comparing a dev number with a held-out one would fire on the slice
+    // changing rather than on the classifier changing.
+    return {
+      id,
+      metric,
+      status: 'skipped',
+      detail: `main recorded the \`${reference.slice}\` slice, this run scored \`${current.slice}\``,
+    }
+  }
+
+  const allowed = reference.joint.lower - THRESHOLDS.jointAccuracyRegressionPp
+  const detail =
+    `${pp(current.joint.lower)} now, ${pp(reference.joint.lower)} on main ` +
+    `(allowed down to ${pp(allowed)}, a drop of ${pp(THRESHOLDS.jointAccuracyRegressionPp)})`
+
+  return { id, metric, status: current.joint.lower >= allowed ? 'pass' : 'fail', detail }
+}
+
+function jointFloor({ current }: GateInput): CheckResult {
+  const id = 'joint-accuracy-floor'
+  const metric = 'joint accuracy (lower bound) against the absolute floor'
+  const skip = agentOnly(current.classifier, THRESHOLDS.jointAccuracyFloor, current.joint.lower)
+  if (skip !== null) return { id, metric, ...skip }
+
+  return {
+    id,
+    metric,
+    status: current.joint.lower >= THRESHOLDS.jointAccuracyFloor ? 'pass' : 'fail',
+    detail: `${pp(current.joint.lower)} against a floor of ${pp(THRESHOLDS.jointAccuracyFloor)}`,
+  }
+}
+
+function hardQuadrantFloor({ current }: GateInput): CheckResult {
+  const id = 'hard-quadrant-floor'
+  const metric = '`app_code` + `intermittent` accuracy (lower bound)'
+  const skip = agentOnly(
+    current.classifier,
+    THRESHOLDS.hardQuadrantFloor,
+    current.hardQuadrant.lower,
+  )
+  if (skip !== null) return { id, metric, ...skip }
+
+  if (current.hardQuadrant.support === 0) {
+    return { id, metric, status: 'skipped', detail: 'no hard-quadrant fixtures in this slice' }
+  }
+
+  return {
+    id,
+    metric,
+    status: current.hardQuadrant.lower >= THRESHOLDS.hardQuadrantFloor ? 'pass' : 'fail',
+    detail:
+      `${pp(current.hardQuadrant.lower)} over ${String(current.hardQuadrant.support)} fixtures, ` +
+      `against a floor of ${pp(THRESHOLDS.hardQuadrantFloor)}`,
+  }
+}
+
+/**
+ * An absolute floor the baseline is nowhere near is a target, not a gate.
+ *
+ * Enabling it now would make `main` permanently red on a fact everybody already
+ * knows, and a permanently red gate is one people learn to merge past. The check
+ * still runs and still prints, so the distance to the target stays visible.
+ */
+function agentOnly(
+  classifier: Classifier,
+  floor: number,
+  observed: number,
+): Pick<CheckResult, 'status' | 'detail'> | null {
+  if (classifier === 'agent') return null
+  return {
+    status: 'skipped',
+    detail:
+      `a target for the agent, not the baseline — currently ${pp(observed)} against ` +
+      `${pp(floor)}. Enforced from M3, when \`--classifier=agent\` runs (#35).`,
+  }
+}
+
+function beatsBaseline({ current, baseline }: GateInput): CheckResult {
+  const id = 'beats-baseline'
+  const metric = 'agent joint accuracy against the baseline on the same fixtures'
+
+  if (current.classifier !== 'agent') {
+    return { id, metric, status: 'skipped', detail: 'this run scored the baseline itself' }
+  }
+  if (baseline === null || baseline === undefined) {
+    return { id, metric, status: 'skipped', detail: 'no baseline scored alongside this run' }
+  }
+
+  return {
+    id,
+    metric,
+    status: current.joint.lower >= baseline.joint.lower ? 'pass' : 'fail',
+    detail:
+      `agent ${pp(current.joint.lower)}, baseline ${pp(baseline.joint.lower)} — ` +
+      'any regression against the control blocks, since the delta is the result this project reports',
+  }
+}
+
+function selfConsistency({ current }: GateInput): CheckResult {
+  const id = 'self-consistency'
+  const metric = 'label stability across samples'
+
+  if (current.selfConsistency === null) {
+    return {
+      id,
+      metric,
+      status: 'skipped',
+      detail:
+        'not measured — the baseline is deterministic, so sampling means nothing until a model ' +
+        'is involved. Enforced from M3 (#36).',
+    }
+  }
+
+  return {
+    id,
+    metric,
+    status: current.selfConsistency >= THRESHOLDS.selfConsistencyFloor ? 'pass' : 'fail',
+    detail: `${pp(current.selfConsistency)} against a floor of ${pp(THRESHOLDS.selfConsistencyFloor)}`,
+  }
+}
+
+function cost({ current, reference }: GateInput): CheckResult {
+  const id = 'cost-per-fixture'
+  const metric = 'cost per fixture against main'
+
+  if (current.costPerFixtureUsd === null) {
+    return {
+      id,
+      metric,
+      status: 'skipped',
+      detail: 'no model call, so no cost. Enforced from M3 (#30).',
+    }
+  }
+  if (reference?.costPerFixtureUsd == null) {
+    return { id, metric, status: 'skipped', detail: 'no cost recorded on main to compare with' }
+  }
+
+  const allowed = reference.costPerFixtureUsd * (1 + THRESHOLDS.costIncrease)
+  return {
+    id,
+    metric,
+    status: current.costPerFixtureUsd <= allowed ? 'pass' : 'fail',
+    detail:
+      `$${current.costPerFixtureUsd.toFixed(4)} now, $${reference.costPerFixtureUsd.toFixed(4)} on main ` +
+      `(allowed up to $${allowed.toFixed(4)}, +${String(THRESHOLDS.costIncrease * 100)}%)`,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+
+const MARK: Record<CheckStatus, string> = { pass: 'pass', fail: 'FAIL', skipped: 'skip' }
+
+export function renderGateReport(report: GateReport): string {
+  const lines = report.checks.map(
+    (c) => `  ${MARK[c.status].padEnd(5)} ${c.metric}\n        ${c.detail}`,
+  )
+
+  const failed = report.checks.filter((c) => c.status === 'fail')
+  if (failed.length > 0) {
+    lines.push(
+      '',
+      `  ${String(failed.length)} threshold(s) crossed. The numbers above come from this run and`,
+      '  from the metrics recorded on main; neither is an estimate of the other.',
+      '',
+      '  If the change is a deliberate trade, say so in the pull request and move the',
+      '  threshold in eval/gate.ts in the same commit, so the decision is reviewable.',
+    )
+  }
+
+  return lines.join('\n')
+}

--- a/eval/holdout-log.json
+++ b/eval/holdout-log.json
@@ -6,6 +6,13 @@
       "slice": "holdout",
       "n": 11,
       "jointAccuracy": 0.36363636363636365
+    },
+    {
+      "date": "2026-08-11",
+      "datasetRevision": "0f6b7fcc27f49b04",
+      "slice": "holdout",
+      "n": 11,
+      "jointAccuracy": 0.36363636363636365
     }
   ]
 }

--- a/eval/holdout-metrics.json
+++ b/eval/holdout-metrics.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "classifier": "baseline",
+  "slice": "holdout",
+  "datasetRevision": "0f6b7fcc27f49b04",
+  "n": 11,
+  "joint": {
+    "point": 0.36363636363636365,
+    "lower": 0.15166471095367576,
+    "upper": 0.6461988254921511
+  },
+  "owner": {
+    "point": 0.6363636363636364,
+    "lower": 0.35380117450784887,
+    "upper": 0.8483352890463243,
+    "macroF1": 0.25925925925925924
+  },
+  "determinism": {
+    "point": 0.7272727272727273,
+    "lower": 0.43435469882387084,
+    "upper": 0.902539407099751,
+    "macroF1": 0.7179487179487178
+  },
+  "hardQuadrant": {
+    "point": 0.25,
+    "lower": 0.04558726080970055,
+    "upper": 0.6993581574175981,
+    "support": 4,
+    "correct": 1
+  },
+  "selfConsistency": null,
+  "costPerFixtureUsd": null
+}

--- a/eval/holdout-report.md
+++ b/eval/holdout-report.md
@@ -144,7 +144,7 @@ dataset grows towards the 60 fixtures the methodology targets.
 
 ## Held-out usage
 
-Last evaluated: **2026-08-11** · 1 evaluation(s) in the last 30 days · limit 3
+Last evaluated: **2026-08-11** · 2 evaluation(s) in the last 30 days · limit 3
 
 Every run is appended to [`eval/holdout-log.json`](holdout-log.json), which is committed. A log kept
 outside version control would be advisory in the worst way — absent on a fresh clone, and

--- a/eval/metrics.json
+++ b/eval/metrics.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "classifier": "baseline",
+  "slice": "dev",
+  "datasetRevision": "eb99bece4ad0347c",
+  "n": 22,
+  "joint": {
+    "point": 0.36363636363636365,
+    "lower": 0.19733204670366125,
+    "upper": 0.5704829190986899
+  },
+  "owner": {
+    "point": 0.5,
+    "lower": 0.3072210627372502,
+    "upper": 0.6927789372627497,
+    "macroF1": 0.3817204301075268
+  },
+  "determinism": {
+    "point": 0.8181818181818182,
+    "lower": 0.6148339256287345,
+    "upper": 0.9269311541657794,
+    "macroF1": 0.8035714285714286
+  },
+  "hardQuadrant": {
+    "point": 0.3333333333333333,
+    "lower": 0.09677141110578041,
+    "upper": 0.700006684861608,
+    "support": 6,
+    "correct": 2
+  },
+  "selfConsistency": null,
+  "costPerFixtureUsd": null
+}

--- a/eval/run-eval.ts
+++ b/eval/run-eval.ts
@@ -13,6 +13,7 @@ import {
   type ScoredFixture,
 } from './confusion.js'
 import { DATASET_DIR, listFixtures, loadLabels, loadPayload } from './dataset.js'
+import { readReferenceSnapshot, renderGateReport, runGate, snapshot } from './gate.js'
 import { formatProportion, score, type Metrics } from './metrics.js'
 import {
   appendHoldoutRun,
@@ -54,9 +55,11 @@ export interface Options {
   classifier: 'baseline' | 'agent'
   slice: SliceSelector
   samples: number
-  /** Verify the committed report is current instead of rewriting it. */
+  /** Verify the committed report is current, and hold the numbers to the thresholds. */
   gate: boolean
   out: string
+  /** Git ref holding the metrics a regression is measured against. */
+  reference: string
 }
 
 /**
@@ -74,6 +77,20 @@ export const REPORT_PATHS: Record<SliceSelector, string> = {
 }
 
 /**
+ * The machine-readable half, written beside each report.
+ *
+ * The gate has to read the values recorded on `main`, and parsing prose for
+ * numbers turns a formatting change into a silent gate failure. Two artefacts
+ * for one run is the cost of not having a regex over a markdown table decide
+ * what merges.
+ */
+export const METRICS_PATHS: Record<SliceSelector, string> = {
+  dev: 'eval/metrics.json',
+  holdout: 'eval/holdout-metrics.json',
+  all: 'eval/metrics-all.json',
+}
+
+/**
  * The default slice is `dev`, not `all`.
  *
  * This is the whole discipline in one line. Anything that runs habitually — the
@@ -86,6 +103,7 @@ export const DEFAULTS: Options = {
   samples: 1,
   gate: false,
   out: REPORT_PATHS.dev,
+  reference: 'origin/main',
 }
 
 /** Capabilities the CLI accepts but cannot do yet, with the issue that will land them. */
@@ -124,6 +142,10 @@ export function parseArgs(argv: string[]): Options {
         break
       case 'gate':
         options.gate = true
+        break
+      case 'reference':
+        if (value === undefined || value === '') throw new UsageError(`--reference needs a git ref`)
+        options.reference = value
         break
       case 'out':
         if (value === undefined || value === '') throw new UsageError(`--out needs a path`)
@@ -600,7 +622,9 @@ const USAGE = `
     --classifier=baseline|agent   which classifier to score   (default: baseline)
     --slice=dev|holdout|all       which fixtures to use       (default: all)
     --n=<number>                  samples per fixture         (default: 1)
-    --gate                        verify the committed report is current, write nothing
+    --gate                        verify the committed report is current and hold it to
+                                  the thresholds in eval/gate.ts; writes nothing
+    --reference=<git-ref>         what a regression is measured against (default: origin/main)
     --out=<path>                  where to write              (default: eval/report.md)
 `
 
@@ -663,11 +687,33 @@ async function main(argv: string[]): Promise<number> {
     )
   }
 
+  const current = snapshot(
+    evaluation.metrics,
+    quadrantBreakdown(
+      evaluation.fixtures.filter((f) => !f.labels.lowConfidenceGroundTruth).map((f) => f.judgement),
+    ),
+    {
+      classifier: options.classifier,
+      slice: options.slice,
+      datasetRevision: evaluation.datasetRevision,
+    },
+  )
+  const metricsPath = metricsPathFor(options)
+
   if (options.gate) {
     const committed = readCommitted(options.out)
     if (committed === report) {
       console.log(`\n  ${options.out} is up to date.\n`)
-      return 0
+
+      // Freshness only says the report matches the code. The thresholds say
+      // whether the numbers it contains are allowed to merge.
+      const gate = runGate({
+        current,
+        reference: readReferenceSnapshot(metricsPath, options.reference),
+      })
+      console.log(`  Thresholds against \`${options.reference}\`:\n`)
+      console.log(`${renderGateReport(gate)}\n`)
+      return gate.failed ? 1 : 0
     }
     const cause =
       committed === null
@@ -694,8 +740,16 @@ async function main(argv: string[]): Promise<number> {
   }
 
   writeFileSync(options.out, report)
-  console.log(`\n  Wrote ${options.out}\n`)
+  writeFileSync(metricsPath, `${JSON.stringify(current, null, 2)}\n`)
+  console.log(`\n  Wrote ${options.out} and ${metricsPath}\n`)
   return 0
+}
+
+/** Follows `--out` when it was given, so a redirected run does not clobber the committed pair. */
+function metricsPathFor(options: Options): string {
+  return options.out === REPORT_PATHS[options.slice]
+    ? METRICS_PATHS[options.slice]
+    : options.out.replace(/\.md$/, '.metrics.json')
 }
 
 function readCommitted(path: string): string | null {

--- a/eval/slices.ts
+++ b/eval/slices.ts
@@ -140,6 +140,16 @@ export function emptyHoldoutBuckets(composition: readonly SliceComposition[]): s
 export const OVERUSE_LIMIT = 3
 export const OVERUSE_WINDOW_DAYS = 30
 
+/**
+ * The log counts runs, not insights, and over-counts on purpose.
+ *
+ * Regenerating the held-out report after a formatting change teaches nobody
+ * anything, and in a strict sense should not spend budget. But the tool cannot
+ * tell that from a real consultation, and any flag meaning "this one does not
+ * count" is a flag for never counting. Erring towards over-counting costs an
+ * occasional early warning; erring the other way costs the entire mechanism.
+ */
+
 export const HOLDOUT_LOG = 'eval/holdout-log.json'
 
 const HoldoutRunSchema = z

--- a/wiki/Evaluation-Methodology.md
+++ b/wiki/Evaluation-Methodology.md
@@ -187,6 +187,34 @@ behind every number.
 lowest number reported, and reporting the axes separately without it would be the most natural way
 to accidentally flatter the classifier.
 
+## The merge gate
+
+`npm run eval -- --gate` runs on every pull request. It verifies the committed report and metrics
+match a fresh run, then holds those numbers to the thresholds in `eval/gate.ts` — one file, each
+value carrying the reason it has the value it does.
+
+| Condition                                                           | Threshold      | Active |
+| ------------------------------------------------------------------- | -------------- | ------ |
+| Joint accuracy lower bound drops below the value recorded on `main` | −5pp           | yes    |
+| Joint accuracy lower bound below absolute floor                     | 0.65           | M3     |
+| Agent fails to beat the baseline on joint accuracy                  | any regression | M3     |
+| Self-consistency below floor                                        | 0.80           | M3     |
+| Hard-quadrant accuracy lower bound below floor                      | 0.50           | M3     |
+| Cost per fixture rises sharply                                      | +50%           | M3     |
+
+Five of the six are targets for the **agent**, not descriptions of the baseline — whose joint
+accuracy lower bound is 0.197 against a floor of 0.65. Enabling them today would make `main`
+permanently red on facts everybody already knows, and a permanently red gate is one people learn to
+merge past. They are implemented, printed on every run with the current distance to the target, and
+each names the condition that switches it on.
+
+Comparisons use interval **lower bounds**, never point estimates: at this dataset size a point
+estimate moves several percentage points between two classifiers that are indistinguishable, so
+gating on it would fire on the dice.
+
+Ratcheting means editing `gate.ts` in a reviewable commit. There is no runtime override — a gate
+you can wave through at 3am is not a gate.
+
 ## The ablation study
 
 `npm run eval:ablation` re-runs the dataset with parts of the context removed: no history, no diff,


### PR DESCRIPTION
Closes #29.

`npm run eval -- --gate` now does two things: verifies the committed report and metrics match a fresh run, and holds those numbers to the thresholds from the methodology table. All six live in `eval/gate.ts`, one file, each carrying the reason it has the value it does.

## Lower bounds, never point estimates

At n=22 a point estimate moves several percentage points between two classifiers that are indistinguishable, so gating on it would fire on the dice. One test makes that concrete: a classifier whose point estimate **rose** from 0.4 to 0.9 while its lower bound **fell** from 0.30 to 0.10 has got noisier, not better — and the gate fails it.

## Five of the six thresholds are agent targets, and saying so is the point

| Condition | Threshold | Active |
| --- | --- | --- |
| Joint accuracy lower bound drops below the value on `main` | −5pp | **yes** |
| Joint accuracy lower bound below absolute floor | 0.65 | M3 |
| Agent fails to beat the baseline | any regression | M3 |
| Self-consistency below floor | 0.80 | M3 |
| Hard-quadrant accuracy lower bound below floor | 0.50 | M3 |
| Cost per fixture rises sharply | +50% | M3 |

The baseline's joint accuracy lower bound is **0.197 against a floor of 0.65**; its hard-quadrant lower bound is **0.097 against 0.50**. Switching those on today would make `main` permanently red on facts everybody already knows — and a permanently red gate is one people learn to merge past, which is worse than no gate because everyone still believes it is there.

So they are implemented, printed on every run with the current distance to the target, and each names the condition that switches it on:

```
  skip  joint accuracy (lower bound) against the absolute floor
        a target for the agent, not the baseline — currently 19.7pp against 65.0pp.
        Enforced from M3, when `--classifier=agent` runs (#35).
```

What is left active is the one check that means something today: nothing may make the classifier measurably worse than what is recorded on `main`.

## Verified end to end, not only in unit tests

A gate that has never fired is a gate nobody has tested. Against a throwaway ref recording an inflated 90%:

```
$ npx tsx eval/run-eval.ts --gate --reference=tmp-inflated
  FAIL  joint accuracy (lower bound) against main
        19.7pp now, 90.0pp on main (allowed down to 85.0pp, a drop of 5.0pp)
...
  1 threshold(s) crossed.
  If the change is a deliberate trade, say so in the pull request and move the
  threshold in eval/gate.ts in the same commit, so the decision is reviewable.

EXIT=1
```

## Reading the reference

The gate compares against `origin/main:eval/metrics.json` — a machine-readable snapshot written beside each report. Parsing prose for numbers would turn a formatting change into a silent gate failure, which is the specific way a gate stops working without anybody noticing.

- A **missing** snapshot yields null and skips the comparison. The first run, and any branch older than this feature, are ordinary states.
- A snapshot that **exists but does not parse** throws instead. Treating a corrupt reference as "no reference" would disable the gate exactly when something is wrong.
- A **dev** number is never compared against a **held-out** one. That would fire on the slice changing rather than the classifier changing.

## Why the CI job still always runs

The AC asks for the job to run only when `agents/`, `eval/` or `prompts/` changed. It is also a **required status check**, and a required check that skips leaves a PR waiting forever for a status that never arrives — the deadlock `docs/branching-strategy.md` already warns about.

Reconciled by running the job always and letting path detection decide how much work it does, exported as `SENTRA_EVAL_SCOPE_CHANGED`. Today the whole evaluation is free — no model, no network — so it runs either way. From M3 that flag is what stops a documentation-only change from paying for a model run.

## One honest side effect

The held-out log gained a second entry from regenerating the report after a format change. Left in, with the reason recorded in `slices.ts` and the methodology: **the log counts runs, not insights, and over-counts on purpose.** Any flag meaning "this one does not count" is a flag for never counting. Erring towards over-counting costs an occasional early warning; erring the other way costs the mechanism.

## Verification

`npx eslint .`, `npx tsc --build`, `npx prettier --check .`, `npm run eval:lint`, `npm run docs:status:check`, `npm run eval -- --gate` all clean. **663 unit tests pass**, up from 632.
