### PR TITLE
feat(agents): add cassette record and replay for model calls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,15 +2,25 @@
 # and the eval harness in replay mode — runs without it.
 ANTHROPIC_API_KEY=
 
-# Model used by the agents. Pinned deliberately: a model change moves classifier
-# behaviour, so it is upgraded with an eval run attached to the PR.
-SENTRA_MODEL=claude-sonnet-5
-
 # Replay/record mode for model calls (ADR-0005).
 #   SENTRA_REPLAY=1  serve responses from agents/replay/cassettes, no network
 #   SENTRA_RECORD=1  make live calls and write cassettes
+#   SENTRA_LIVE=1    force live calls; needed only if you authenticate with an
+#                    `ant auth login` profile, which leaves nothing here to detect
+#
+# Set at most one. Two at once is refused rather than resolved — a silent winner
+# is how a stale cassette gets mistaken for a model change.
+#
+# With none set and no credentials above, replay is the default. That is what
+# lets a fresh clone run the pipeline with nothing configured.
 SENTRA_REPLAY=
 SENTRA_RECORD=
+SENTRA_LIVE=
+
+# The model is NOT configured here. It is pinned in agents/model-client.ts, because
+# a model change moves every number in eval/report.md and belongs in a reviewable
+# commit with an eval run attached — not in someone's local environment, where two
+# people would silently publish figures from two different models.
 
 # Hard ceiling on output tokens per pipeline run. When hit, the orchestrator stops
 # dispatching and the report says how many failures went unclassified.

--- a/agents/cassettes.test.ts
+++ b/agents/cassettes.test.ts
@@ -1,0 +1,391 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  cassetteFile,
+  cassetteKey,
+  CassetteMissError,
+  CassetteTransport,
+  listCassettes,
+  ModeError,
+  REDACTED,
+  resolveMode,
+  scrub,
+} from './cassettes.js'
+import {
+  TransportError,
+  type ModelRequest,
+  type ModelResponse,
+  type Transport,
+} from './transport.js'
+
+const request = (over: Partial<ModelRequest> = {}): ModelRequest => ({
+  model: 'claude-opus-5',
+  maxTokens: 8000,
+  effort: 'high',
+  system: 'You classify test failures.\nUse the rubric.',
+  prompt: 'Classify this failure.',
+  schemaName: 'Classification',
+  jsonSchema: { type: 'object', properties: { owner: { type: 'string' } } },
+  promptVersion: 'triage.v1',
+  ...over,
+})
+
+const response: ModelResponse = {
+  raw: { owner: 'app_code' },
+  stopReason: 'end_turn',
+  model: 'claude-opus-5',
+  usage: { inputTokens: 1200, outputTokens: 88 },
+}
+
+/** Fails on any call. Wrapping this is how "replay makes no network call" is proved. */
+const unreachable: Transport = {
+  send() {
+    throw new Error('the inner transport was called in replay mode')
+  },
+  countInputTokens() {
+    throw new Error('the inner transport was called in replay mode')
+  },
+}
+
+const recording = (): Transport & { sends: number } => {
+  const t = {
+    sends: 0,
+    send(_request: ModelRequest) {
+      t.sends += 1
+      return Promise.resolve(response)
+    },
+    countInputTokens(_request: ModelRequest) {
+      return Promise.resolve(1200)
+    },
+  }
+  return t
+}
+
+const scratch = (): string => mkdtempSync(join(tmpdir(), 'sentra-cassettes-'))
+
+describe('resolveMode', () => {
+  it('replays when asked', () => {
+    expect(resolveMode({ SENTRA_REPLAY: '1', ANTHROPIC_API_KEY: 'sk-ant-x' })).toBe('replay')
+  })
+
+  it('records when asked', () => {
+    expect(resolveMode({ SENTRA_RECORD: '1', ANTHROPIC_API_KEY: 'sk-ant-x' })).toBe('record')
+  })
+
+  it('replays when there are no credentials, so a fresh clone works', () => {
+    // The claim the README rests on: clone, run, see it work, no key.
+    expect(resolveMode({})).toBe('replay')
+  })
+
+  it('treats an auth token as credentials too', () => {
+    // Checking ANTHROPIC_API_KEY alone would put a token-authenticated
+    // developer into replay and leave them wondering why nothing changed.
+    expect(resolveMode({ ANTHROPIC_AUTH_TOKEN: 'x' })).toBe('live')
+  })
+
+  it('treats an empty key as no key', () => {
+    expect(resolveMode({ ANTHROPIC_API_KEY: '' })).toBe('replay')
+  })
+
+  it('lets a profile-authenticated developer force live', () => {
+    // The SDK also accepts an `ant auth login` profile, which leaves nothing in
+    // the environment to detect. Without this flag that developer silently gets
+    // replay.
+    expect(resolveMode({ SENTRA_LIVE: '1' })).toBe('live')
+  })
+
+  it('refuses two conflicting requests rather than picking a winner', () => {
+    // A silent winner is a trap: somebody who meant to re-record and got replay
+    // sees stale answers and concludes the model changed.
+    expect(() => resolveMode({ SENTRA_REPLAY: '1', SENTRA_RECORD: '1' })).toThrow(ModeError)
+    expect(() => resolveMode({ SENTRA_LIVE: '1', SENTRA_REPLAY: '1' })).toThrow(/exactly one/)
+  })
+
+  it('names both modes that were asked for', () => {
+    const error = (() => {
+      try {
+        resolveMode({ SENTRA_REPLAY: '1', SENTRA_RECORD: '1' })
+        return ''
+      } catch (e) {
+        return e instanceof Error ? e.message : ''
+      }
+    })()
+    expect(error).toContain('replay')
+    expect(error).toContain('record')
+  })
+})
+
+describe('the cassette key', () => {
+  it('is stable across runs', () => {
+    expect(cassetteKey(request())).toBe(cassetteKey(request()))
+  })
+
+  it.each([
+    ['a reworded prompt', { prompt: 'Classify this differently.' }],
+    ['a different prompt version', { promptVersion: 'triage.v2' }],
+    ['a different model', { model: 'claude-sonnet-5' }],
+    ['a different system prompt', { system: 'Something else.' }],
+    ['a different effort', { effort: 'low' as const }],
+    ['a different token ceiling', { maxTokens: 4000 }],
+  ])('changes on %s', (_case, over) => {
+    expect(cassetteKey(request(over))).not.toBe(cassetteKey(request()))
+  })
+
+  it('changes when the output schema changes', () => {
+    // A reshaped output is a different question even when the prose is
+    // identical; replaying the old answer would validate against the new schema
+    // by luck or fail confusingly.
+    expect(cassetteKey(request({ jsonSchema: { type: 'object', properties: {} } }))).not.toBe(
+      cassetteKey(request()),
+    )
+  })
+
+  it('names files so a directory sorts by prompt version', () => {
+    expect(cassetteFile(request())).toMatch(/^triage\.v1\.[0-9a-f]{16}\.json$/)
+  })
+})
+
+describe('scrubbing', () => {
+  it.each([
+    ['an Anthropic key', 'key sk-ant-api03-AbCdEfGh12345678 here'],
+    ['a bearer token', 'Authorization: Bearer abcdefghijklmnop123'],
+    ['a GitHub token', 'ghp_abcdefghijklmnopqrstuvwxyz0123'],
+    ['a fine-grained GitHub token', 'github_pat_11ABCDEFG0abcdefghijklmn'],
+    ['an AWS access key', 'AKIAIOSFODNN7EXAMPLE'],
+    ['a Slack token', 'xoxb-123456789012-abcdefghijkl'],
+  ])('removes %s', (_case, text) => {
+    expect(scrub(text)).toContain(REDACTED)
+    expect(scrub(text)).not.toMatch(
+      /sk-ant-api03-A|abcdefghijklmnop123|ghp_abcdef|AKIAIOSF|xoxb-123/,
+    )
+  })
+
+  it('reaches into nested structures, where a leak would actually hide', () => {
+    const scrubbed = scrub({ a: [{ b: 'sk-ant-api03-SECRETVALUE123' }] })
+    expect(JSON.stringify(scrubbed)).toContain(REDACTED)
+    expect(JSON.stringify(scrubbed)).not.toContain('SECRETVALUE')
+  })
+
+  it('leaves ordinary text alone', () => {
+    const text = 'expected 3 to equal 4 at board.spec.ts:42'
+    expect(scrub(text)).toBe(text)
+  })
+
+  it('does not touch keys, since a key name is not a secret', () => {
+    expect(scrub({ ANTHROPIC_API_KEY: 'ordinary' })).toEqual({ ANTHROPIC_API_KEY: 'ordinary' })
+  })
+
+  it('passes non-strings through unchanged', () => {
+    expect(scrub({ n: 1, b: true, z: null })).toEqual({ n: 1, b: true, z: null })
+  })
+})
+
+describe('replay', () => {
+  it('serves the recorded response without touching the network', async () => {
+    // The property the whole feature rests on. The inner transport throws on
+    // any call, so a fallthrough fails loudly here rather than costing money in
+    // production.
+    const dir = scratch()
+    const record = new CassetteTransport(recording(), {
+      mode: 'record',
+      dir,
+      today: () => '2026-08-11',
+    })
+    await record.send(request())
+
+    const replay = new CassetteTransport(unreachable, { mode: 'replay', dir })
+    await expect(replay.send(request())).resolves.toMatchObject({ raw: { owner: 'app_code' } })
+  })
+
+  it('serves the token count from the cassette too', async () => {
+    const dir = scratch()
+    await new CassetteTransport(recording(), {
+      mode: 'record',
+      dir,
+      today: () => '2026-08-11',
+    }).send(request())
+
+    const replay = new CassetteTransport(unreachable, { mode: 'replay', dir })
+    await expect(replay.countInputTokens(request())).resolves.toBe(1200)
+  })
+
+  it('throws on a miss rather than falling through to a live call', async () => {
+    // A silent fallthrough turns a free deterministic run into a surprise bill
+    // and an intermittent test, and takes months to notice.
+    const replay = new CassetteTransport(unreachable, { mode: 'replay', dir: scratch() })
+    await expect(replay.send(request())).rejects.toThrow(CassetteMissError)
+  })
+
+  it('names the key, the expected file and how to re-record', async () => {
+    const replay = new CassetteTransport(unreachable, { mode: 'replay', dir: scratch() })
+    const error = (await replay.send(request()).catch((e: unknown) => e)) as Error
+
+    expect(error.message).toContain(cassetteKey(request()))
+    expect(error.message).toContain(cassetteFile(request()))
+    expect(error.message).toContain('SENTRA_RECORD=1')
+  })
+
+  it('misses when the prompt changes, rather than replaying a stale answer', async () => {
+    const dir = scratch()
+    await new CassetteTransport(recording(), {
+      mode: 'record',
+      dir,
+      today: () => '2026-08-11',
+    }).send(request())
+
+    const replay = new CassetteTransport(unreachable, { mode: 'replay', dir })
+    await expect(replay.send(request({ prompt: 'A different question.' }))).rejects.toThrow(
+      CassetteMissError,
+    )
+  })
+
+  it('reports a corrupt cassette as corrupt, not as a miss', async () => {
+    // "Re-record" is the wrong advice for somebody whose problem is a bad edit
+    // to a committed file.
+    const dir = scratch()
+    writeFileSync(join(dir, cassetteFile(request())), JSON.stringify({ key: 'x' }))
+
+    const replay = new CassetteTransport(unreachable, { mode: 'replay', dir })
+    const error = (await replay.send(request()).catch((e: unknown) => e)) as Error
+    expect(error).toBeInstanceOf(TransportError)
+    expect(error.message).toContain('not a valid cassette')
+  })
+})
+
+describe('recording', () => {
+  it('writes a cassette and still returns the live response', async () => {
+    const dir = scratch()
+    const inner = recording()
+    const transport = new CassetteTransport(inner, {
+      mode: 'record',
+      dir,
+      today: () => '2026-08-11',
+    })
+
+    await expect(transport.send(request())).resolves.toMatchObject({ raw: { owner: 'app_code' } })
+    expect(inner.sends).toBe(1)
+    expect(listCassettes(dir)).toHaveLength(1)
+  })
+
+  it('stores multi-line text as lines, so a prompt edit diffs readably', async () => {
+    // Inside a JSON string a whole prompt is one enormous line, and any change
+    // to it reviews as a single altered line with no sign of what moved.
+    const dir = scratch()
+    await new CassetteTransport(recording(), {
+      mode: 'record',
+      dir,
+      today: () => '2026-08-11',
+    }).send(request())
+    const cassette = listCassettes(dir)[0]
+    expect(cassette?.request.system).toEqual(['You classify test failures.', 'Use the rubric.'])
+  })
+
+  it('stores a digest of the schema rather than the schema', async () => {
+    // The schema runs to hundreds of derived lines and would bury the prompt in
+    // every review, but it still belongs in the identity.
+    const dir = scratch()
+    await new CassetteTransport(recording(), {
+      mode: 'record',
+      dir,
+      today: () => '2026-08-11',
+    }).send(request())
+    const raw = readFileSync(join(dir, cassetteFile(request())), 'utf8')
+    expect(raw).toContain('schemaDigest')
+    expect(raw).not.toContain('"properties"')
+  })
+
+  it('scrubs secrets before anything is committed', async () => {
+    // The last point at which a leaked credential can be caught: after this it
+    // is in git history forever.
+    const dir = scratch()
+    const leaky: Transport = {
+      send: () =>
+        Promise.resolve({ ...response, raw: { note: 'used sk-ant-api03-LEAKED12345678' } }),
+      countInputTokens: () => Promise.resolve(10),
+    }
+    await new CassetteTransport(leaky, { mode: 'record', dir, today: () => '2026-08-11' }).send(
+      request({ prompt: 'token ghp_abcdefghijklmnopqrstuvwxyz0123' }),
+    )
+
+    const raw = readFileSync(
+      join(dir, cassetteFile(request({ prompt: 'token ghp_abcdefghijklmnopqrstuvwxyz0123' }))),
+      'utf8',
+    )
+    expect(raw).not.toContain('LEAKED')
+    expect(raw).not.toContain('ghp_abcdef')
+    expect(raw).toContain(REDACTED)
+  })
+
+  it('writes JSON a human can read', async () => {
+    const dir = scratch()
+    await new CassetteTransport(recording(), {
+      mode: 'record',
+      dir,
+      today: () => '2026-08-11',
+    }).send(request())
+    const raw = readFileSync(join(dir, cassetteFile(request())), 'utf8')
+    expect(raw).toContain('\n  "key"')
+    expect(raw.endsWith('\n')).toBe(true)
+  })
+
+  it('records the date, so #40 can spot a cassette older than its prompt', async () => {
+    const dir = scratch()
+    await new CassetteTransport(recording(), {
+      mode: 'record',
+      dir,
+      today: () => '2026-08-11',
+    }).send(request())
+    expect(listCassettes(dir)[0]?.recordedAt).toBe('2026-08-11')
+  })
+})
+
+describe('live mode', () => {
+  it('passes straight through and writes nothing', async () => {
+    const dir = scratch()
+    const inner = recording()
+    const transport = new CassetteTransport(inner, { mode: 'live', dir })
+
+    await transport.send(request())
+    await transport.countInputTokens(request())
+
+    expect(inner.sends).toBe(1)
+    expect(listCassettes(dir)).toEqual([])
+  })
+})
+
+describe('listCassettes', () => {
+  it('returns nothing for a directory that does not exist yet', () => {
+    expect(listCassettes(join(scratch(), 'missing'))).toEqual([])
+  })
+
+  it('refuses a corrupt file rather than skipping it', () => {
+    // Skipping would make a broken cassette look like a missing one, and the
+    // staleness check in #40 would report a clean sheet.
+    const dir = scratch()
+    writeFileSync(join(dir, 'triage.v1.deadbeefdeadbeef.json'), '{"nope":true}')
+    expect(() => listCassettes(dir)).toThrow(/not a valid cassette/)
+  })
+
+  it('returns them sorted, so a listing does not churn', async () => {
+    const dir = scratch()
+    const transport = new CassetteTransport(recording(), {
+      mode: 'record',
+      dir,
+      today: () => '2026-08-11',
+    })
+    await transport.send(request({ promptVersion: 'triage.v2' }))
+    await transport.send(request({ promptVersion: 'triage.v1' }))
+
+    expect(listCassettes(dir).map((c) => c.promptVersion)).toEqual(['triage.v1', 'triage.v2'])
+  })
+})
+
+describe('the committed cassette directory', () => {
+  it('parses, whatever is in it', () => {
+    // Empty today. When the triage agent lands in #35 this is what stops a
+    // hand-edited cassette reaching main.
+    expect(() => listCassettes()).not.toThrow()
+  })
+})

--- a/agents/cassettes.ts
+++ b/agents/cassettes.ts
@@ -1,0 +1,365 @@
+import { createHash } from 'node:crypto'
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { z } from 'zod'
+import {
+  TransportError,
+  type ModelRequest,
+  type ModelResponse,
+  type Transport,
+} from './transport.js'
+
+/**
+ * Record and replay for model calls.
+ *
+ * This is what makes the README's central claim true — clone the repository,
+ * run the pipeline, see it work, with no credentials — and it makes the
+ * integration tests free and deterministic at the same time. Specified in
+ * ADR-0005.
+ *
+ * The design point everything else follows from: **a replay miss is a loud
+ * error, never a fallthrough to a live call.** A miss that quietly reaches the
+ * network turns "free deterministic test" into a surprise bill and a flaky
+ * test, and does it in a way nobody notices for months — the suite still
+ * passes, just slower and occasionally differently.
+ *
+ * Implemented as a decorator around a `Transport` rather than inside the
+ * Anthropic one, so replay has no opinion about the SDK and the SDK adapter has
+ * no opinion about replay. In replay mode the inner transport is never touched
+ * at all, which a test asserts by wrapping one that throws on any call.
+ */
+
+export type Mode = 'live' | 'record' | 'replay'
+
+export const CASSETTE_DIR = 'agents/replay/cassettes'
+
+// ---------------------------------------------------------------------------
+// Mode
+// ---------------------------------------------------------------------------
+
+export class ModeError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ModeError'
+  }
+}
+
+/**
+ * Which mode the environment asks for.
+ *
+ * Pure, so the precedence is testable without touching `process.env`. The
+ * precedence itself is the interesting part:
+ *
+ * Asking for record *and* replay at once is refused rather than resolved. Any
+ * silent winner here is a trap — a developer who meant to re-record and got
+ * replay sees stale answers and concludes the model changed.
+ *
+ * Absent credentials mean replay, per ADR-0005, so a clone with no key works.
+ * "Absent" is judged from `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN`
+ * together, and even then it can be wrong: the SDK also accepts an
+ * `ant auth login` profile that leaves no trace in the environment. Somebody
+ * authenticated that way and expecting live calls gets replay instead, which is
+ * why `SENTRA_LIVE=1` exists to say so explicitly.
+ */
+export interface ModeEnv {
+  SENTRA_REPLAY?: string | undefined
+  SENTRA_RECORD?: string | undefined
+  SENTRA_LIVE?: string | undefined
+  ANTHROPIC_API_KEY?: string | undefined
+  ANTHROPIC_AUTH_TOKEN?: string | undefined
+}
+
+export function resolveMode(env: ModeEnv): Mode {
+  const wantsReplay = env.SENTRA_REPLAY === '1'
+  const wantsRecord = env.SENTRA_RECORD === '1'
+  const wantsLive = env.SENTRA_LIVE === '1'
+
+  const asked = [wantsReplay && 'replay', wantsRecord && 'record', wantsLive && 'live'].filter(
+    (mode): mode is Mode => mode !== false,
+  )
+  if (asked.length > 1) {
+    throw new ModeError(
+      `SENTRA_REPLAY, SENTRA_RECORD and SENTRA_LIVE ask for different things (${asked.join(', ')}). ` +
+        'Set exactly one — guessing which you meant is how a stale cassette gets mistaken for a model change.',
+    )
+  }
+
+  if (wantsReplay) return 'replay'
+  if (wantsRecord) return 'record'
+  if (wantsLive) return 'live'
+
+  const credentialed =
+    (env.ANTHROPIC_API_KEY ?? '') !== '' || (env.ANTHROPIC_AUTH_TOKEN ?? '') !== ''
+  return credentialed ? 'live' : 'replay'
+}
+
+// ---------------------------------------------------------------------------
+// The cassette format
+// ---------------------------------------------------------------------------
+
+/**
+ * Multi-line text is stored as an array of lines.
+ *
+ * A prompt inside a JSON string is one enormous line, so any edit to it shows
+ * up in review as a single changed line with no indication of what moved. Split
+ * into lines it diffs like the prose it is. Rejoined on read, so nothing
+ * downstream knows.
+ */
+const LinesSchema = z.array(z.string())
+
+const CassetteSchema = z
+  .object({
+    key: z.string(),
+    promptVersion: z.string(),
+    model: z.string(),
+    /** Day precision. Enough for #40 to spot a cassette older than its prompt. */
+    recordedAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    request: z.object({
+      effort: z.string(),
+      maxTokens: z.number().int().positive(),
+      schemaName: z.string(),
+      /** A digest, not the schema — see `cassetteKey`. */
+      schemaDigest: z.string(),
+      system: LinesSchema,
+      prompt: LinesSchema,
+    }),
+    inputTokens: z.number().int().nonnegative(),
+    response: z.object({
+      raw: z.unknown(),
+      stopReason: z.string().nullable(),
+      model: z.string(),
+      usage: z.object({
+        inputTokens: z.number().int().nonnegative(),
+        outputTokens: z.number().int().nonnegative(),
+      }),
+    }),
+  })
+  .strict()
+
+export type Cassette = z.infer<typeof CassetteSchema>
+
+/**
+ * A stable identity for a request.
+ *
+ * Covers the prompt version, the model, and everything about the request that
+ * could change the answer — including the response schema, because a reshaped
+ * output is a different question even when the prose is identical.
+ *
+ * The schema is hashed rather than stored: it is derived from a Zod type, runs
+ * to hundreds of lines, and would bury the prompt in every cassette review.
+ * Storing its digest keeps it in the identity without putting it on the page.
+ */
+export function cassetteKey(request: ModelRequest): string {
+  return createHash('sha256')
+    .update(
+      JSON.stringify([
+        request.promptVersion,
+        request.model,
+        request.effort,
+        request.maxTokens,
+        request.schemaName,
+        schemaDigest(request),
+        request.system,
+        request.prompt,
+      ]),
+    )
+    .digest('hex')
+    .slice(0, 16)
+}
+
+const schemaDigest = (request: ModelRequest): string =>
+  createHash('sha256').update(JSON.stringify(request.jsonSchema)).digest('hex').slice(0, 12)
+
+/** `triage.v1.a1b2c3d4e5f6a7b8.json` — sorts by prompt version, unique by request. */
+export const cassetteFile = (request: ModelRequest): string =>
+  `${request.promptVersion}.${cassetteKey(request)}.json`
+
+// ---------------------------------------------------------------------------
+// Scrubbing
+// ---------------------------------------------------------------------------
+
+/**
+ * Patterns that must never reach a committed file.
+ *
+ * A cassette is written from a live response and then committed forever, so
+ * this is the last point at which a leaked credential can be caught. Deliberately
+ * broad: a false positive costs an unreadable cassette, a false negative costs a
+ * key in public git history.
+ */
+const SECRETS: readonly RegExp[] = [
+  /sk-ant-[A-Za-z0-9_-]{8,}/g,
+  /\bBearer\s+[A-Za-z0-9._~+/-]{12,}=*/gi,
+  /\bghp_[A-Za-z0-9]{20,}/g,
+  /\bgithub_pat_[A-Za-z0-9_]{20,}/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\bxox[baprs]-[A-Za-z0-9-]{10,}/g,
+]
+
+export const REDACTED = '[redacted]'
+
+/** Walks strings only; keys are left alone because a key name is not a secret. */
+export function scrub<T>(value: T): T {
+  if (typeof value === 'string') {
+    return SECRETS.reduce<string>((text, pattern) => text.replace(pattern, REDACTED), value) as T
+  }
+  if (Array.isArray(value)) return (value as unknown[]).map((item) => scrub(item)) as T
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, scrub(v)]),
+    ) as T
+  }
+  return value
+}
+
+// ---------------------------------------------------------------------------
+// The transport decorator
+// ---------------------------------------------------------------------------
+
+export class CassetteMissError extends Error {
+  constructor(
+    readonly key: string,
+    readonly file: string,
+    readonly promptVersion: string,
+  ) {
+    super(
+      [
+        `no cassette for ${promptVersion} request ${key}.`,
+        '',
+        `Expected: ${file}`,
+        '',
+        'Replay never falls through to a live call — a silent fallthrough turns a free,',
+        'deterministic run into a surprise bill and an intermittent test. Re-record with:',
+        '',
+        '    SENTRA_RECORD=1 npm run eval -- --classifier=agent',
+        '',
+        'and commit the cassette it writes.',
+      ].join('\n'),
+    )
+    this.name = 'CassetteMissError'
+  }
+}
+
+export interface CassetteOptions {
+  mode: Mode
+  dir?: string
+  /** Injected so a recording test does not have to reason about the clock. */
+  today?: () => string
+}
+
+/**
+ * Wraps a transport with record and replay.
+ *
+ * In `replay` the inner transport is unreachable — not merely unused. That is
+ * the property the whole feature rests on, and it is asserted by a test that
+ * wraps a transport which throws on any call.
+ */
+export class CassetteTransport implements Transport {
+  private readonly dir: string
+  private readonly today: () => string
+
+  constructor(
+    private readonly inner: Transport,
+    private readonly options: CassetteOptions,
+  ) {
+    this.dir = options.dir ?? CASSETTE_DIR
+    this.today = options.today ?? (() => new Date().toISOString().slice(0, 10))
+  }
+
+  get mode(): Mode {
+    return this.options.mode
+  }
+
+  async countInputTokens(request: ModelRequest): Promise<number> {
+    if (this.mode === 'replay') return this.load(request).inputTokens
+    return this.inner.countInputTokens(request)
+  }
+
+  async send(request: ModelRequest): Promise<ModelResponse> {
+    if (this.mode === 'replay') {
+      const cassette = this.load(request)
+      return {
+        raw: cassette.response.raw,
+        stopReason: cassette.response.stopReason,
+        model: cassette.response.model,
+        usage: cassette.response.usage,
+      }
+    }
+
+    const response = await this.inner.send(request)
+    if (this.mode === 'record') {
+      // Counted after the fact rather than before, so recording adds one
+      // request rather than two to every call it captures.
+      const inputTokens = response.usage.inputTokens
+      this.write(request, inputTokens, response)
+    }
+    return response
+  }
+
+  private load(request: ModelRequest): Cassette {
+    const file = cassetteFile(request)
+    let raw: string
+    try {
+      raw = readFileSync(join(this.dir, file), 'utf8')
+    } catch {
+      throw new CassetteMissError(cassetteKey(request), file, request.promptVersion)
+    }
+
+    const parsed = CassetteSchema.safeParse(JSON.parse(raw))
+    if (!parsed.success) {
+      // A corrupt cassette is not a miss. Treating it as one would print
+      // "re-record" at somebody whose problem is a bad edit to a committed file.
+      throw new TransportError(
+        'client',
+        `${file} is not a valid cassette: ${parsed.error.issues[0]?.message ?? ''}`,
+      )
+    }
+    return parsed.data
+  }
+
+  private write(request: ModelRequest, inputTokens: number, response: ModelResponse): void {
+    const cassette: Cassette = scrub({
+      key: cassetteKey(request),
+      promptVersion: request.promptVersion,
+      model: request.model,
+      recordedAt: this.today(),
+      request: {
+        effort: request.effort,
+        maxTokens: request.maxTokens,
+        schemaName: request.schemaName,
+        schemaDigest: schemaDigest(request),
+        system: request.system.split('\n'),
+        prompt: request.prompt.split('\n'),
+      },
+      inputTokens,
+      response: {
+        raw: response.raw,
+        stopReason: response.stopReason,
+        model: response.model,
+        usage: response.usage,
+      },
+    })
+
+    mkdirSync(this.dir, { recursive: true })
+    writeFileSync(join(this.dir, cassetteFile(request)), `${JSON.stringify(cassette, null, 2)}\n`)
+  }
+}
+
+/** Every committed cassette, for the staleness check in #40 and for tests. */
+export function listCassettes(dir: string = CASSETTE_DIR): Cassette[] {
+  let files: string[]
+  try {
+    files = readdirSync(dir)
+      .filter((file) => file.endsWith('.json'))
+      .sort()
+  } catch {
+    return []
+  }
+
+  return files.map((file) => {
+    const parsed = CassetteSchema.safeParse(JSON.parse(readFileSync(join(dir, file), 'utf8')))
+    if (!parsed.success) {
+      throw new Error(`${file} is not a valid cassette: ${parsed.error.issues[0]?.message ?? ''}`)
+    }
+    return parsed.data
+  })
+}

--- a/agents/index.ts
+++ b/agents/index.ts
@@ -10,3 +10,4 @@
 
 export * from './transport.js'
 export * from './model-client.js'
+export * from './cassettes.js'

--- a/agents/model-client.ts
+++ b/agents/model-client.ts
@@ -209,6 +209,7 @@ export async function callModel<T>(
     prompt: options.prompt,
     schemaName: options.schemaName,
     jsonSchema: toolSchema(options.schema),
+    promptVersion: options.promptVersion,
   }
 
   let corrections = ''

--- a/agents/replay/cassettes/README.md
+++ b/agents/replay/cassettes/README.md
@@ -1,0 +1,41 @@
+# Replay cassettes
+
+Recorded model responses, committed so the pipeline runs with no API key and no network — the
+claim [ADR-0005](../../../docs/adr/0005-replay-cassettes-for-credential-free-demo.md) exists to
+make true, and what makes the integration tests free and deterministic.
+
+Empty until the triage agent lands in #35. The machinery that reads and writes these files is
+`agents/cassettes.ts`.
+
+## Recording
+
+```bash
+SENTRA_RECORD=1 npm run eval -- --classifier=agent
+```
+
+Commit whatever it writes. Recording needs credentials; everything else does not.
+
+## Reading a diff
+
+Each file is one request and one response. `system` and `prompt` are stored as arrays of lines
+rather than as strings, so a reworded prompt reviews line by line instead of as a single altered
+line thousands of characters long.
+
+`schemaDigest` stands in for the response schema. The schema is derived from a Zod type, runs to
+hundreds of lines, and would bury the prompt in every review — but it still belongs in the
+cassette's identity, because a reshaped output is a different question even when the prose is
+identical. Hashing it keeps it in the key without putting it on the page.
+
+## Rules
+
+**A replay miss is an error, never a live call.** A silent fallthrough turns a free deterministic
+run into a surprise bill and an intermittent test, and takes months to notice. The error names the
+missing key and the command above.
+
+**Do not hand-edit a cassette.** The point of a recording is that it is what the model actually
+said. An edited one is a fixture pretending to be evidence, and every number derived from it
+inherits the pretence. Re-record instead.
+
+**Secrets are scrubbed on write** — Anthropic keys, bearer tokens, GitHub and AWS and Slack
+credentials. That scrub is the last point at which a leaked credential can be caught before it is
+in public git history forever, so it is deliberately broad.

--- a/agents/transport.test.ts
+++ b/agents/transport.test.ts
@@ -175,6 +175,7 @@ const request = {
   prompt: 'this failure',
   schemaName: 'Classification',
   jsonSchema: { type: 'object' as const },
+  promptVersion: 'triage.v1',
 }
 
 describe('AnthropicTransport', () => {

--- a/agents/transport.ts
+++ b/agents/transport.ts
@@ -23,6 +23,15 @@ export interface ModelRequest {
   /** Names the shape in the response format; surfaces in errors and telemetry. */
   schemaName: string
   jsonSchema: JsonSchemaObject
+  /**
+   * Which prompt file produced this.
+   *
+   * Carried on the request rather than only on the call options because it is
+   * part of the cassette key: the same input under a reworded prompt is a
+   * different question, and replaying yesterday's answer to it would be a lie
+   * that looks exactly like a passing test.
+   */
+  promptVersion: string
 }
 
 export type Effort = 'low' | 'medium' | 'high' | 'xhigh' | 'max'

--- a/docs/adr/0005-replay-cassettes-for-credential-free-demo.md
+++ b/docs/adr/0005-replay-cassettes-for-credential-free-demo.md
@@ -19,11 +19,19 @@ every CI run.
 
 All model calls route through one wrapper supporting three modes:
 
-| Mode     | Trigger                              | Behaviour                                         |
-| -------- | ------------------------------------ | ------------------------------------------------- |
-| `live`   | default, key present                 | Real API call                                     |
-| `record` | `SENTRA_RECORD=1`                    | Real call; request/response written to a cassette |
-| `replay` | `SENTRA_REPLAY=1`, or no key present | Cassette lookup; no network                       |
+| Mode     | Trigger                                 | Behaviour                                         |
+| -------- | --------------------------------------- | ------------------------------------------------- |
+| `live`   | `SENTRA_LIVE=1`, or credentials present | Real API call                                     |
+| `record` | `SENTRA_RECORD=1`                       | Real call; request/response written to a cassette |
+| `replay` | `SENTRA_REPLAY=1`, or no credentials    | Cassette lookup; no network                       |
+
+Setting more than one of the three is refused rather than resolved. Any silent winner is a trap:
+somebody who meant to re-record and got replay sees stale answers and concludes the model changed.
+
+"No credentials" is judged from `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` together — and even
+then it can be wrong, because the SDK also accepts an `ant auth login` profile that leaves nothing
+in the environment to detect. Somebody authenticated that way would silently get replay, which is
+what `SENTRA_LIVE=1` exists to override.
 
 Cassettes live in `agents/replay/cassettes/`, are committed, and are keyed by a stable hash of
 (prompt version, model, normalised request body). A replay miss is a loud error, never a silent

--- a/docs/agent-design.md
+++ b/docs/agent-design.md
@@ -15,10 +15,14 @@ Every agent call goes through `agents/model-client.ts`, which provides:
 - **Input sanitisation.** Test names, error messages, and diff hunks are untrusted text. They are
   length-capped, fenced inside explicit delimiters, and prefixed with a standing instruction that
   content inside the delimiters is data, never instruction.
-- **Replay/record.** With `SENTRA_REPLAY=1`, requests hash to a cassette file under
-  `agents/replay/cassettes/` and the recorded response is returned. With `SENTRA_RECORD=1`, live
-  responses are written there. This makes the demo credential-free and the integration tests free
-  and deterministic.
+- **Replay/record.** A decorator around the transport, so replay has no opinion about the SDK and
+  the SDK adapter has none about replay. `SENTRA_REPLAY=1` serves from
+  `agents/replay/cassettes/`; `SENTRA_RECORD=1` writes there; with no credentials replay is the
+  default, which is what makes the demo credential-free and the integration tests free and
+  deterministic. **A replay miss throws** — in replay the inner transport is unreachable, not
+  merely unused, and a test proves it by wrapping one that fails on any call. A silent fallthrough
+  would turn a free deterministic run into a surprise bill and an intermittent test, and would take
+  months to notice.
 - **Telemetry.** One OpenTelemetry span per call, carrying model, token counts, latency, cost,
   retry count, and cassette hit/miss. Exported to `otel-spans.json`.
 - **Budget.** A per-run token ceiling, checked **before** dispatch against a real


### PR DESCRIPTION
Closes #31. Three modes on the transport — `live`, `record`, `replay` — with cassettes committed under `agents/replay/cassettes/`.

This is what makes the README's central claim true (clone, run, see it work, no credentials) and makes the integration tests free and deterministic at the same time. Built as a **decorator** around a `Transport`, so replay has no opinion about the SDK and the SDK adapter has none about replay.

## A miss is an error, never a live call

The property everything else rests on. A miss that quietly reaches the network turns "free deterministic test" into a surprise bill and an intermittent test — and does it in a way nobody notices for months, because the suite still passes, just slower and occasionally differently.

In replay the inner transport is **unreachable**, not merely unused. The test proves it by wrapping a transport that throws on any call:

```
no cassette for triage.v1 request 3f2a8c1d9e7b4a05.

Expected: triage.v1.3f2a8c1d9e7b4a05.json

Replay never falls through to a live call — a silent fallthrough turns a free,
deterministic run into a surprise bill and an intermittent test. Re-record with:

    SENTRA_RECORD=1 npm run eval -- --classifier=agent
```

A **corrupt** cassette is reported as corrupt rather than as a miss. "Re-record" is the wrong advice for somebody whose problem is a bad edit to a committed file.

## The key covers everything that changes the answer

Prompt version, model, effort, token ceiling, system, prompt — and the **response schema**, because a reshaped output is a different question even when the prose is identical.

`promptVersion` had to move onto `ModelRequest` for this. Replaying yesterday's answer to a reworded prompt is a lie that looks exactly like a passing test.

The schema is hashed rather than stored: derived from a Zod type, hundreds of lines, and it would bury the prompt in every review — but it still belongs in the identity.

## Cassettes are written to be reviewed

`system` and `prompt` are stored as **arrays of lines**. Inside a JSON string a whole prompt is one enormous line, and any change to it reviews as a single altered line with no sign of what moved.

Secrets are scrubbed on write — Anthropic keys, bearer tokens, GitHub, AWS and Slack credentials. That scrub is the last point at which a leaked credential can be caught before it is in public git history forever, so it is deliberately broad: a false positive costs an unreadable cassette, a false negative costs a key.

## Mode resolution has two traps, both closed

**Two modes at once is refused, not resolved.** A silent winner is how somebody who meant to re-record gets replay, sees stale answers, and concludes the model changed.

**"No credentials" is not just `ANTHROPIC_API_KEY`.** It checks `ANTHROPIC_AUTH_TOKEN` too — and even then it can be wrong, because the SDK also accepts an `ant auth login` profile that leaves *nothing in the environment to detect*. Somebody authenticated that way would silently get replay and wonder why nothing changed. `SENTRA_LIVE=1` exists to say otherwise.

## One thing found on the way

`.env.example` advertised `SENTRA_MODEL=claude-sonnet-5` — a variable **nothing reads**, naming a **different model** from the one the code pins. Removed, with the reason in its place: the model belongs in a reviewable commit with an eval run attached, not in a local environment where two people would publish figures from two different models and neither would know.

## Verification

`npx eslint .`, `npx tsc --build`, `npx prettier --check .`, `npm run eval -- --gate` all clean. **795 tests pass**, up from 751; `cassettes.ts` at 98.7% statements / 91.8% branches. Still no live API call anywhere in the suite.

The cassette directory is empty and documented — it fills when the triage agent lands in #35.