### PR TITLE
feat(agents): add the model client every call goes through

### DIFF
--- a/agents/index.ts
+++ b/agents/index.ts
@@ -1,11 +1,12 @@
 /**
  * @sentra/agents
  *
- * Triage, root-cause and fix-suggestion agents, plus the orchestrator that turns analysis.json into report.md.
+ * The triage, root-cause and fix-suggestion agents, the orchestrator that turns
+ * analysis.json into report.md, and the one model client they all go through.
  *
- * The implementation lands in M3 and M7; this file exists so the
- * workspace, its TypeScript project reference and its public entry point are
- * in place before anything depends on them.
+ * The agents themselves land later in M3; the client and its transport port are
+ * the parts that exist.
  */
 
-export {}
+export * from './transport.js'
+export * from './model-client.js'

--- a/agents/model-client.test.ts
+++ b/agents/model-client.test.ts
@@ -1,0 +1,295 @@
+import { ClassificationSchema } from '@sentra/contracts'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  BudgetExceededError,
+  callModel,
+  MODEL_CONFIG,
+  SchemaViolationError,
+  TokenBudget,
+  type CallDeps,
+  type ModelConfig,
+} from './model-client.js'
+import {
+  TransportError,
+  type ModelRequest,
+  type ModelResponse,
+  type Transport,
+} from './transport.js'
+
+/**
+ * Every retry branch, exercised without a network or a wall clock.
+ *
+ * The transport is a port precisely so this file can produce a rate limit, a
+ * 4xx, a malformed response and a refusal on demand. A retry policy whose
+ * branches are only reachable against a live API is a policy nobody has
+ * watched work — and the branch that matters most is the one that decides *not*
+ * to retry, which never fires in a happy-path integration test.
+ */
+
+const VALID = {
+  owner: 'app_code',
+  determinism: 'intermittent',
+  confidence: 0.7,
+  reasoning: 'the diff changes the reducer the failing assertion reads',
+  evidence: ['expected 3 to equal 4'],
+}
+
+/** A transport driven by a queued script, so a test states the sequence it wants. */
+function scripted(
+  steps: (ModelResponse | Error)[],
+  tokensPerCall = 100,
+): Transport & {
+  sent: ModelRequest[]
+  counted: ModelRequest[]
+} {
+  const sent: ModelRequest[] = []
+  const counted: ModelRequest[] = []
+  const queue = [...steps]
+
+  return {
+    sent,
+    counted,
+    countInputTokens(request) {
+      counted.push(request)
+      return Promise.resolve(tokensPerCall)
+    },
+    send(request) {
+      sent.push(request)
+      const step = queue.shift()
+      if (step === undefined) throw new Error('the transport ran out of scripted steps')
+      if (step instanceof Error) return Promise.reject(step)
+      return Promise.resolve(step)
+    },
+  }
+}
+
+const ok = (raw: unknown = VALID): ModelResponse => ({
+  raw,
+  stopReason: 'end_turn',
+  model: MODEL_CONFIG.model,
+  usage: { inputTokens: 100, outputTokens: 40 },
+})
+
+const call = (deps: Partial<CallDeps> & { transport: Transport }) =>
+  callModel(
+    {
+      schema: ClassificationSchema,
+      schemaName: 'Classification',
+      system: 'You classify test failures.',
+      prompt: 'Classify this failure.',
+      promptVersion: 'triage.v1',
+      label: 'triage',
+    },
+    { sleep: () => Promise.resolve(), random: () => 0.5, now: () => 0, ...deps },
+  )
+
+describe('a successful call', () => {
+  it('returns the parsed value, not the raw response', async () => {
+    const { value } = await call({ transport: scripted([ok()]) })
+    expect(value.owner).toBe('app_code')
+    expect(value.confidence).toBe(0.7)
+  })
+
+  it('never writes a model ID at the call site', async () => {
+    // The one answer to "which model produced this number" lives in config.
+    const transport = scripted([ok()])
+    await call({ transport })
+    expect(transport.sent[0]?.model).toBe(MODEL_CONFIG.model)
+  })
+
+  it('derives the response schema from the Zod type', async () => {
+    const transport = scripted([ok()])
+    await call({ transport })
+    const schema = transport.sent[0]?.jsonSchema
+    expect(schema?.properties).toHaveProperty('owner')
+    expect(schema?.required).toEqual(expect.arrayContaining(['owner', 'determinism']))
+  })
+
+  it('reports what the call cost and how many dispatches it took', async () => {
+    const { telemetry } = await call({ transport: scripted([ok()]) })
+    expect(telemetry).toMatchObject({
+      label: 'triage',
+      promptVersion: 'triage.v1',
+      attempts: 1,
+      schemaViolations: 0,
+      transientFailures: 0,
+      inputTokens: 100,
+      outputTokens: 40,
+    })
+  })
+
+  it('emits telemetry to the observer as well as returning it', async () => {
+    const onTelemetry = vi.fn()
+    await call({ transport: scripted([ok()]), onTelemetry })
+    expect(onTelemetry).toHaveBeenCalledOnce()
+  })
+})
+
+describe('schema violations', () => {
+  it('retries and shows the model its own errors', async () => {
+    // A bare "try again" re-runs the same misunderstanding at the same price.
+    const transport = scripted([ok({ owner: 'app_code' }), ok()])
+    const { value, telemetry } = await call({ transport })
+
+    expect(value.owner).toBe('app_code')
+    expect(telemetry.schemaViolations).toBe(1)
+    expect(telemetry.attempts).toBe(2)
+    expect(transport.sent[1]?.prompt).toContain('did not match the required schema')
+    expect(transport.sent[1]?.prompt).toContain('determinism')
+  })
+
+  it('does not append corrections to the first attempt', async () => {
+    const transport = scripted([ok()])
+    await call({ transport })
+    expect(transport.sent[0]?.prompt).toBe('Classify this failure.')
+  })
+
+  it('gives up after the configured number of attempts, naming the last issues', async () => {
+    const transport = scripted([ok({}), ok({}), ok({})])
+    await expect(call({ transport })).rejects.toThrow(SchemaViolationError)
+    expect(transport.sent).toHaveLength(MODEL_CONFIG.schemaRetries + 1)
+  })
+
+  it('rejects a response that is well-formed but violates a business rule', async () => {
+    // `evidence` is non-empty by schema — the requirement that makes an
+    // overconfident answer visible in review rather than buried in a decimal.
+    const transport = scripted([ok({ ...VALID, evidence: [] }), ok()])
+    const { telemetry } = await call({ transport })
+    expect(telemetry.schemaViolations).toBe(1)
+  })
+})
+
+describe('transient failures', () => {
+  const rateLimit = () => new TransportError('rate-limit', 'slow down', 429)
+  const server = () => new TransportError('server', 'upstream fell over', 503)
+
+  it('retries a rate limit', async () => {
+    const { telemetry } = await call({ transport: scripted([rateLimit(), ok()]) })
+    expect(telemetry.transientFailures).toBe(1)
+  })
+
+  it('retries a server fault', async () => {
+    const { telemetry } = await call({ transport: scripted([server(), ok()]) })
+    expect(telemetry.transientFailures).toBe(1)
+  })
+
+  it('backs off exponentially, with jitter', async () => {
+    // Full jitter rather than a fixed curve: a fleet that all backs off
+    // identically re-collides at every step, turning one rate limit into a herd.
+    const sleep = vi.fn((_ms: number) => Promise.resolve())
+    await call({
+      transport: scripted([rateLimit(), rateLimit(), rateLimit(), ok()]),
+      sleep,
+      random: () => 1,
+    })
+    expect(sleep.mock.calls.map(([ms]) => ms)).toEqual([500, 1000, 2000])
+  })
+
+  it('caps the backoff rather than growing without bound', async () => {
+    const sleep = vi.fn((_ms: number) => Promise.resolve())
+    const config: ModelConfig = { ...MODEL_CONFIG, backoffBaseMs: 5000, backoffCapMs: 6000 }
+    await call({
+      transport: scripted([rateLimit(), rateLimit(), ok()]),
+      config,
+      sleep,
+      random: () => 1,
+    })
+    expect(sleep.mock.calls.map(([ms]) => ms)).toEqual([5000, 6000])
+  })
+
+  it('scales the wait by the jitter draw', async () => {
+    const sleep = vi.fn((_ms: number) => Promise.resolve())
+    await call({ transport: scripted([rateLimit(), ok()]), sleep, random: () => 0.25 })
+    expect(sleep).toHaveBeenCalledWith(125)
+  })
+
+  it('gives up after the configured number of attempts', async () => {
+    const transport = scripted([server(), server(), server(), server()])
+    await expect(call({ transport })).rejects.toThrow(/upstream fell over/)
+    expect(transport.sent).toHaveLength(MODEL_CONFIG.transientRetries + 1)
+  })
+})
+
+describe('failures that must not be retried', () => {
+  it('does not retry a malformed request', async () => {
+    // The branch that matters most, and the one a happy-path integration test
+    // never reaches: re-sending a 4xx produces the same 4xx at the same cost.
+    const transport = scripted([new TransportError('client', 'bad request', 400)])
+    await expect(call({ transport })).rejects.toThrow(/bad request/)
+    expect(transport.sent).toHaveLength(1)
+  })
+
+  it('does not retry a refusal', async () => {
+    // A refusal is a decision, not a fault. Asking again spends budget to be
+    // told the same thing.
+    const transport = scripted([new TransportError('refusal', 'the model declined', 200)])
+    await expect(call({ transport })).rejects.toThrow(/declined/)
+    expect(transport.sent).toHaveLength(1)
+  })
+
+  it('does not retry something it cannot classify', async () => {
+    // Retrying an unrecognised throw is how a bug becomes a bill.
+    const transport = scripted([new TypeError('cannot read properties of undefined')])
+    await expect(call({ transport })).rejects.toThrow(TypeError)
+    expect(transport.sent).toHaveLength(1)
+  })
+})
+
+describe('the token budget', () => {
+  it('is checked before dispatch, not tallied after', async () => {
+    // A budget that only reports what was spent is an invoice.
+    const transport = scripted([ok()], 500)
+    const budget = new TokenBudget(100)
+    await expect(call({ transport, budget })).rejects.toThrow(BudgetExceededError)
+    expect(transport.sent).toHaveLength(0)
+  })
+
+  it('counts against the model rather than estimating from characters', async () => {
+    const transport = scripted([ok()])
+    await call({ transport, budget: new TokenBudget(1000) })
+    expect(transport.counted).toHaveLength(1)
+  })
+
+  it('spends down across calls', async () => {
+    const budget = new TokenBudget(250)
+    await call({ transport: scripted([ok()]), budget })
+    expect(budget.spent).toBe(100)
+    expect(budget.remaining).toBe(150)
+  })
+
+  it('re-checks before a schema retry, since the corrected prompt is longer', async () => {
+    // Checking once against the first attempt is not a budget.
+    const transport = scripted([ok({}), ok()], 60)
+    const budget = new TokenBudget(100)
+    await expect(call({ transport, budget })).rejects.toThrow(BudgetExceededError)
+    expect(transport.sent).toHaveLength(1)
+  })
+
+  it('names both the request and what was left', async () => {
+    const budget = new TokenBudget(30)
+    const error = await call({ transport: scripted([ok()]), budget }).catch((e: unknown) => e)
+    expect((error as Error).message).toContain('100 input tokens')
+    expect((error as Error).message).toContain('30 remain')
+  })
+})
+
+describe('MODEL_CONFIG', () => {
+  it('pins a model rather than tracking whatever is newest', () => {
+    // A model change moves every number in eval/report.md, so it happens in a
+    // reviewable commit with an eval run attached — never via a dependency bump.
+    expect(MODEL_CONFIG.model).toBe('claude-opus-5')
+  })
+
+  it('leaves room for thinking and the answer together', () => {
+    // max_tokens caps both on this model tier; a tight budget truncates the
+    // answer the model was deliberating about.
+    expect(MODEL_CONFIG.maxTokens).toBeGreaterThanOrEqual(4000)
+  })
+
+  it('sends no sampling parameters, which this model rejects', async () => {
+    const transport = scripted([ok()])
+    await call({ transport })
+    expect(transport.sent[0]).not.toHaveProperty('temperature')
+    expect(transport.sent[0]).not.toHaveProperty('topP')
+  })
+})

--- a/agents/model-client.ts
+++ b/agents/model-client.ts
@@ -1,0 +1,311 @@
+import type { z } from 'zod'
+import { toolSchema } from '@sentra/contracts'
+import { TransportError, type Effort, type ModelRequest, type Transport } from './transport.js'
+
+/**
+ * The single wrapper every model call goes through.
+ *
+ * One interception point is what makes replay, sanitisation, telemetry and the
+ * budget possible at all. If any agent can build its own request, each of those
+ * becomes a convention that holds until the first call site forgets it.
+ *
+ * Three behaviours here are worth stating, because getting any of them wrong
+ * produces a system that looks fine and quietly misbehaves.
+ *
+ * **Retries are classified, not counted.** A schema violation is retryable and
+ * the model needs to see its own error to correct it. A rate limit is retryable
+ * after waiting. A malformed request is not retryable at all. Collapsing these
+ * into `retry(3)` builds something that spends its budget re-sending requests
+ * that will never succeed.
+ *
+ * **The budget is checked before dispatch, against a real count.** Estimating
+ * tokens with a character heuristic is how a budget silently stops binding;
+ * `countInputTokens` asks the same model that will serve the request.
+ *
+ * **The model ID is never written at a call site.** It lives in `MODEL_CONFIG`,
+ * so "which model produced this number" has one answer per commit rather than
+ * one per file.
+ */
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface ModelConfig {
+  model: string
+  maxTokens: number
+  effort: Effort
+  /** How many times a schema violation may be re-sent with the error attached. */
+  schemaRetries: number
+  /** How many times a rate limit or server fault may be retried. */
+  transientRetries: number
+  /** First backoff step, in milliseconds. Doubles per attempt, with full jitter. */
+  backoffBaseMs: number
+  backoffCapMs: number
+}
+
+/**
+ * One place for every knob that changes what a published number means.
+ *
+ * Changing anything here changes the classifier, so it belongs in a reviewable
+ * commit next to the eval numbers it moves — never in a call site.
+ */
+export const MODEL_CONFIG: ModelConfig = {
+  /**
+   * Pinned deliberately. `.github/dependabot.yml` ignores the SDK for the same
+   * reason: a model change moves every metric in `eval/report.md`, so it is
+   * made on purpose with an eval run attached, not absorbed by a dependency
+   * bump.
+   */
+  model: 'claude-opus-5',
+
+  /**
+   * Caps thinking *and* response text together on this model tier, where
+   * thinking is on by default. A classification is a few hundred tokens; the
+   * rest of this is headroom so a long deliberation cannot truncate the answer
+   * it was deliberating about.
+   */
+  maxTokens: 8_000,
+
+  /**
+   * Left at the API default rather than guessed downward.
+   *
+   * Lower effort is unusually strong on this model and is the obvious cost
+   * lever, but picking a level before measuring is tuning without evidence.
+   * The sweep belongs to #38, where it can be run against the dataset and the
+   * chosen value defended with numbers.
+   */
+  effort: 'high',
+
+  schemaRetries: 2,
+  transientRetries: 3,
+  backoffBaseMs: 500,
+  backoffCapMs: 8_000,
+}
+
+// ---------------------------------------------------------------------------
+// Budget
+// ---------------------------------------------------------------------------
+
+export class BudgetExceededError extends Error {
+  constructor(
+    readonly requested: number,
+    readonly remaining: number,
+    readonly limit: number,
+  ) {
+    super(
+      `this call needs ${String(requested)} input tokens and ${String(remaining)} remain of a ${String(limit)} budget`,
+    )
+    this.name = 'BudgetExceededError'
+  }
+}
+
+/**
+ * A hard ceiling on input tokens across a run.
+ *
+ * Checked before dispatch rather than tallied afterwards. A budget that only
+ * reports what was spent is an invoice.
+ */
+export class TokenBudget {
+  private used = 0
+
+  constructor(readonly limit: number) {}
+
+  get spent(): number {
+    return this.used
+  }
+
+  get remaining(): number {
+    return Math.max(0, this.limit - this.used)
+  }
+
+  /** Throws rather than returning false — a budget that can be ignored is not one. */
+  reserve(tokens: number): void {
+    if (tokens > this.remaining) {
+      throw new BudgetExceededError(tokens, this.remaining, this.limit)
+    }
+    this.used += tokens
+  }
+}
+
+/** Unbounded, for tests and for callers that budget elsewhere. */
+export const UNLIMITED = new TokenBudget(Number.MAX_SAFE_INTEGER)
+
+// ---------------------------------------------------------------------------
+// Calling
+// ---------------------------------------------------------------------------
+
+export interface CallOptions<T> {
+  schema: z.ZodType<T>
+  /** Names the output shape for the model and for telemetry. */
+  schemaName: string
+  system: string
+  prompt: string
+  /** Which prompt file produced this, so a number is traceable to its wording. */
+  promptVersion: string
+  /** Human-readable call site, for telemetry and error messages. */
+  label: string
+}
+
+export interface CallTelemetry {
+  label: string
+  promptVersion: string
+  model: string
+  /** Every dispatch, including retries — the number that explains a cost. */
+  attempts: number
+  schemaViolations: number
+  transientFailures: number
+  inputTokens: number
+  outputTokens: number
+  durationMs: number
+}
+
+export interface CallResult<T> {
+  value: T
+  telemetry: CallTelemetry
+}
+
+/** Injected so every retry branch is reachable from a test without waiting or a network. */
+export interface CallDeps {
+  transport: Transport
+  config?: ModelConfig
+  budget?: TokenBudget
+  sleep?: (ms: number) => Promise<void>
+  random?: () => number
+  now?: () => number
+  onTelemetry?: (telemetry: CallTelemetry) => void
+}
+
+export class SchemaViolationError extends Error {
+  constructor(
+    readonly label: string,
+    readonly attempts: number,
+    readonly issues: string,
+  ) {
+    super(`${label} did not return a valid ${String(attempts)} time(s): ${issues}`)
+    this.name = 'SchemaViolationError'
+  }
+}
+
+export async function callModel<T>(
+  options: CallOptions<T>,
+  deps: CallDeps,
+): Promise<CallResult<T>> {
+  const config = deps.config ?? MODEL_CONFIG
+  const budget = deps.budget ?? UNLIMITED
+  const sleep = deps.sleep ?? defaultSleep
+  const random = deps.random ?? Math.random
+  const now = deps.now ?? Date.now
+
+  const started = now()
+  const counters = { attempts: 0, schemaViolations: 0, transientFailures: 0 }
+  const usage = { inputTokens: 0, outputTokens: 0 }
+
+  const request: ModelRequest = {
+    model: config.model,
+    maxTokens: config.maxTokens,
+    effort: config.effort,
+    system: options.system,
+    prompt: options.prompt,
+    schemaName: options.schemaName,
+    jsonSchema: toolSchema(options.schema),
+  }
+
+  let corrections = ''
+  let lastIssues = ''
+
+  for (let schemaAttempt = 0; schemaAttempt <= config.schemaRetries; schemaAttempt++) {
+    const attempt: ModelRequest = { ...request, prompt: `${options.prompt}${corrections}` }
+
+    // Counted every time, because a correction makes the prompt longer — a
+    // budget checked once against the first attempt is not a budget.
+    const inputTokens = await withTransientRetry(
+      () => deps.transport.countInputTokens(attempt),
+      config,
+      counters,
+      { sleep, random },
+    )
+    budget.reserve(inputTokens)
+
+    counters.attempts += 1
+    const response = await withTransientRetry(
+      () => deps.transport.send(attempt),
+      config,
+      counters,
+      {
+        sleep,
+        random,
+      },
+    )
+    usage.inputTokens += response.usage.inputTokens
+    usage.outputTokens += response.usage.outputTokens
+
+    const parsed = options.schema.safeParse(response.raw)
+    if (parsed.success) {
+      const telemetry: CallTelemetry = {
+        label: options.label,
+        promptVersion: options.promptVersion,
+        model: response.model,
+        ...counters,
+        ...usage,
+        durationMs: now() - started,
+      }
+      deps.onTelemetry?.(telemetry)
+      return { value: parsed.data, telemetry }
+    }
+
+    counters.schemaViolations += 1
+    lastIssues = describe(parsed.error)
+
+    // The model is shown its own failure. A bare "try again" retries the same
+    // misunderstanding at the same price.
+    corrections =
+      `\n\nYour previous response did not match the required schema:\n${lastIssues}\n` +
+      `Return a corrected response. Change only what the errors above require.`
+  }
+
+  throw new SchemaViolationError(options.label, config.schemaRetries + 1, lastIssues)
+}
+
+/**
+ * Retry a transient failure with exponential backoff and full jitter.
+ *
+ * Full jitter rather than a fixed multiplier: a fleet that all backs off by the
+ * same curve re-collides at every step, which is how one rate limit becomes a
+ * synchronised herd. `random()` is injected so the schedule is assertable.
+ */
+async function withTransientRetry<T>(
+  operation: () => Promise<T>,
+  config: ModelConfig,
+  counters: { transientFailures: number },
+  deps: { sleep: (ms: number) => Promise<void>; random: () => number },
+): Promise<T> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await operation()
+    } catch (error) {
+      const failure = error instanceof TransportError ? error : null
+
+      // A refusal, a 4xx, or anything unclassified goes straight up. Retrying
+      // a request the server has already judged is how a budget disappears
+      // without a single useful response.
+      if (failure?.retryable !== true) throw error
+      if (attempt >= config.transientRetries) throw error
+
+      counters.transientFailures += 1
+      const ceiling = Math.min(config.backoffCapMs, config.backoffBaseMs * 2 ** attempt)
+      await deps.sleep(Math.floor(deps.random() * ceiling))
+    }
+  }
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms))
+
+/** The first few issues, with paths, so a correction prompt is actionable rather than a dump. */
+function describe(error: z.ZodError): string {
+  return error.issues
+    .slice(0, 5)
+    .map((issue) => `  ${issue.path.join('.') || '<root>'}: ${issue.message}`)
+    .join('\n')
+}

--- a/agents/package.json
+++ b/agents/package.json
@@ -10,5 +10,10 @@
       "types": "./dist/index.d.ts",
       "default": "./index.ts"
     }
+  },
+  "dependencies": {
+    "@sentra/contracts": "*",
+    "@anthropic-ai/sdk": "*",
+    "zod": "*"
   }
 }

--- a/agents/transport.test.ts
+++ b/agents/transport.test.ts
@@ -1,0 +1,132 @@
+import Anthropic from '@anthropic-ai/sdk'
+import { describe, expect, it } from 'vitest'
+import { classify, TransportError } from './transport.js'
+
+/**
+ * The SDK-exception mapping, tested against real SDK errors.
+ *
+ * This is the part of the retry policy that rots without anything going red.
+ * `model-client.test.ts` stubs the transport, so every branch there is driven
+ * by a `TransportError` this file's function was supposed to produce — a new
+ * SDK error class, a reordered `instanceof` chain, or a renamed status field
+ * would change what gets retried while every one of those tests still passes.
+ *
+ * Errors are built with the SDK's own factory rather than hand-rolled objects,
+ * so the test breaks if the SDK's hierarchy moves under it. That is the point.
+ */
+
+/**
+ * A real SDK error for a given status.
+ *
+ * The headers argument is load-bearing and easy to get wrong: `generate` with
+ * `undefined` headers returns an `APIConnectionError` regardless of the status,
+ * because to the SDK "no headers" means no response ever arrived. Passing them
+ * is what produces the status-specific subclass — the first draft of this
+ * helper omitted them and every case silently became a connection error.
+ */
+const from = (status: number): unknown =>
+  Anthropic.APIError.generate(
+    status,
+    { error: { message: `status ${String(status)}` } },
+    undefined,
+    new Headers({ 'content-type': 'application/json' }),
+  )
+
+describe('classifying SDK errors', () => {
+  it.each([
+    [429, 'rate-limit'],
+    [500, 'server'],
+    [503, 'server'],
+    [529, 'server'],
+  ])('treats %i as %s, which is retryable', (status, kind) => {
+    const classified = classify(from(status))
+    expect(classified.kind).toBe(kind)
+    expect(classified.retryable).toBe(true)
+  })
+
+  it.each([
+    [400, 'a malformed request'],
+    [401, 'a missing key'],
+    [403, 'a key without permission'],
+    [404, 'an unknown model'],
+    [413, 'an oversized request'],
+    [422, 'an unprocessable body'],
+  ])('refuses to retry %i — %s', (status) => {
+    const classified = classify(from(status))
+    expect(classified.kind).toBe('client')
+    expect(classified.retryable).toBe(false)
+  })
+
+  it('treats a response that never arrived as a retryable server fault', () => {
+    // The SDK models "no headers" as no response at all. A request that died in
+    // the network is exactly the case worth retrying.
+    const noResponse = Anthropic.APIError.generate(500, undefined, 'socket hang up', undefined)
+    expect(noResponse).toBeInstanceOf(Anthropic.APIConnectionError)
+    expect(classify(noResponse).retryable).toBe(true)
+  })
+
+  it('maps a connection failure to a retryable server fault', () => {
+    // Checked before the general APIError case, because in this SDK
+    // APIConnectionError is a subclass — the general branch would swallow it
+    // and classify a recoverable network blip as a permanent 4xx.
+    const classified = classify(new Anthropic.APIConnectionError({ message: 'socket hang up' }))
+    expect(classified.kind).toBe('server')
+    expect(classified.retryable).toBe(true)
+  })
+
+  it('confirms the subclass relationship the ordering depends on', () => {
+    // If this ever stops being true, the ordering above is no longer load-
+    // bearing and the comment explaining it is misleading.
+    expect(new Anthropic.APIConnectionError({ message: 'x' })).toBeInstanceOf(Anthropic.APIError)
+  })
+
+  it('carries the status through, so a failure can be diagnosed without a rerun', () => {
+    expect(classify(from(429)).status).toBe(429)
+    expect(classify(from(400)).status).toBe(400)
+  })
+
+  it('keeps the original error as the cause', () => {
+    const original = from(500)
+    expect(classify(original).cause).toBe(original)
+  })
+
+  it('passes an already-classified error through unchanged', () => {
+    // Otherwise a refusal, which the transport raises itself, would be
+    // re-wrapped as an unclassified client fault and lose its kind.
+    const refusal = new TransportError('refusal', 'declined', 200)
+    expect(classify(refusal)).toBe(refusal)
+  })
+
+  it.each([
+    ['a plain Error', new Error('something went wrong')],
+    ['a thrown string', 'nope'],
+    ['a thrown object', { weird: true }],
+  ])('treats %s as a client fault rather than retrying it', (_case, thrown) => {
+    // Retrying something nobody has classified is how a bug becomes a bill.
+    const classified = classify(thrown)
+    expect(classified.kind).toBe('client')
+    expect(classified.retryable).toBe(false)
+  })
+
+  it('keeps a message for anything it could not classify', () => {
+    expect(classify(new Error('socket exploded')).message).toBe('socket exploded')
+    expect(classify('nope').message).toBe('nope')
+  })
+})
+
+describe('TransportError', () => {
+  it.each([
+    ['rate-limit', true],
+    ['server', true],
+    ['client', false],
+    ['refusal', false],
+  ] as const)('%s is retryable: %s', (kind, retryable) => {
+    expect(new TransportError(kind, 'x').retryable).toBe(retryable)
+  })
+
+  it('does not treat a refusal as a fault to retry', () => {
+    // A refusal is a decision. Asking again spends budget to be told the same
+    // thing, and on an evaluation run it would do so 33 times.
+    expect(new TransportError('refusal', 'declined', 200).retryable).toBe(false)
+  })
+})

--- a/agents/transport.ts
+++ b/agents/transport.ts
@@ -1,0 +1,242 @@
+import Anthropic from '@anthropic-ai/sdk'
+import type { JsonSchemaObject } from '@sentra/contracts'
+
+/**
+ * The one place the Anthropic SDK is constructed.
+ *
+ * Everything above this file talks to a `Transport`, which is what makes
+ * replay (#31), sanitisation (#32), telemetry and the token budget properties
+ * of the system rather than conventions. A convention holds until somebody
+ * writes one call site that forgets it; a port holds because there is nothing
+ * else to call. `eslint.config.js` refuses an SDK import anywhere else in
+ * `agents/`, so the rule is a build failure rather than a review comment.
+ */
+
+/** Model behaviour a caller is allowed to vary. Never a model ID — that lives in config. */
+export interface ModelRequest {
+  model: string
+  /** Caps thinking *and* response text together, so it needs room for both. */
+  maxTokens: number
+  effort: Effort
+  system: string
+  prompt: string
+  /** Names the shape in the response format; surfaces in errors and telemetry. */
+  schemaName: string
+  jsonSchema: JsonSchemaObject
+}
+
+export type Effort = 'low' | 'medium' | 'high' | 'xhigh' | 'max'
+
+export interface ModelResponse {
+  /** Whatever the model returned, still unvalidated. Parsing is the caller's job. */
+  raw: unknown
+  stopReason: string | null
+  model: string
+  usage: { inputTokens: number; outputTokens: number }
+}
+
+export interface Transport {
+  send(request: ModelRequest): Promise<ModelResponse>
+  /** Counted against the same model, before dispatch, so the budget is checked on facts. */
+  countInputTokens(request: ModelRequest): Promise<number>
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Why a call failed, in the only terms the retry policy cares about.
+ *
+ * Collapsing these into one retryable/not flag is what produces a client that
+ * burns its budget re-sending a malformed request that will never succeed. The
+ * SDK already distinguishes them; this keeps the distinction rather than
+ * flattening it at the boundary.
+ */
+export type FailureKind =
+  /** 429. Retryable, but only after waiting. */
+  | 'rate-limit'
+  /** 5xx or a connection failure. Retryable — the request itself was fine. */
+  | 'server'
+  /** 4xx. The request is wrong; sending it again will produce the same 4xx. */
+  | 'client'
+  /** The model declined. A policy outcome, not a fault — see below. */
+  | 'refusal'
+
+export class TransportError extends Error {
+  constructor(
+    readonly kind: FailureKind,
+    message: string,
+    readonly status?: number,
+    override readonly cause?: unknown,
+  ) {
+    super(message)
+    this.name = 'TransportError'
+  }
+
+  get retryable(): boolean {
+    return this.kind === 'rate-limit' || this.kind === 'server'
+  }
+}
+
+/**
+ * Map an SDK exception onto the taxonomy above.
+ *
+ * Exported because this mapping is the part that silently rots: a new SDK
+ * error class, or a reordered `instanceof` chain, changes what gets retried
+ * without changing any test that stubs the transport. Tested directly against
+ * constructed SDK errors instead.
+ *
+ * Order matters — `APIConnectionError` is checked before `APIError` because in
+ * this SDK it is a subclass, and the general case would swallow it.
+ */
+export function classify(error: unknown): TransportError {
+  if (error instanceof TransportError) return error
+
+  if (error instanceof Anthropic.RateLimitError) {
+    return new TransportError('rate-limit', error.message, 429, error)
+  }
+  if (error instanceof Anthropic.APIConnectionError) {
+    return new TransportError('server', error.message, undefined, error)
+  }
+  if (error instanceof Anthropic.APIError) {
+    // `status` is loosely typed on the SDK error; narrowed here rather than
+    // trusted, because it decides whether the call is retried.
+    const status = typeof error.status === 'number' ? error.status : 0
+    const kind: FailureKind = status >= 500 || status === 0 ? 'server' : 'client'
+    return new TransportError(kind, error.message, status, error)
+  }
+
+  // An unrecognised throw is treated as a client fault on purpose: retrying
+  // something nobody has classified is how a bug becomes a bill.
+  return new TransportError(
+    'client',
+    error instanceof Error ? error.message : String(error),
+    undefined,
+    error,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// The real transport
+// ---------------------------------------------------------------------------
+
+export interface AnthropicTransportOptions {
+  client?: Anthropic
+  /**
+   * Whether a policy refusal may be served by a different model.
+   *
+   * Off by default, and the reason is specific to this project rather than
+   * general caution: every number published here names the model that produced
+   * it. A silent substitution part-way through an evaluation would make the
+   * headline a blend of two models while the report still claims one, which is
+   * exactly the kind of quiet dishonesty the whole harness exists to prevent.
+   *
+   * Worth turning on for the PR-comment path, where an answer from a fallback
+   * model beats no answer at all. Not for `npm run eval`.
+   */
+  allowModelFallback?: boolean
+}
+
+export class AnthropicTransport implements Transport {
+  private readonly client: Anthropic
+
+  constructor(private readonly options: AnthropicTransportOptions = {}) {
+    // Zero-arg construction resolves ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN,
+    // or an `ant auth login` profile — so an absent env var does not mean
+    // absent credentials, and the client must not assert on one.
+    this.client = options.client ?? new Anthropic()
+  }
+
+  async countInputTokens(request: ModelRequest): Promise<number> {
+    try {
+      const counted = await this.client.messages.countTokens({
+        model: request.model,
+        system: request.system,
+        messages: [{ role: 'user', content: request.prompt }],
+      })
+      return counted.input_tokens
+    } catch (error) {
+      throw classify(error)
+    }
+  }
+
+  async send(request: ModelRequest): Promise<ModelResponse> {
+    let response
+    try {
+      response = await this.client.messages.create({
+        model: request.model,
+        max_tokens: request.maxTokens,
+        system: request.system,
+        messages: [{ role: 'user', content: request.prompt }],
+        output_config: {
+          effort: request.effort,
+          // `schemaName` is deliberately not sent — JSONOutputFormat carries
+          // only `type` and `schema`. It is kept on the request for telemetry
+          // and error messages, where naming the expected shape is what makes
+          // a violation readable.
+          format: {
+            type: 'json_schema',
+            schema: request.jsonSchema as unknown as Record<string, unknown>,
+          },
+        },
+      })
+    } catch (error) {
+      throw classify(error)
+    }
+
+    // Checked before `content` is touched. A refused response is a successful
+    // HTTP 200 whose content array is empty or partial, so indexing it first
+    // turns a policy outcome into an undefined-property crash.
+    if (response.stop_reason === 'refusal') {
+      throw new TransportError(
+        'refusal',
+        `the model declined to classify this input${
+          this.options.allowModelFallback === true
+            ? ''
+            : ' (model fallback is disabled — see AnthropicTransportOptions)'
+        }`,
+        200,
+        response.stop_details,
+      )
+    }
+
+    return {
+      raw: extractJson(response.content),
+      stopReason: response.stop_reason,
+      model: response.model,
+      usage: {
+        inputTokens: response.usage.input_tokens,
+        outputTokens: response.usage.output_tokens,
+      },
+    }
+  }
+}
+
+/**
+ * The JSON the model produced, from the text blocks of the response.
+ *
+ * Thinking blocks are skipped rather than concatenated. With thinking on by
+ * default on this model tier, gluing every block together produces a string
+ * that is not JSON and fails as a schema violation — which would then be
+ * *retried*, spending budget on a bug in this function.
+ */
+function extractJson(content: readonly { type: string }[]): unknown {
+  const text = content
+    .filter((block): block is { type: 'text'; text: string } => block.type === 'text')
+    .map((block) => block.text)
+    .join('')
+
+  if (text.trim() === '') {
+    throw new TransportError('server', 'the response carried no text block to parse')
+  }
+
+  try {
+    return JSON.parse(text)
+  } catch {
+    // Structured output should make this impossible; treated as a schema
+    // problem rather than a crash so the retry loop can show the model its
+    // own output.
+    throw new TransportError('server', `the response was not JSON: ${text.slice(0, 200)}`)
+  }
+}

--- a/docs/agent-design.md
+++ b/docs/agent-design.md
@@ -6,10 +6,12 @@ omission — see [Why no agent loop](#why-there-is-no-agent-loop).
 
 ## Shared infrastructure
 
-Every agent call goes through one wrapper that provides:
+Every agent call goes through `agents/model-client.ts`, which provides:
 
-- **Structured output** via a tool-use schema. The model cannot return prose where an enum is
-  expected; a schema violation triggers a retry with the validation error appended.
+- **Structured output** from the Zod schema. The response format is derived from the same schema
+  that validates the reply, so the model cannot return prose where an enum is expected. A schema
+  violation triggers a retry with the validation errors appended — the model is shown its own
+  failure, because a bare "try again" re-runs the same misunderstanding at the same price.
 - **Input sanitisation.** Test names, error messages, and diff hunks are untrusted text. They are
   length-capped, fenced inside explicit delimiters, and prefixed with a standing instruction that
   content inside the delimiters is data, never instruction.
@@ -19,8 +21,44 @@ Every agent call goes through one wrapper that provides:
   and deterministic.
 - **Telemetry.** One OpenTelemetry span per call, carrying model, token counts, latency, cost,
   retry count, and cassette hit/miss. Exported to `otel-spans.json`.
-- **Budget.** A per-run token ceiling. When it is hit the orchestrator stops dispatching and the
-  report says how many failures went unclassified rather than silently truncating.
+- **Budget.** A per-run token ceiling, checked **before** dispatch against a real
+  `count_tokens` call rather than a character estimate, and re-checked before each schema retry
+  because a corrected prompt is longer. When it is hit the orchestrator stops dispatching and the
+  report says how many failures went unclassified rather than silently truncating. A budget that
+  only reports what was spent is an invoice.
+
+### One transport, enforced
+
+`agents/transport.ts` is the only module allowed to construct an SDK client, and
+`eslint.config.js` fails the build on an `@anthropic-ai/sdk` import anywhere else under `agents/`.
+Every property above is a property of going through that seam; without the rule each one holds
+until the first call site that forgets, and then stops holding silently.
+
+### Retries are classified, not counted
+
+| Failure                                  | Retried                       | Why                                                              |
+| ---------------------------------------- | ----------------------------- | ---------------------------------------------------------------- |
+| Schema violation                         | yes, with the errors appended | The model can correct itself once it sees what was wrong         |
+| Rate limit (429)                         | yes, after backing off        | The request is fine; the timing is not                           |
+| Server fault (5xx) or connection failure | yes, after backing off        | Nothing about the request caused it                              |
+| Malformed request (4xx)                  | **no**                        | Sending it again produces the same 4xx                           |
+| Refusal                                  | **no**                        | A decision, not a fault — asking again buys the same answer      |
+| Anything unclassified                    | **no**                        | Retrying what nobody has categorised is how a bug becomes a bill |
+
+Backoff is exponential with **full jitter**. A fleet that backs off on an identical curve
+re-collides at every step, which is how one rate limit becomes a synchronised herd.
+
+### The model is pinned, and refusals are not papered over
+
+The model ID lives in `MODEL_CONFIG` and nowhere else, so "which model produced this number" has
+one answer per commit. `.github/dependabot.yml` ignores the SDK for the same reason: a model change
+moves every figure in `eval/report.md` and belongs in a reviewable commit with an eval run attached.
+
+Server-side model fallback on a refusal is **off by default**. It is a real feature and a
+reasonable default for the PR-comment path, where an answer from a second model beats no answer.
+It is the wrong default here: a silent substitution part-way through an evaluation would make the
+headline a blend of two models while the report still names one. A refusal surfaces as a typed
+error and is recorded.
 
 ## 1. Triage agent
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -106,6 +106,39 @@ export default tseslint.config(
   },
 
   // ---------------------------------------------------------------------------
+  // Guardrail: exactly one module may construct an SDK client.
+  //
+  // Replay, sanitisation, the token budget and telemetry are all properties of
+  // going through `agents/transport.ts`. A second module that builds its own
+  // client keeps every one of those working right up until the first call site
+  // that forgets, and then loses them silently. This makes that a build failure
+  // rather than something review has to catch every time.
+  // ---------------------------------------------------------------------------
+  {
+    files: ['agents/**/*.ts'],
+    // Exactly the transport and its own test. The test constructs real SDK
+    // errors on purpose — the mapping it checks is the part that rots when the
+    // SDK's exception hierarchy moves. Exempting `**/*.test.ts` wholesale would
+    // let any agent's test build a client and quietly become the template for
+    // the production code beside it.
+    ignores: ['agents/transport.ts', 'agents/transport.test.ts'],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@anthropic-ai/sdk', '@anthropic-ai/sdk/*'],
+              message:
+                'Model calls go through agents/transport.ts. A second SDK client would bypass replay, sanitisation, the token budget and telemetry — see docs/agent-design.md.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
   // Config and script files are plain JavaScript and are not in any tsconfig,
   // so type-aware rules cannot run against them.
   // ---------------------------------------------------------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "eval"
       ],
       "dependencies": {
+        "@anthropic-ai/sdk": "0.116.0",
         "zod": "4.4.3"
       },
       "devDependencies": {
@@ -77,6 +78,27 @@
       "version": "0.1.0",
       "license": "MIT"
     },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.116.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.116.0.tgz",
+      "integrity": "sha512-4UEapYQ+epLEMsAuLZDvW8ExVSOtHD8a7zTyLzhw0H9RXJ1eilPgmqhjwgcdg22diwx13spw6fJ4rONZ+bS7Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
@@ -133,6 +155,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -1435,6 +1466,12 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2715,6 +2752,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
@@ -3096,6 +3139,19 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -3995,6 +4051,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/std-env": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
@@ -4101,6 +4167,12 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     ]
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "0.116.0",
     "zod": "4.4.3"
   }
 }


### PR DESCRIPTION
Closes #30. The first model call in the project — or rather, the one wrapper every future model call has to go through.

## One transport, enforced by lint

Replay (#31), sanitisation (#32), telemetry and the token budget are all properties of going through `agents/transport.ts`. Without a rule, each one holds until the first call site that forgets — and then stops holding *silently*.

```
agents/probe.ts
  1:1  error  '@anthropic-ai/sdk' import is restricted... Model calls go through
              agents/transport.ts. A second SDK client would bypass replay,
              sanitisation, the token budget and telemetry.
```

Verified by writing the violating import and watching it fire. The exemption is `transport.ts` **and its own test** — not `**/*.test.ts`, which would let any agent's test build a client and quietly become the template for the production code beside it. Re-checked that a fresh `agents/*.test.ts` is still caught.

## Retries are classified, not counted

| Failure | Retried | Why |
| --- | --- | --- |
| Schema violation | yes, **with the errors appended** | The model can correct itself once it sees what was wrong |
| Rate limit (429) | yes, after backing off | The request is fine; the timing is not |
| 5xx / connection | yes, after backing off | Nothing about the request caused it |
| Malformed request (4xx) | **no** | Sending it again produces the same 4xx |
| Refusal | **no** | A decision, not a fault — asking again buys the same answer |
| Anything unclassified | **no** | Retrying what nobody categorised is how a bug becomes a bill |

Collapsing these into `retry(3)` builds a system that spends its budget re-sending requests that cannot succeed. And a schema violation is retried by showing the model *its own* errors — a bare "try again" re-runs the same misunderstanding at the same price.

Backoff is exponential with **full jitter**: a fleet backing off on an identical curve re-collides at every step, turning one rate limit into a herd. `sleep` and `random` are injected, so the schedule is asserted rather than assumed — `[500, 1000, 2000]` at full draw, capped, and scaled by the draw.

## The budget binds before dispatch

Checked against a real `count_tokens` call, not a character heuristic — and **re-checked before each schema retry**, because a corrected prompt is longer. A budget checked once against the first attempt is not a budget; one that only reports what was spent is an invoice.

## Two decisions I want flagged, not buried

**`effort` is left at the API default.** Lower effort is unusually strong on this model tier and is the obvious cost lever — but picking a level before measuring is tuning without evidence. The sweep belongs to #38, where it can be run against the dataset and defended with numbers.

**Server-side model fallback on a refusal is off by default.** This one is a deliberate departure from the general recommendation, and the reason is specific to this project: every number here names the model that produced it. A silent substitution part-way through an evaluation would make the headline a blend of two models while the report still claims one — exactly the quiet dishonesty the harness exists to prevent. It is implemented and one flag away, and it is probably the *right* default for the PR-comment path, where an answer from a second model beats no answer. Refusals surface as a typed error instead of being papered over.

## Tests

`model-client.test.ts` drives every retry branch through the port — including the three that decide **not** to retry, which no happy-path integration test ever reaches.

`transport.test.ts` checks the SDK-exception mapping against errors built by the SDK's own factory, because that mapping is the part that rots when the exception hierarchy moves while every stubbed test still passes.

Writing it found the trap immediately:

```
APIError.generate(429, {...}, undefined, undefined)  →  APIConnectionError
APIError.generate(429, {...}, undefined, headers)    →  RateLimitError
```

To the SDK, "no headers" means no response ever arrived. The first draft of the helper omitted them and silently tested one branch six times. Both behaviours are now pinned, including the `APIConnectionError instanceof APIError` relationship the `classify()` ordering depends on.

## Verification

`npx eslint .`, `npx tsc --build`, `npx prettier --check .`, `npm run eval -- --gate` all clean. **739 tests pass**, up from 688; coverage 94.4% statements / 81.7% branches, above the floor.

No live API call is made anywhere in the test suite.
