### PR TITLE
fix(eval): test the guards nothing was watching, and set a coverage floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,10 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - run: npm ci
-      - run: npm run test:unit -- --coverage
+      # test:coverage rather than `test:unit -- --coverage`, so the invocation CI
+      # runs is the one a contributor can run locally by name. The thresholds in
+      # vitest.config.ts fail the job on their own.
+      - run: npm run test:coverage
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,12 +19,28 @@ someone else could pick up any issue and know exactly what "done" means.
 git clone https://github.com/AKogut/ai-flaky-test-triage.git
 cd ai-flaky-test-triage
 npm install
-npm run demo            # full pipeline in replay mode — no API key needed
+npm run help            # every command, what it does, and whether it exists yet
+```
+
+What runs today:
+
+```bash
+npm run test:coverage   # the full suite, with the coverage floor enforced
+npm run eval            # score the baseline against the golden dataset
+npm run eval:lint       # dataset composition and label-leakage check
+npm run lint && npm run typecheck
+```
+
+And what does not yet, with the milestone it arrives in:
+
+```bash
+npm run demo            # 🚧 M3 · #39 — full pipeline in replay mode, no API key
+npm run dev             # 🚧 M4 · #48 — start TaskFlow locally
+npm test                # 🚧 M5 · #50 — unit and e2e together
 ```
 
 Requires Node ≥ 22.13 — the floor ESLint 10 sets, not an arbitrary one. An `ANTHROPIC_API_KEY` is
-only needed for live model calls; everything else,
-including the whole test suite, runs in replay mode.
+only needed for live model calls; nothing that works today needs one.
 
 ```bash
 cp .env.example .env    # optional, for live runs
@@ -106,14 +122,26 @@ The highest-leverage and easiest-to-fool area of the project.
 ## Running the evaluation
 
 ```bash
-npm run eval                      # full dataset, N=5 samples per fixture
-npm run eval -- --slice=dev       # development slice only
-npm run eval -- --n=1 --replay    # fast, free, deterministic — for wiring changes
-npm run eval:ablation             # context ablation study
+npm run eval                     # development slice, baseline → eval/report.md
+npm run eval -- --gate           # verify the committed report and apply the thresholds
+npm run eval -- --slice=holdout  # the held-out slice — see the budget below
+npm run eval:ablation            # 🚧 M9 · #74
 ```
 
-Results land in `eval/report.md` and `eval/ablation.md`. Both are committed, so a regression shows
-up as a diff.
+`--classifier=agent` parses today and then declines: the agent lands in M3 (#35). The command
+itself works, only that value does not, which is why it carries no marker above — a 🚧 on a line
+beginning `npm run eval` would read as the whole command being unbuilt.
+
+The default is the **development slice**, not the whole dataset. That is the discipline: anything
+run habitually must not touch the held-out fixtures, or they stop being held out.
+
+`eval/report.md` and `eval/metrics.json` are committed, so a regression shows up as a diff. `--gate`
+is what keeps that true — it regenerates in memory and fails if the committed pair disagrees, then
+applies the thresholds in `eval/gate.ts`. Run it before pushing; CI runs the same command.
+
+**The held-out slice has a budget.** Every `--slice=holdout` or `--slice=all` run is appended to
+`eval/holdout-log.json`, which is committed. Past three evaluations in 30 days the harness warns.
+Iterate against `--slice=dev`; the held-out slice is for confirming a result, not finding one.
 
 ## Reporting a misclassification
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 <!-- status:start -->
 
-> **Project status: M2 — Golden dataset, baseline & eval harness.**
-> 2 of 11 milestones complete.
-> Current exit criterion: `npm run eval` scores the baseline heuristic on ≥30 labelled fixtures and writes a report with per-axis accuracy, intervals, and both confusion matrices — with no model involved.
+> **Project status: M3 — Triage agent & replay mode.**
+> 3 of 11 milestones complete.
+> Current exit criterion: the triage agent beats the baseline on joint accuracy by a margin that survives its confidence interval — or the finding that it does not is documented in the README. Either way, `npm run demo` runs the classifier end to end with no API key.
 >
 > Progress is tracked as [milestones](https://github.com/AKogut/ai-flaky-test-triage/milestones), not dates.
 > Commands marked 🚧 in the script table are not implemented yet and say so when run.
@@ -140,20 +140,21 @@ cat eval/report.md
 
 ### Script reference
 
-| Script                       | Milestone | What it does                                               |
-| ---------------------------- | --------- | ---------------------------------------------------------- |
-| `npm run help`               | M0        | Annotated listing of every pipeline command and its status |
-| `npm run dev`                | M4 🚧     | Start TaskFlow (API + client) locally                      |
-| `npm run build`              | M4 🚧     | Build the TaskFlow client bundle                           |
-| `npm run test:unit`          | M0        | Vitest — API, flakemetry-lib, prompt builders, contracts   |
-| `npm run test:e2e`           | M5 🚧     | Playwright — TaskFlow UI flows including the flaky specs   |
-| `npm test`                   | M5 🚧     | Unit and E2E together; emits results.json                  |
-| `npm run flakemetry:analyze` | M6 🚧     | Test report + history → analysis.json                      |
-| `npm run agents:analyze`     | M7 🚧     | analysis.json → report.md                                  |
-| `npm run analyze`            | M8 🚧     | flakemetry and agents in sequence                          |
-| `npm run eval`               | M2        | Golden-dataset evaluation → eval/report.md                 |
-| `npm run eval:ablation`      | M9 🚧     | Context-ablation study → eval/ablation.md                  |
-| `npm run demo`               | M3 🚧     | Full pipeline in replay mode, no credentials               |
+| Script                       | Milestone | What it does                                                  |
+| ---------------------------- | --------- | ------------------------------------------------------------- |
+| `npm run help`               | M0        | Annotated listing of every pipeline command and its status    |
+| `npm run dev`                | M4 🚧     | Start TaskFlow (API + client) locally                         |
+| `npm run build`              | M4 🚧     | Build the TaskFlow client bundle                              |
+| `npm run test:unit`          | M0        | Vitest — API, flakemetry-lib, prompt builders, contracts      |
+| `npm run test:coverage`      | M2        | Vitest with coverage, enforcing the floor in vitest.config.ts |
+| `npm run test:e2e`           | M5 🚧     | Playwright — TaskFlow UI flows including the flaky specs      |
+| `npm test`                   | M5 🚧     | Unit and E2E together; emits results.json                     |
+| `npm run flakemetry:analyze` | M6 🚧     | Test report + history → analysis.json                         |
+| `npm run agents:analyze`     | M7 🚧     | analysis.json → report.md                                     |
+| `npm run analyze`            | M8 🚧     | flakemetry and agents in sequence                             |
+| `npm run eval`               | M2        | Golden-dataset evaluation → eval/report.md                    |
+| `npm run eval:ablation`      | M9 🚧     | Context-ablation study → eval/ablation.md                     |
+| `npm run demo`               | M3 🚧     | Full pipeline in replay mode, no credentials                  |
 
 🚧 marks a script that is not implemented yet; running it says so and names its issue.
 Everything else runs today. `npm run help` prints this table from the terminal.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,7 +39,7 @@ The measurement apparatus, built before the thing it measures. Hand-authored adv
 the non-LLM baseline heuristic, metrics with confidence intervals, confusion matrices, and the CI
 gate.
 
-**Status:** in progress
+**Status:** done
 
 **Exit criterion:** `npm run eval` scores the baseline heuristic on ≥30 labelled fixtures and
 writes a report with per-axis accuracy, intervals, and both confusion matrices — with no model
@@ -50,7 +50,7 @@ involved.
 The first model call. Structured output, the shared rubric, prompt versioning, cassette
 record/replay, calibration measurement, and self-consistency sampling.
 
-**Status:** planned
+**Status:** in progress
 
 **Exit criterion:** the triage agent beats the baseline on joint accuracy by a margin that survives
 its confidence interval — or the finding that it does not is documented in the README. Either way,

--- a/eval/cli.test.ts
+++ b/eval/cli.test.ts
@@ -1,0 +1,207 @@
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { listFixtures, loadLabels, loadPayload } from './dataset.js'
+import { main as hygieneMain } from './hygiene.js'
+import { main as evalMain } from './run-eval.js'
+
+/**
+ * The command-line surfaces and the guards that only fire when something is
+ * wrong.
+ *
+ * These paths were the least covered in the repository, which is the wrong way
+ * round: a guard whose failing branch has never run is a guard nobody has
+ * watched work, and an exit code nothing asserts is a CI gate that might be
+ * returning zero on failure.
+ */
+
+const quiet = () => {
+  vi.spyOn(console, 'log').mockImplementation(() => undefined)
+  vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+  vi.spyOn(console, 'error').mockImplementation(() => undefined)
+}
+
+const scratch = (): string => mkdtempSync(join(tmpdir(), 'sentra-cli-'))
+
+beforeEach(quiet)
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// dataset.ts guards
+// ---------------------------------------------------------------------------
+
+describe('the dataset refuses to load something incomplete', () => {
+  const dir = (files: Record<string, unknown>): string => {
+    const path = scratch()
+    for (const [file, body] of Object.entries(files)) {
+      writeFileSync(join(path, file), JSON.stringify(body))
+    }
+    return path
+  }
+
+  const payload = loadPayload(listFixtures()[0] ?? '').payload
+  const labels = loadLabels(listFixtures()[0] ?? '')
+
+  it('throws on a payload with no labels rather than scoring fewer fixtures than it says', () => {
+    // The failure this prevents is silent: the fixture simply vanishes, and
+    // every published metric is computed over a smaller dataset than the report
+    // claims.
+    const path = dir({ 'orphan.run.json': { ...payload, name: 'orphan' } })
+    expect(() => listFixtures(path)).toThrow(/Incomplete fixtures/)
+    expect(() => listFixtures(path)).toThrow(/orphan\.run\.json has no \.labels\.json/)
+  })
+
+  it('throws on labels with no payload', () => {
+    const path = dir({ 'orphan.labels.json': { ...labels, name: 'orphan' } })
+    expect(() => listFixtures(path)).toThrow(/orphan\.labels\.json has no \.run\.json/)
+  })
+
+  it('names every orphan, not just the first', () => {
+    const path = dir({
+      'a.run.json': { ...payload, name: 'a' },
+      'b.run.json': { ...payload, name: 'b' },
+    })
+    const message = (() => {
+      try {
+        listFixtures(path)
+        return ''
+      } catch (error) {
+        return error instanceof Error ? error.message : ''
+      }
+    })()
+    expect(message).toContain('a.run.json')
+    expect(message).toContain('b.run.json')
+  })
+
+  it('refuses a payload whose declared name disagrees with its filename', () => {
+    // Two names for one fixture means a report row and a labels file that look
+    // related and are not.
+    const path = dir({
+      'stated-one-thing.run.json': { ...payload, name: 'declares-another' },
+      'stated-one-thing.labels.json': { ...labels, name: 'stated-one-thing' },
+    })
+    expect(() => loadPayload('stated-one-thing', path)).toThrow(/the two must match/)
+  })
+
+  it('refuses labels whose declared name disagrees with the filename', () => {
+    const path = dir({
+      'stated-one-thing.run.json': { ...payload, name: 'stated-one-thing' },
+      'stated-one-thing.labels.json': { ...labels, name: 'declares-another' },
+    })
+    expect(() => loadLabels('stated-one-thing', path)).toThrow(/the two must match/)
+  })
+
+  it('ignores files that are neither half of a fixture', () => {
+    const path = dir({
+      'a.run.json': { ...payload, name: 'a' },
+      'a.labels.json': { ...labels, name: 'a' },
+    })
+    writeFileSync(join(path, 'README.md'), '# not a fixture')
+    expect(listFixtures(path)).toEqual(['a'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// npm run eval:lint
+// ---------------------------------------------------------------------------
+
+describe('the hygiene CLI', () => {
+  it('passes on the committed dataset', () => {
+    expect(hygieneMain()).toBe(0)
+  })
+
+  it('returns a failing code when a fixture is incomplete', () => {
+    // Previously this branch called process.exit, so nothing could assert it —
+    // the one path that fails the build was the one path never exercised.
+    const path = scratch()
+    const first = listFixtures()[0] ?? ''
+    writeFileSync(
+      join(path, 'lonely.run.json'),
+      JSON.stringify({ ...loadPayload(first).payload, name: 'lonely' }),
+    )
+    expect(hygieneMain(path)).toBe(1)
+  })
+
+  it('returns zero for an empty directory, which is unfinished rather than broken', () => {
+    expect(hygieneMain(scratch())).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// npm run eval
+// ---------------------------------------------------------------------------
+
+describe('the eval CLI', () => {
+  it('writes a report and its metrics, and says where', async () => {
+    const out = join(scratch(), 'report.md')
+    expect(await evalMain([`--out=${out}`])).toBe(0)
+    expect(existsSync(out)).toBe(true)
+    expect(existsSync(out.replace(/\.md$/, '.metrics.json'))).toBe(true)
+  })
+
+  it('keeps the metrics beside a redirected report rather than clobbering the committed pair', () => {
+    // `--out=/tmp/x.md` writing eval/metrics.json would silently overwrite the
+    // file the gate compares against.
+    const out = join(scratch(), 'report.md')
+    expect(existsSync('eval/metrics.json')).toBe(true)
+    const before = readFileSync('eval/metrics.json', 'utf8')
+    return evalMain([`--out=${out}`]).then(() => {
+      expect(readFileSync('eval/metrics.json', 'utf8')).toBe(before)
+    })
+  })
+
+  it.each([
+    ['an unknown flag', ['--slyce=dev']],
+    ['a bare argument', ['dev']],
+    ['a bad value', ['--slice=everything']],
+    ['a fractional sample count', ['--n=1.5']],
+  ])('exits 2 on %s', async (_case, argv) => {
+    // Distinct from 1: usage errors are the caller's mistake, threshold
+    // failures are the classifier's, and CI reads the difference.
+    expect(await evalMain(argv)).toBe(2)
+  })
+
+  it('exits 2 on a capability that does not exist yet', async () => {
+    expect(await evalMain(['--classifier=agent'])).toBe(2)
+  })
+
+  it('exits 1 when the report it is gating on is missing', async () => {
+    const out = join(scratch(), 'nothing-here.md')
+    expect(await evalMain(['--gate', `--out=${out}`])).toBe(1)
+  })
+
+  it('exits 1 when the committed report is stale', async () => {
+    const out = join(scratch(), 'report.md')
+    await evalMain([`--out=${out}`])
+    writeFileSync(out, `${readFileSync(out, 'utf8')}\nedited by hand\n`)
+    expect(await evalMain(['--gate', `--out=${out}`])).toBe(1)
+  })
+
+  it('exits 0 when the committed report is current', async () => {
+    const out = join(scratch(), 'report.md')
+    await evalMain([`--out=${out}`])
+    expect(await evalMain(['--gate', `--out=${out}`])).toBe(0)
+  })
+
+  it('gates on the committed report in the repository', async () => {
+    // The check CI runs, run here so the failure arrives before the push.
+    expect(await evalMain(['--gate'])).toBe(0)
+  })
+
+  it('notes that sampling the baseline more than once is wasted', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    await evalMain([`--out=${join(scratch(), 'r.md')}`, '--n=5'])
+    expect(log.mock.calls.flat().join('\n')).toContain('deterministic')
+  })
+
+  it('does not touch the held-out log while gating', async () => {
+    // A verification is not a consultation. If `--gate` logged, CI would spend
+    // the budget on work nobody chose to do.
+    const before = readFileSync('eval/holdout-log.json', 'utf8')
+    await evalMain(['--gate'])
+    expect(readFileSync('eval/holdout-log.json', 'utf8')).toBe(before)
+  })
+})

--- a/eval/hygiene.ts
+++ b/eval/hygiene.ts
@@ -183,8 +183,13 @@ export function runHygiene(dir: string = DATASET_DIR): HygieneReport {
 
 const pct = (n: number): string => `${(n * 100).toFixed(0)}%`
 
-function main(): void {
-  const report = runHygiene()
+/**
+ * Returns the exit code rather than calling `process.exit`, so the failure path
+ * is testable. A guard whose only untested branch is the one that fails the
+ * build is a guard nobody has watched work.
+ */
+export function main(dir: string = DATASET_DIR): number {
+  const report = runHygiene(dir)
 
   console.log(`\n  Golden dataset: ${String(report.fixtures)} fixtures\n`)
   console.log('  bucket                       count   share   target')
@@ -207,9 +212,10 @@ function main(): void {
     console.error(
       `\n  ${String(report.errors.length)} problem(s). See eval/golden-dataset/README.md.\n`,
     )
-    process.exit(1)
+    return 1
   }
   console.log('\n  No leakage or pairing problems found.\n')
+  return 0
 }
 
-if (process.argv[1]?.endsWith('hygiene.ts') === true) main()
+if (process.argv[1]?.endsWith('hygiene.ts') === true) process.exitCode = main()

--- a/eval/run-eval.ts
+++ b/eval/run-eval.ts
@@ -628,7 +628,7 @@ const USAGE = `
     --out=<path>                  where to write              (default: eval/report.md)
 `
 
-async function main(argv: string[]): Promise<number> {
+export async function main(argv: string[]): Promise<number> {
   let options: Options
   try {
     options = parseArgs(argv)

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "test:unit": "vitest run",
     "typecheck": "tsc --build",
     "typecheck:clean": "tsc --build --clean",
-    "wiki:publish": "./scripts/publish-wiki.sh"
+    "wiki:publish": "./scripts/publish-wiki.sh",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@commitlint/cli": "21.2.1",

--- a/scripts/script-manifest.json
+++ b/scripts/script-manifest.json
@@ -30,6 +30,13 @@
       "status": "implemented"
     },
     {
+      "name": "test:coverage",
+      "description": "Vitest with coverage, enforcing the floor in vitest.config.ts",
+      "milestone": "M2",
+      "issue": 123,
+      "status": "implemented"
+    },
+    {
       "name": "test:e2e",
       "description": "Playwright — TaskFlow UI flows including the flaky specs",
       "milestone": "M5",

--- a/tests/unit/status-banner.test.ts
+++ b/tests/unit/status-banner.test.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
@@ -117,8 +118,7 @@ describe('the committed pages', () => {
    * `eval:ablation` or `analyze`. A guard that has to be remembered is a guard
    * that eventually lies.
    */
-  describe('unimplemented commands in the wiki quickstart (#116)', () => {
-    const page = readFileSync(join(root, 'wiki/Getting-Started.md'), 'utf8')
+  describe('unimplemented commands in every document that shows one (#116, #134)', () => {
     const manifest = JSON.parse(
       readFileSync(join(root, 'scripts/script-manifest.json'), 'utf8'),
     ) as { scripts: { name: string; status: 'implemented' | 'pending' }[] }
@@ -126,30 +126,70 @@ describe('the committed pages', () => {
     /** `test:unit` → `npm run test:unit`; `test` → `npm test`. */
     const invocation = (name: string): string => (name === 'test' ? 'npm test' : `npm run ${name}`)
 
-    /** Lines that invoke the command, excluding longer names that contain it. */
-    const mentions = (command: string): string[] =>
-      page
-        .split('\n')
-        .filter((line) => new RegExp(`${command}(?![\\w:-])`).test(line) && line.includes('#'))
+    /**
+     * Every tracked document, rather than the one page somebody remembered.
+     *
+     * The first version named `wiki/Getting-Started.md` alone, and
+     * `CONTRIBUTING.md` — the file a contributor reads immediately before
+     * typing the commands, so the worst place for a false one — described
+     * `npm run demo` and a whole evaluation section in the present tense the
+     * entire time (#134).
+     */
+    const documents = execSync('git ls-files "*.md"', { cwd: root, encoding: 'utf8' })
+      .split('\n')
+      .filter((file) => file !== '')
+
+    /**
+     * Lines that present a command with an inline annotation.
+     *
+     * The `#` is what separates "here is a command to run" from prose that
+     * happens to name one. A sentence explaining why `npm test` will eventually
+     * contain flaky specs is not a promise that it runs today.
+     */
+    const annotatedMentions = (command: string): { file: string; line: string }[] =>
+      documents.flatMap((file) =>
+        readFileSync(join(root, file), 'utf8')
+          .split('\n')
+          .filter((line) => new RegExp(`${command}(?![\\w:-])`).test(line) && line.includes('#'))
+          .map((line) => ({ file, line })),
+      )
 
     it.each(manifest.scripts.filter((s) => s.status === 'pending').map((s) => s.name))(
-      'npm run %s is shown with a marker',
+      '%s is shown with a marker wherever it is annotated',
       (name) => {
-        for (const line of mentions(invocation(name))) {
-          expect(line, `"${line.trim()}" describes a pending command with no 🚧`).toContain('🚧')
-        }
-      },
-    )
-
-    it.each(manifest.scripts.filter((s) => s.status === 'implemented').map((s) => s.name))(
-      'npm run %s is not marked as pending',
-      (name) => {
-        for (const line of mentions(invocation(name))) {
-          expect(line, `"${line.trim()}" marks an implemented command as pending`).not.toContain(
+        for (const { file, line } of annotatedMentions(invocation(name))) {
+          expect(line, `${file}: "${line.trim()}" shows a pending command with no 🚧`).toContain(
             '🚧',
           )
         }
       },
     )
+
+    it.each(manifest.scripts.filter((s) => s.status === 'implemented').map((s) => s.name))(
+      '%s is never marked as pending',
+      (name) => {
+        for (const { file, line } of annotatedMentions(invocation(name))) {
+          expect(
+            line,
+            `${file}: "${line.trim()}" marks an implemented command as pending`,
+          ).not.toContain('🚧')
+        }
+      },
+    )
+
+    it('marks the README script table in step with the manifest', () => {
+      // The table is the canonical listing, and its milestone column carries the
+      // marker separately from the quickstart blocks above it.
+      const readme = readFileSync(join(root, 'README.md'), 'utf8')
+      for (const entry of manifest.scripts) {
+        const row = readme
+          .split('\n')
+          .find((line) => new RegExp(`^\\| \`${invocation(entry.name)}\`(?![\\w:-])`).test(line))
+        expect(row, `${entry.name} has no row in the README table`).toBeTruthy()
+        expect(row?.includes('🚧'), `${entry.name} is marked ${entry.status} in the manifest`).toBe(
+          entry.status === 'pending',
+        )
+      }
+    })
   })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,31 @@ export default defineConfig({
       reporter: ['text-summary', 'lcov'],
       reportsDirectory: 'coverage',
       exclude: ['**/dist/**', '**/*.config.*', 'scripts/**', 'tests/**'],
+
+      /**
+       * A floor, not a target.
+       *
+       * Set a few points below what is measured today (96.6% statements, 82.9%
+       * branches) on purpose. A threshold pinned to the current number fails on
+       * the first honest refactor that deletes a well-covered file, and a gate
+       * that fires on noise is one somebody switches off — at which point the
+       * repository has no coverage check at all and everyone still believes it
+       * does.
+       *
+       * Branches sit lower than the rest because the uncovered ones are mostly
+       * defensive `?? 0` fallbacks on indexed access that `noUncheckedIndexedAccess`
+       * requires and that no input can reach. Chasing those to 95% would mean
+       * writing tests for states the type system already excludes.
+       *
+       * Raise these when a milestone genuinely lifts the number, in the same
+       * commit that lifts it.
+       */
+      thresholds: {
+        statements: 93,
+        branches: 78,
+        functions: 93,
+        lines: 93,
+      },
     },
   },
 })

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -19,10 +19,13 @@
 git clone https://github.com/AKogut/ai-flaky-test-triage.git
 cd ai-flaky-test-triage
 npm install
-npm run demo     # no API key needed
+npm run help            # every command, and whether it exists yet
+npm run test:coverage   # the full suite, with the coverage floor enforced
+npm run eval            # score the baseline against the golden dataset
+npm run demo            # 🚧 M3 · #39 — full pipeline in replay mode
 ```
 
-Node ≥ 22.13. A key is only required for live model calls.
+Node ≥ 22.13. A key is only required for live model calls, and nothing that works today needs one.
 
 ## Who can merge, and what happens to an outside pull request
 

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -2,9 +2,9 @@
 
 <!-- status:start -->
 
-> **Project status: M2 — Golden dataset, baseline & eval harness.**
-> 2 of 11 milestones complete.
-> Current exit criterion: `npm run eval` scores the baseline heuristic on ≥30 labelled fixtures and writes a report with per-axis accuracy, intervals, and both confusion matrices — with no model involved.
+> **Project status: M3 — Triage agent & replay mode.**
+> 3 of 11 milestones complete.
+> Current exit criterion: the triage agent beats the baseline on joint accuracy by a margin that survives its confidence interval — or the finding that it does not is documented in the README. Either way, `npm run demo` runs the classifier end to end with no API key.
 >
 > Progress is tracked as [milestones](https://github.com/AKogut/ai-flaky-test-triage/milestones), not dates.
 > Commands marked 🚧 below are not implemented yet. Running one names the milestone it

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -4,9 +4,9 @@
 
 <!-- status:start -->
 
-> **Project status: M2 — Golden dataset, baseline & eval harness.**
-> 2 of 11 milestones complete.
-> Current exit criterion: `npm run eval` scores the baseline heuristic on ≥30 labelled fixtures and writes a report with per-axis accuracy, intervals, and both confusion matrices — with no model involved.
+> **Project status: M3 — Triage agent & replay mode.**
+> 3 of 11 milestones complete.
+> Current exit criterion: the triage agent beats the baseline on joint accuracy by a margin that survives its confidence interval — or the finding that it does not is documented in the README. Either way, `npm run demo` runs the classifier end to end with no API key.
 >
 > Progress is tracked as [milestones](https://github.com/AKogut/ai-flaky-test-triage/milestones), not dates.
 > Commands marked 🚧 below are not implemented yet. Running one names the milestone it


### PR DESCRIPTION
An audit of the whole repository. Two findings mattered; both are fixed here, and **M2 closes**.

Closes #123. Closes #134.

## The least-covered code was the code that only runs when something is wrong

Coverage was 87.4% statements / 75.5% branches, and the gaps were not spread evenly:

| File | Before | What was missing |
| --- | --- | --- |
| `run-eval.ts` | 63.6% | the entire CLI `main()`, including every exit code |
| `hygiene.ts` | 70.3% | the CLI, including the branch that fails the build |
| `dataset.ts` | 71.4% | every `throw` |

Those throws are not incidental:

- `listFixtures` refuses a fixture missing half of itself. **Nothing tested it.** That guard is what stops a payload with no labels vanishing from the dataset silently, taking every published metric down with it.
- `loadPayload` / `loadLabels` refuse a declared name that disagrees with the filename. Nothing tested either.
- Both CLIs were untested end to end. An exit code nothing asserts is a CI gate that might be returning zero on failure, and nobody would find out.

`eval/cli.test.ts` adds 22 tests over the dataset guards, the hygiene CLI and the eval CLI's exit codes — usage error `2`, gate failure `1`, success `0`. `hygiene.ts` now returns its code instead of calling `process.exit`, because a guard whose only untested branch is the one that fails the build is a guard nobody has watched work.

**After: 96.6% statements, 82.9% branches, 96.9% lines.** `dataset.ts` is at 100%.

## The floor, set after improving the number rather than around it

`93 / 78 / 93 / 93`, a few points below what is measured, with the reason next to it. A threshold pinned to today's number fails on the first honest refactor that deletes a well-covered file — and a check that fires on noise is one somebody switches off, at which point there is no coverage check and everyone still believes there is.

Branches sit lower deliberately: most uncovered ones are `?? 0` fallbacks that `noUncheckedIndexedAccess` requires and no input can reach. Chasing those to 95% would mean testing states the type system already excludes.

CI runs `npm run test:coverage`, so the invocation that gates is the one a contributor can run by name.

## CONTRIBUTING was describing an evaluation that does not exist

Not just unmarked commands — the section was wrong in detail:

| What it said | What is true |
| --- | --- |
| `npm run eval` — "full dataset, N=5 samples per fixture" | development slice, N=1 |
| `npm run eval -- --n=1 --replay` | **no such flag** — exits 2 |
| `npm run eval:ablation` | M9, not built |
| "Results land in `eval/report.md` and `eval/ablation.md`. Both are committed." | `ablation.md` does not exist |

Rewritten to what the CLI actually does, including the held-out budget. `npm run demo` in CONTRIBUTING and the wiki now carries its marker.

## The check that should have caught it named one file by hand

It now derives its file list from `git ls-files` and its command list from `script-manifest.json`, and asserts in **both** directions across every tracked document: pending commands carry a marker, implemented ones do not. It also holds the README table's milestone column to the manifest.

It earned its keep immediately — by rejecting a line I had just written:

```
npm run eval -- --classifier=agent  # 🚧 M3 · #35
```

`npm run eval` is built; only that flag *value* is not. A 🚧 on a line beginning with a working command reads as the command being unbuilt. Reworded into prose.

## M2 closes

Every issue in the milestone is done. ROADMAP moves M2 → done, M3 → in progress, and the three status banners are regenerated from it.

## Verification

`npx eslint .`, `npx tsc --build`, `npx prettier --check .`, `npm run eval -- --gate`, `npm run eval:lint`, `npm run docs:status:check` all clean. **688 tests pass**, up from 663, with the coverage floor enforced.
