### PR TITLE
feat(prompts): give the rubric one copy and make published versions immutable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,14 @@ jobs:
           npm ci --silent
           npm run docs:status:check
 
+      # The rubric the model is sent and the rubric the dataset was labelled by
+      # are one file; docs/taxonomy.md carries a generated copy. Drift between
+      # them turns every accuracy figure into agreement with a rule nobody is
+      # applying, and nothing about the repository looks different afterwards.
+      - name: Documented rubric matches the one the prompt embeds
+        if: steps.detect.outputs.has-code == 'true'
+        run: npm run prompts:sync:check
+
       # Label leakage is the quietest way to inflate an accuracy number, so this
       # runs on every push rather than only when the dataset changes — a leaked
       # term arrives just as easily through an edit to the checker itself.
@@ -295,6 +303,14 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "::notice::No change under agents/, eval/ or prompts/ — from M3 the model run is skipped here."
           fi
+
+      # eval/report.md attributes its numbers to a prompt version. Editing that
+      # version in place keeps the record and breaks the link, so a published
+      # version — and the rubric substituted into it — is immutable. This runs
+      # here rather than in hygiene because it needs the full history that job
+      # does not fetch; it throws rather than passing if the ref is unreadable.
+      - name: Published prompt versions were not edited in place
+        run: npm run prompts:freeze -- --ref=origin/main
 
       - name: Run golden-dataset evaluation
         env:

--- a/docs/agent-design.md
+++ b/docs/agent-design.md
@@ -75,27 +75,48 @@ the file under test, and the test's own source.
 
 **Output:** the `Classification` object from [taxonomy.md](taxonomy.md#output-schema).
 
-**Prompt structure:**
+**Prompt structure.** Every instruction is in the system message and every untrusted string is in
+the user message, with nothing interpolated across the line. That split is the reason
+`prompts/registry.ts` offers exactly one substitution — the rubric — and refuses a template with
+any other placeholder: a prompt file that could interpolate evidence would be a prompt file that
+can put attacker text inside an instruction.
 
-1. Role and the two-axis definition, verbatim from the taxonomy doc — the same text the human
-   labeller used, so the model and the ground truth share a rubric.
-2. The ordered labelling rules, so ambiguous cases resolve the same way the dataset does.
-3. Explicit instruction to reason about the axes independently.
-4. The evidence bundle, in delimited blocks.
-5. A requirement to quote evidence for the decision.
+System (`prompts/triage.v1.md`):
+
+1. Role, and what the output is for.
+2. The rubric — the two-axis definition and the ordered labelling rules, substituted verbatim from
+   the same file the human labeller applies, so the model and the ground truth cannot disagree.
+3. What absence and truncation in the evidence mean, so a capped field is not read as a complete
+   one.
+4. The output contract, including what `confidence` is measured against and a requirement to quote
+   the evidence relied on rather than summarise it.
+
+User (`agents/sanitise.ts`):
+
+5. The standing "this is data" preamble, then the evidence in delimited blocks.
 
 **Design notes:**
 
-- The rubric is loaded from a single source shared with the eval harness. A prompt change that
-  contradicts the labelling rules is a bug, and keeping one copy makes it impossible.
+- **The rubric has one copy.** `prompts/rubric.md` is substituted into the prompt at load time and
+  generated into [taxonomy.md](taxonomy.md#the-rubric), which is what the human labeller applies.
+  A prompt whose definition of `intermittent` has drifted from the dataset's would make the
+  evaluation measure agreement with a rule nobody is following, and the figure would look exactly
+  like the one that meant something. `npm run prompts:sync` writes the copy, a unit test fails when
+  it is stale, and a test asserts no prompt file contains a pasted duplicate — the invariant is
+  "there is no second copy", not "the copies currently agree".
 - **There is no temperature to set.** This model rejects `temperature`, `top_p` and `top_k` with a
   400, so the usual "pin it to 0 and call it deterministic" move is not available — and the loss is
   smaller than it looks, because it was never determinism in the first place. Variance is measured
   rather than suppressed: the eval harness samples N times per fixture and reports
   self-consistency as a first-class metric. A test asserts the client sends no sampling parameter,
   so this cannot drift back in.
-- Prompts are versioned (`prompts/triage.v3.md`). `eval/report.md` records which version produced
-  which numbers, so a regression is attributable.
+- **Prompts are versioned and published versions are immutable.** `prompts/triage.v1.md`;
+  `eval/report.md` and `eval/metrics.json` record which version produced which numbers, so a
+  regression is attributable. Editing a version in place keeps the record and destroys the link —
+  the report still names `triage.v1`, and `triage.v1` is now different text — so
+  `npm run prompts:freeze` fails the build on any change to a prompt the committed metrics name,
+  the rubric included, since it is a section of every prompt rather than a document about them.
+  The next version is the way forward, not an edit.
 
 ## 2. Root-cause agent
 

--- a/docs/eval-methodology.md
+++ b/docs/eval-methodology.md
@@ -103,7 +103,7 @@ fails the suite with the old and new values side by side.
 
 Each fixture is a `TestRun`-shaped JSON file plus a sibling `.labels.json` carrying ground truth,
 a prose justification for the label, and the rules from
-[taxonomy.md](taxonomy.md#labelling-rules-for-the-golden-dataset) that were applied.
+[taxonomy.md](taxonomy.md#labelling-rules) that were applied.
 
 **Provenance matters.** Fixtures come from three sources, tracked per fixture:
 `synthetic` (hand-authored), `captured` (a real TaskFlow CI run, labelled after the fact), and

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -14,7 +14,17 @@ labeller has to pick arbitrarily. Two people labelling the same fixture disagree
 disagrees with themselves a week later. Once ground truth is unreproducible, accuracy measured
 against it is decoration.
 
-## Two orthogonal axes
+## The rubric
+
+The normative text below is generated from [`prompts/rubric.md`](../prompts/rubric.md) — the same
+file the triage prompt embeds. There is one copy on purpose: a rubric the model applies and a
+rubric the dataset was labelled by that have quietly drifted apart produce an accuracy figure that
+measures agreement with a rule nobody is following, and it looks exactly like the figure that
+meant something. `npm run prompts:sync` writes this block and a unit test fails when it is stale.
+
+<!-- rubric:begin -->
+
+<!-- Generated from prompts/rubric.md by `npm run prompts:sync`. Edit that file, not this block. -->
 
 Every failure gets exactly one value on each axis.
 
@@ -33,7 +43,38 @@ Every failure gets exactly one value on each axis.
 | `deterministic` | Fails every time under the same conditions. | `statusHistory` shows an unbroken failure streak; failed on all retry attempts; flakiness score near 0 with current status failing |
 | `intermittent`  | Fails some of the time.                     | Alternating pass/fail history; passed on retry within the same run; high flakiness score                                           |
 
-### The resulting matrix
+### Labelling rules
+
+Applied in order; the first rule that fires decides.
+
+1. **The run never reached the assertion** (browser crash, port bind failure, install error,
+   OOM) → `environment`, regardless of anything else.
+2. **The test source encodes an unsafe assumption** (asserts without waiting for an async
+   effect, depends on another test's state, depends on list order that is not guaranteed) →
+   `test_code`, even if the product also has a race. Rationale: the test is not a valid
+   detector, so it cannot be evidence about the product.
+3. **The failure reproduces against an unchanged product** (same commit, isolated run) →
+   `test_code` if the test is at fault, `app_code` if the product is.
+4. **Otherwise** → `app_code`.
+
+For `determinism`: `deterministic` iff every attempt in the run failed **and** the recorded
+history shows no pass in the last 5 runs of the same test at the same commit range. Anything
+else is `intermittent`. Where history is absent (`isNew`), fall back to within-run retries only,
+and mark the fixture `lowConfidenceGroundTruth: true` so it can be excluded from headline
+metrics.
+
+### Deciding the axes independently
+
+The axes are orthogonal by construction, and treating them as one judgement is the most common
+way to get both wrong. Knowing a failure is intermittent says nothing about whether the product
+or the test is at fault: a product race and a missing `await` in the spec produce the same
+alternating history. Decide `owner` from what the evidence implicates, decide `determinism` from
+how the failure behaves across attempts and history, and do not let a conclusion on one axis
+argue for a conclusion on the other.
+
+<!-- rubric:end -->
+
+## The resulting matrix
 
 |                   | `deterministic`                                                                     | `intermittent`                                                                                             |
 | ----------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
@@ -78,26 +119,6 @@ type Classification = {
 `evidence` is not decoration. Requiring the model to quote the input it relied on makes
 hallucinated justifications visible in review and gives the eval harness something to check
 beyond the label.
-
-## Labelling rules for the golden dataset
-
-Applied in order; the first rule that fires decides.
-
-1. **The run never reached the assertion** (browser crash, port bind failure, install error,
-   OOM) → `environment`, regardless of anything else.
-2. **The test source encodes an unsafe assumption** (asserts without waiting for an async
-   effect, depends on another test's state, depends on list order that is not guaranteed) →
-   `test_code`, even if the product also has a race. Rationale: the test is not a valid
-   detector, so it cannot be evidence about the product.
-3. **The failure reproduces against an unchanged product** (same commit, isolated run) →
-   `test_code` if the test is at fault, `app_code` if the product is.
-4. **Otherwise** → `app_code`.
-
-For `determinism`: `deterministic` iff every attempt in the run failed **and** the recorded
-history shows no pass in the last 5 runs of the same test at the same commit range. Anything
-else is `intermittent`. Where history is absent (`isNew`), fall back to within-run retries only,
-and mark the fixture `lowConfidenceGroundTruth: true` so it can be excluded from headline
-metrics.
 
 ## Known hard cases
 

--- a/eval/gate.test.ts
+++ b/eval/gate.test.ts
@@ -15,6 +15,7 @@ import { DEFAULTS, evaluate, METRICS_PATHS } from './run-eval.js'
 const at = (lower: number, over: Partial<MetricsSnapshot> = {}): MetricsSnapshot => ({
   version: 1,
   classifier: 'baseline',
+  promptVersion: null,
   slice: 'dev',
   datasetRevision: 'abcd',
   n: 22,
@@ -244,7 +245,12 @@ describe('the snapshot', () => {
   const current = snapshot(
     evaluation.metrics,
     quadrantBreakdown(evaluation.fixtures.map((f) => f.judgement)),
-    { classifier: 'baseline', slice: 'dev', datasetRevision: evaluation.datasetRevision },
+    {
+      classifier: 'baseline',
+      promptVersion: null,
+      slice: 'dev',
+      datasetRevision: evaluation.datasetRevision,
+    },
   )
 
   it('validates against its own schema', () => {

--- a/eval/gate.ts
+++ b/eval/gate.ts
@@ -102,6 +102,13 @@ export interface Interval {
 export interface MetricsSnapshot {
   version: 1
   classifier: Classifier
+  /**
+   * Which prompt produced these numbers; null for the baseline, which has none.
+   *
+   * The link between a figure and the text that produced it, and the input to
+   * `prompts/freeze.ts` — a version named here can no longer be edited in place.
+   */
+  promptVersion: string | null
   slice: string
   datasetRevision: string
   n: number
@@ -125,6 +132,15 @@ export const MetricsSnapshotSchema = z
   .object({
     version: z.literal(1),
     classifier: z.enum(['baseline', 'agent']),
+
+    /**
+     * Additive and defaulted rather than required, so a snapshot committed
+     * before this field existed still parses. `readReferenceSnapshot` throws on
+     * a file it cannot read, which is right for corruption and wrong for "older
+     * than the field" — a required key here would take the gate down on the
+     * commit that introduced it.
+     */
+    promptVersion: z.string().nullable().default(null),
     slice: z.string(),
     datasetRevision: z.string(),
     n: z.number().int().nonnegative(),
@@ -179,13 +195,19 @@ const interval = (p: { point: number; interval: { lower: number; upper: number }
 export function snapshot(
   metrics: Metrics,
   quadrants: readonly QuadrantRow[],
-  context: { classifier: Classifier; slice: string; datasetRevision: string },
+  context: {
+    classifier: Classifier
+    promptVersion: string | null
+    slice: string
+    datasetRevision: string
+  },
 ): MetricsSnapshot {
   const hard = quadrants.find((q) => q.hard)
 
   return {
     version: 1,
     classifier: context.classifier,
+    promptVersion: context.promptVersion,
     slice: context.slice,
     datasetRevision: context.datasetRevision,
     n: metrics.n,

--- a/eval/metrics.json
+++ b/eval/metrics.json
@@ -1,6 +1,7 @@
 {
   "version": 1,
   "classifier": "baseline",
+  "promptVersion": null,
   "slice": "dev",
   "datasetRevision": "eb99bece4ad0347c",
   "n": 22,

--- a/eval/package.json
+++ b/eval/package.json
@@ -12,6 +12,7 @@
     }
   },
   "dependencies": {
-    "@sentra/contracts": "*"
+    "@sentra/contracts": "*",
+    "@sentra/prompts": "*"
   }
 }

--- a/eval/run-eval.ts
+++ b/eval/run-eval.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto'
 import { readFileSync, writeFileSync } from 'node:fs'
 import { format } from 'prettier'
 import type { FixtureLabels } from '@sentra/contracts'
+import { CURRENT_PROMPT } from '@sentra/prompts'
 import { classifyWithBaseline } from './baseline.js'
 import {
   confusionMatrix,
@@ -347,6 +348,21 @@ export function renderReport(evaluation: Evaluation): string {
   ].join('\n')
 }
 
+/**
+ * The prompt behind a set of numbers.
+ *
+ * Null for the baseline, and that is not a placeholder — a heuristic has no
+ * prompt, and writing one in would put a version into `eval/metrics.json` that
+ * `prompts/freeze.ts` would then protect on behalf of numbers no prompt
+ * produced.
+ */
+export function promptVersionFor(classifier: Options['classifier']): string | null {
+  return classifier === 'baseline' ? null : (CURRENT_PROMPT.triage ?? null)
+}
+
+const renderPromptVersion = (version: string | null): string =>
+  version === null ? 'none' : `\`${version}\``
+
 function renderProvenance(evaluation: Evaluation): string {
   const { options, fixtures, datasetRevision: revision } = evaluation
   const excluded = fixtures.filter((f) => f.labels.lowConfidenceGroundTruth).length
@@ -354,7 +370,7 @@ function renderProvenance(evaluation: Evaluation): string {
   const rows: string[][] = [
     ['classifier', `\`${options.classifier}\``],
     ['model', options.classifier === 'baseline' ? 'none — a heuristic, no model call' : 'unknown'],
-    ['prompt version', options.classifier === 'baseline' ? 'none' : 'unknown'],
+    ['prompt version', renderPromptVersion(promptVersionFor(options.classifier))],
     ['dataset', `${String(fixtures.length)} fixtures in \`${DATASET_DIR}\``],
     ['dataset revision', `\`${revision}\``],
     ['slice', `\`${options.slice}\``],
@@ -694,6 +710,7 @@ export async function main(argv: string[]): Promise<number> {
     ),
     {
       classifier: options.classifier,
+      promptVersion: promptVersionFor(options.classifier),
       slice: options.slice,
       datasetRevision: evaluation.datasetRevision,
     },

--- a/eval/tsconfig.json
+++ b/eval/tsconfig.json
@@ -9,6 +9,9 @@
   "references": [
     {
       "path": "../contracts"
+    },
+    {
+      "path": "../prompts"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "workspaces": [
         "contracts",
+        "prompts",
         "app/client",
         "app/server",
         "flakemetry-lib",
@@ -45,7 +46,12 @@
     "agents": {
       "name": "@sentra/agents",
       "version": "0.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "*",
+        "@sentra/contracts": "*",
+        "zod": "*"
+      }
     },
     "app/client": {
       "name": "@sentra/taskflow-client",
@@ -70,7 +76,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@sentra/contracts": "*"
+        "@sentra/contracts": "*",
+        "@sentra/prompts": "*"
       }
     },
     "flakemetry-lib": {
@@ -1427,6 +1434,10 @@
     },
     "node_modules/@sentra/flakemetry": {
       "resolved": "flakemetry-lib",
+      "link": true
+    },
+    "node_modules/@sentra/prompts": {
+      "resolved": "prompts",
       "link": true
     },
     "node_modules/@sentra/taskflow-client": {
@@ -4612,6 +4623,14 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "prompts": {
+      "name": "@sentra/prompts",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "*"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sentra",
   "version": "0.1.0",
   "private": true,
-  "description": "An AI triage layer for CI test failures — packaged as a pipeline step, not a service.",
+  "description": "An AI triage layer for CI test failures \u2014 packaged as a pipeline step, not a service.",
   "license": "MIT",
   "author": "Andrii Kohut",
   "repository": {
@@ -15,6 +15,7 @@
   },
   "workspaces": [
     "contracts",
+    "prompts",
     "app/client",
     "app/server",
     "flakemetry-lib",
@@ -41,13 +42,16 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prepare": "husky",
+    "prompts:freeze": "tsx prompts/freeze.ts",
+    "prompts:sync": "tsx prompts/sync.ts",
+    "prompts:sync:check": "tsx prompts/sync.ts --check",
     "test": "node scripts/pending.mjs test",
+    "test:coverage": "vitest run --coverage",
     "test:e2e": "node scripts/pending.mjs test:e2e",
     "test:unit": "vitest run",
     "typecheck": "tsc --build",
     "typecheck:clean": "tsc --build --clean",
-    "wiki:publish": "./scripts/publish-wiki.sh",
-    "test:coverage": "vitest run --coverage"
+    "wiki:publish": "./scripts/publish-wiki.sh"
   },
   "devDependencies": {
     "@commitlint/cli": "21.2.1",

--- a/prompts/freeze.test.ts
+++ b/prompts/freeze.test.ts
@@ -1,0 +1,218 @@
+import { execFileSync } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+import {
+  METRICS_FILES,
+  frozenViolations,
+  gitDeps,
+  main,
+  publishedVersions,
+  renderViolations,
+  REF_SENTINEL,
+  UnreadableRefError,
+  type FreezeDeps,
+} from './freeze.js'
+
+const REF = 'origin/main'
+
+/** A repository state: what each path holds at the ref, and what it holds locally. */
+const world = (atRef: Record<string, string>, local: Record<string, string>): FreezeDeps => ({
+  // The sentinel is present in every world except the one that tests its absence.
+  showAtRef: (_ref, path) => ({ [REF_SENTINEL]: 'sentinel', ...atRef })[path] ?? null,
+  readLocal: (path) => local[path] ?? null,
+})
+
+const metrics = (promptVersion: string | null): string =>
+  JSON.stringify({ version: 1, classifier: 'agent', promptVersion })
+
+const PUBLISHED = {
+  'eval/metrics.json': metrics('triage.v1'),
+  'prompts/triage.v1.md': 'the prompt\n',
+  'prompts/rubric.md': 'the rubric\n',
+}
+
+describe('what counts as published', () => {
+  it('is whatever the committed metrics name', () => {
+    const deps = world(
+      {
+        'eval/metrics.json': metrics('triage.v1'),
+        'eval/holdout-metrics.json': metrics('triage.v2'),
+      },
+      {},
+    )
+    expect(publishedVersions(REF, deps)).toEqual(['triage.v1', 'triage.v2'])
+  })
+
+  it('is empty for the baseline, which has no prompt to protect', () => {
+    expect(publishedVersions(REF, world({ 'eval/metrics.json': metrics(null) }, {}))).toEqual([])
+  })
+
+  it('is empty when the ref has no metrics at all', () => {
+    expect(publishedVersions(REF, world({}, {}))).toEqual([])
+  })
+
+  /**
+   * This check protects published numbers; it is not the validator for the
+   * metrics format. Throwing here would report the wrong problem loudly enough
+   * to hide the right one.
+   */
+  it('skips a metrics file it cannot parse rather than failing on it', () => {
+    const deps = world(
+      { 'eval/metrics.json': '{ not json', 'eval/holdout-metrics.json': metrics('triage.v1') },
+      {},
+    )
+    expect(publishedVersions(REF, deps)).toEqual(['triage.v1'])
+  })
+
+  it('ignores a version field that is not a version', () => {
+    const deps = world({ 'eval/metrics.json': JSON.stringify({ promptVersion: 7 }) }, {})
+    expect(publishedVersions(REF, deps)).toEqual([])
+  })
+
+  it('looks at every metrics file the harness writes', () => {
+    expect([...METRICS_FILES]).toContain('eval/holdout-metrics.json')
+  })
+})
+
+describe('freezing', () => {
+  it('allows everything while no numbers have been published', () => {
+    const deps = world({ 'eval/metrics.json': metrics(null) }, { 'prompts/triage.v1.md': 'edited' })
+    expect(frozenViolations(REF, deps)).toEqual([])
+  })
+
+  it('passes when the published files are untouched', () => {
+    expect(frozenViolations(REF, world(PUBLISHED, PUBLISHED))).toEqual([])
+  })
+
+  it('catches an edit in place', () => {
+    const deps = world(PUBLISHED, { ...PUBLISHED, 'prompts/triage.v1.md': 'reworded\n' })
+    expect(frozenViolations(REF, deps)).toEqual([
+      { path: 'prompts/triage.v1.md', reason: 'edited', promptVersion: 'triage.v1' },
+    ])
+  })
+
+  /**
+   * The case the frozen set would miss if it were the prompt files only. The
+   * rubric is substituted in at load time, so editing it rewrites every
+   * published prompt at once while leaving all of their files byte-identical.
+   */
+  it('catches a rubric edit, which changes every published prompt at once', () => {
+    const deps = world(PUBLISHED, { ...PUBLISHED, 'prompts/rubric.md': 'reworded\n' })
+    expect(frozenViolations(REF, deps)).toEqual([
+      { path: 'prompts/rubric.md', reason: 'edited', promptVersion: 'triage.v1' },
+    ])
+  })
+
+  it('catches a deletion', () => {
+    const deps = world(PUBLISHED, { 'prompts/rubric.md': 'the rubric\n' })
+    expect(frozenViolations(REF, deps)).toEqual([
+      { path: 'prompts/triage.v1.md', reason: 'deleted', promptVersion: 'triage.v1' },
+    ])
+  })
+
+  it('reports metrics that name a prompt the ref does not have', () => {
+    const deps = world({ 'eval/metrics.json': metrics('triage.v4') }, {})
+    expect(frozenViolations(REF, deps).map((v) => v.reason)).toEqual([
+      'missing-at-ref',
+      'missing-at-ref',
+    ])
+  })
+
+  it('names every offending file at once rather than one per run', () => {
+    const deps = world(PUBLISHED, { 'prompts/triage.v1.md': 'a', 'prompts/rubric.md': 'b' })
+    expect(frozenViolations(REF, deps)).toHaveLength(2)
+  })
+})
+
+describe('the message', () => {
+  it('says what to do instead of what went wrong', () => {
+    const rendered = renderViolations(REF, [
+      { path: 'prompts/triage.v1.md', reason: 'edited', promptVersion: 'triage.v1' },
+    ])
+    expect(rendered).toContain('was edited in place after its numbers were published')
+    expect(rendered).toContain('<agent>.v<n+1>.md')
+  })
+})
+
+describe('the CLI', () => {
+  const say = (): { lines: string[]; log: (message: string) => void } => {
+    const lines: string[] = []
+    return { lines, log: (message) => lines.push(message) }
+  }
+
+  it('is quiet and green before anything is published', () => {
+    const out = say()
+    expect(main([], world({}, {}), out.log)).toBe(0)
+    expect(out.lines.join('')).toContain('nothing to freeze')
+  })
+
+  it('names what it verified when everything holds', () => {
+    const out = say()
+    expect(main([], world(PUBLISHED, PUBLISHED), out.log)).toBe(0)
+    expect(out.lines.join('')).toContain('triage.v1')
+  })
+
+  it('fails on a violation', () => {
+    const out = say()
+    const deps = world(PUBLISHED, { ...PUBLISHED, 'prompts/rubric.md': 'x' })
+    expect(main([], deps, out.log)).toBe(1)
+    expect(out.lines.join('')).toContain('prompts/rubric.md')
+  })
+
+  it('takes the reference ref from the command line', () => {
+    const seen: string[] = []
+    const deps: FreezeDeps = {
+      showAtRef: (ref, path) => {
+        seen.push(ref)
+        return path === REF_SENTINEL ? 'sentinel' : null
+      },
+      readLocal: () => null,
+    }
+    main(['--ref=upstream/main'], deps, () => undefined)
+    expect(new Set(seen)).toEqual(new Set(['upstream/main']))
+  })
+
+  /**
+   * The failure this guard exists for: a shallow checkout that never fetched the
+   * reference makes every lookup return nothing, and without the probe the check
+   * reports "nothing to freeze" — green, and blind.
+   */
+  it('refuses to pass on a ref it cannot read', () => {
+    const blind: FreezeDeps = { showAtRef: () => null, readLocal: () => null }
+    expect(() => main([], blind, () => undefined)).toThrow(UnreadableRefError)
+  })
+})
+
+describe('reading git', () => {
+  it('returns null for a path no ref has, rather than throwing', () => {
+    expect(gitDeps.showAtRef('HEAD', 'prompts/no-such-file.md')).toBeNull()
+    expect(gitDeps.readLocal('prompts/no-such-file.md')).toBeNull()
+  })
+
+  it('reads a committed file back', () => {
+    expect(gitDeps.showAtRef('HEAD', 'package.json')).toContain('"name": "sentra"')
+    expect(gitDeps.readLocal('package.json')).toContain('"name": "sentra"')
+  })
+
+  /**
+   * The whole check is a comparison between these two readers. If one of them
+   * normalised line endings or stripped a trailing newline and the other did
+   * not, every file would look edited and the check would be switched off within
+   * a day.
+   */
+  it('reads a committed file identically from both sides', () => {
+    const changed = new Set(
+      execFileSync('git', ['diff', '--name-only', 'HEAD', '--', 'docs'], { encoding: 'utf8' })
+        .split('\n')
+        .filter(Boolean),
+    )
+    const tracked = execFileSync('git', ['ls-files', 'docs'], { encoding: 'utf8' })
+      .split('\n')
+      .filter((path) => path.endsWith('.md') && !changed.has(path))
+
+    // Chosen from the working tree rather than hard-coded, so the test does not
+    // start lying the day that one file is edited on a branch.
+    const [path] = tracked
+    expect(path).toBeDefined()
+    expect(gitDeps.showAtRef('HEAD', path ?? '')).toBe(gitDeps.readLocal(path ?? ''))
+  })
+})

--- a/prompts/freeze.ts
+++ b/prompts/freeze.ts
@@ -1,0 +1,200 @@
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { PROMPT_DIR, RUBRIC_FILE } from './registry.js'
+
+/**
+ * A published prompt version is immutable.
+ *
+ * `eval/report.md` says which prompt version produced which numbers. That is the
+ * whole mechanism by which a regression is attributable: two reports, two
+ * versions, and the diff between them explains the move. Editing a version in
+ * place keeps the record and destroys the link — the report still names
+ * `triage.v1`, and `triage.v1` is now different text. Nothing looks broken.
+ * Every past number silently becomes a claim about a prompt that no longer
+ * exists.
+ *
+ * The check compares the working tree against the reference ref for every
+ * version the committed metrics on that ref actually name. Nothing to maintain
+ * by hand, and it stays quiet until numbers exist to protect.
+ *
+ * The rubric is frozen alongside them, and that is the part worth stating: it is
+ * not a document *about* the prompt, it is a section *of* it, substituted in at
+ * load time. An edit there rewrites every published prompt at once while leaving
+ * every prompt file untouched — the exact shape of change this check exists to
+ * catch, and the one it would miss if the frozen set were the prompt files only.
+ */
+
+export const METRICS_FILES = [
+  'eval/metrics.json',
+  'eval/holdout-metrics.json',
+  'eval/metrics-all.json',
+] as const
+
+export interface FreezeDeps {
+  /** File contents at a git ref, or null when the ref does not have that path. */
+  showAtRef: (ref: string, path: string) => string | null
+  /** Working-tree contents, or null when the file is gone. */
+  readLocal: (path: string) => string | null
+  metricsFiles?: readonly string[]
+}
+
+/**
+ * A path every ref of this repository has.
+ *
+ * Without it the check fails open in the one environment it matters in. A
+ * shallow CI checkout that never fetched the reference makes every `git show`
+ * return nothing, `publishedVersions` comes back empty, and the check reports
+ * "nothing to freeze" — passing, green, and blind. Probing a path that must
+ * exist turns an unreadable ref into an error instead of an all-clear.
+ */
+export const REF_SENTINEL = 'package.json'
+
+export class UnreadableRefError extends Error {
+  constructor(readonly ref: string) {
+    super(
+      `cannot read ${ref} (${REF_SENTINEL} is not there). Fetch it first — ` +
+        'on a shallow checkout every lookup returns nothing and this check would pass without looking at anything.',
+    )
+    this.name = 'UnreadableRefError'
+  }
+}
+
+export interface Violation {
+  path: string
+  reason: 'edited' | 'deleted' | 'missing-at-ref'
+  promptVersion: string
+}
+
+/**
+ * Prompt versions named by the metrics committed on `ref`.
+ *
+ * A metrics file that does not parse is skipped rather than thrown on. This
+ * check protects published numbers; it is not the validator for the metrics
+ * format, and failing here on a malformed file would report the wrong problem
+ * loudly enough to hide the right one.
+ */
+export function publishedVersions(ref: string, deps: FreezeDeps): string[] {
+  if (deps.showAtRef(ref, REF_SENTINEL) === null) throw new UnreadableRefError(ref)
+
+  const versions = new Set<string>()
+
+  for (const path of deps.metricsFiles ?? METRICS_FILES) {
+    const raw = deps.showAtRef(ref, path)
+    if (raw === null) continue
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(raw)
+    } catch {
+      continue
+    }
+
+    const version = (parsed as { promptVersion?: unknown }).promptVersion
+    if (typeof version === 'string' && version !== '') versions.add(version)
+  }
+
+  return [...versions].sort()
+}
+
+export function frozenViolations(ref: string, deps: FreezeDeps): Violation[] {
+  const versions = publishedVersions(ref, deps)
+  if (versions.length === 0) return []
+
+  const files = [
+    ...versions.map((version) => [join(PROMPT_DIR, `${version}.md`), version] as const),
+    // Substituted into every prompt at load time, so an edit here changes all of
+    // them without touching one of their files.
+    [join(PROMPT_DIR, RUBRIC_FILE), versions.join(', ')] as const,
+  ]
+
+  const violations: Violation[] = []
+  for (const [path, promptVersion] of files) {
+    const published = deps.showAtRef(ref, path)
+    if (published === null) {
+      violations.push({ path, reason: 'missing-at-ref', promptVersion })
+      continue
+    }
+
+    const local = deps.readLocal(path)
+    if (local === null) {
+      violations.push({ path, reason: 'deleted', promptVersion })
+    } else if (local !== published) {
+      violations.push({ path, reason: 'edited', promptVersion })
+    }
+  }
+  return violations
+}
+
+const EXPLANATION: Record<Violation['reason'], string> = {
+  edited: 'was edited in place after its numbers were published',
+  deleted: 'was deleted after its numbers were published',
+  'missing-at-ref': 'is named by published metrics but does not exist at the reference ref',
+}
+
+export function renderViolations(ref: string, violations: readonly Violation[]): string {
+  return [
+    `${String(violations.length)} published prompt file(s) changed against ${ref}:`,
+    '',
+    ...violations.map(
+      ({ path, reason, promptVersion }) => `  ${path} ${EXPLANATION[reason]} (${promptVersion})`,
+    ),
+    '',
+    '  eval/report.md attributes its numbers to a prompt version. Changing that version in place',
+    '  leaves every published figure describing text that no longer exists, and nothing about the',
+    '  repository looks wrong afterwards.',
+    '',
+    '  Add the next version instead — copy the file to <agent>.v<n+1>.md, edit that, and point',
+    '  CURRENT_PROMPT at it. The old numbers keep meaning what they said.',
+  ].join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+export const gitDeps: FreezeDeps = {
+  showAtRef: (ref, path) => {
+    try {
+      return execFileSync('git', ['show', `${ref}:${path}`], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      })
+    } catch {
+      return null
+    }
+  },
+  readLocal: (path) => {
+    try {
+      return readFileSync(path, 'utf8')
+    } catch {
+      return null
+    }
+  },
+}
+
+export function main(
+  argv: readonly string[],
+  deps: FreezeDeps = gitDeps,
+  log: (message: string) => void = console.log,
+): number {
+  const ref = argv.find((arg) => arg.startsWith('--ref='))?.slice('--ref='.length) ?? 'origin/main'
+  const violations = frozenViolations(ref, deps)
+
+  if (violations.length === 0) {
+    const published = publishedVersions(ref, deps)
+    log(
+      published.length === 0
+        ? `No prompt version is referenced by metrics on ${ref} yet; nothing to freeze.`
+        : `Published prompt versions are unchanged against ${ref}: ${published.join(', ')}.`,
+    )
+    return 0
+  }
+
+  log(renderViolations(ref, violations))
+  return 1
+}
+
+if (process.argv[1]?.endsWith('freeze.ts') === true) {
+  process.exitCode = main(process.argv.slice(2))
+}

--- a/prompts/index.ts
+++ b/prompts/index.ts
@@ -1,0 +1,32 @@
+/**
+ * @sentra/prompts
+ *
+ * The versioned prompt files, the rubric they share with `docs/taxonomy.md`, and
+ * the two checks that keep both facts true: the doc copy is generated, and a
+ * version whose numbers are published cannot be edited in place.
+ */
+
+export * from './registry.js'
+
+// Both CLIs export `main`; naming them here keeps the package surface unambiguous.
+
+export {
+  BEGIN_MARKER,
+  END_MARKER,
+  SyncError,
+  TAXONOMY_DOC,
+  syncedDoc,
+  main as syncMain,
+  type SyncDeps,
+} from './sync.js'
+
+export {
+  METRICS_FILES,
+  frozenViolations,
+  gitDeps,
+  publishedVersions,
+  renderViolations,
+  main as freezeMain,
+  type FreezeDeps,
+  type Violation,
+} from './freeze.js'

--- a/prompts/package.json
+++ b/prompts/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@sentra/prompts",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Versioned prompt files and the rubric that the model and the human labeller share, with the loader that assembles them.",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./index.ts"
+    }
+  },
+  "dependencies": {
+    "zod": "*"
+  }
+}

--- a/prompts/registry.test.ts
+++ b/prompts/registry.test.ts
@@ -1,0 +1,138 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  CURRENT_PROMPT,
+  PROMPT_DIR,
+  PromptError,
+  RUBRIC_FILE,
+  RUBRIC_PLACEHOLDER,
+  listPromptVersions,
+  loadPrompt,
+  loadRubric,
+} from './registry.js'
+
+const scratch = (files: Record<string, string>): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'sentra-prompts-'))
+  for (const [name, contents] of Object.entries(files)) writeFileSync(join(dir, name), contents)
+  return dir
+}
+
+describe('loading', () => {
+  it('substitutes the rubric into the prompt', () => {
+    const dir = scratch({
+      'rubric.md': 'Rule 1. Rule 2.\n',
+      'triage.v1.md': `Before.\n\n${RUBRIC_PLACEHOLDER}\n\nAfter.\n`,
+    })
+    expect(loadPrompt('triage.v1', dir).system).toBe('Before.\n\nRule 1. Rule 2.\n\nAfter.')
+  })
+
+  it('reports the version it loaded, since that is what gets recorded', () => {
+    const dir = scratch({ 'rubric.md': 'r', 'triage.v3.md': RUBRIC_PLACEHOLDER })
+    expect(loadPrompt('triage.v3', dir).version).toBe('triage.v3')
+  })
+
+  /**
+   * Sending it would put `{{evidence}}` in front of the model as though it were
+   * an instruction, and the reply would look entirely ordinary.
+   */
+  it('refuses a template with a placeholder it cannot fill', () => {
+    const dir = scratch({
+      'rubric.md': 'r',
+      'triage.v1.md': `${RUBRIC_PLACEHOLDER}\n{{evidence}}`,
+    })
+    expect(() => loadPrompt('triage.v1', dir)).toThrow(/unresolved placeholder \{\{evidence\}\}/)
+  })
+
+  it.each([
+    ['no agent', '.v1'],
+    ['no version', 'triage'],
+    ['a zero version', 'triage.v0'],
+    ['a decimal version', 'triage.v1.2'],
+    ['a path traversal', '../../etc/passwd'],
+  ])('rejects %s as a version', (_case, version) => {
+    expect(() => loadPrompt(version, PROMPT_DIR)).toThrow(PromptError)
+  })
+
+  it('names what does exist when a version does not', () => {
+    const dir = scratch({ 'rubric.md': 'r', 'triage.v1.md': RUBRIC_PLACEHOLDER })
+    expect(() => loadPrompt('triage.v9', dir)).toThrow(/found triage\.v1/)
+  })
+
+  it('says so plainly when the directory has no prompts at all', () => {
+    const dir = scratch({ 'rubric.md': 'r' })
+    expect(() => loadPrompt('triage.v1', dir)).toThrow(/found none/)
+  })
+
+  it('says which file is missing when the rubric is gone', () => {
+    const dir = scratch({ 'triage.v1.md': RUBRIC_PLACEHOLDER })
+    expect(() => loadRubric(dir)).toThrow(/rubric is missing/)
+  })
+
+  it('lists versions from the directory rather than a list to maintain', () => {
+    const dir = scratch({
+      'rubric.md': 'r',
+      'triage.v2.md': 'x',
+      'triage.v1.md': 'x',
+      'README.md': 'x',
+      'notes.txt': 'x',
+    })
+    expect(listPromptVersions(dir)).toEqual(['triage.v1', 'triage.v2'])
+  })
+
+  it('treats a missing directory as no prompts rather than an error', () => {
+    expect(listPromptVersions(join(tmpdir(), 'sentra-does-not-exist'))).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The repository's own prompts
+// ---------------------------------------------------------------------------
+
+describe('the committed prompts', () => {
+  const versions = listPromptVersions()
+
+  it('has at least one', () => {
+    expect(versions.length).toBeGreaterThan(0)
+  })
+
+  it('points CURRENT_PROMPT at versions that exist', () => {
+    for (const version of Object.values(CURRENT_PROMPT)) {
+      expect(versions).toContain(version)
+    }
+  })
+
+  it.each(versions)('%s embeds the rubric by reference, exactly once', (version) => {
+    const template = readFileSync(join(PROMPT_DIR, `${version}.md`), 'utf8')
+    expect(template.split(RUBRIC_PLACEHOLDER)).toHaveLength(2)
+  })
+
+  /**
+   * The invariant the whole feature exists for, stated the only way that
+   * survives an edit: not "the copies match" — they would, on the day someone
+   * pastes one — but "there is no second copy to fall out of step".
+   *
+   * Derived from the rubric's own lines rather than a list of phrases, so it
+   * keeps working when the rubric is rewritten.
+   */
+  it.each(versions)('%s contains no pasted copy of the rubric', (version) => {
+    const template = readFileSync(join(PROMPT_DIR, `${version}.md`), 'utf8')
+    const substantial = loadRubric()
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 40)
+
+    expect(substantial.length).toBeGreaterThan(5)
+    expect(substantial.filter((line) => template.includes(line))).toEqual([])
+  })
+
+  it.each(versions)('%s resolves against the real rubric', (version) => {
+    const prompt = loadPrompt(version)
+    expect(prompt.system).toContain(loadRubric())
+  })
+
+  it('keeps the rubric where both readers look for it', () => {
+    expect(loadRubric()).toBe(readFileSync(join(PROMPT_DIR, RUBRIC_FILE), 'utf8').trimEnd())
+  })
+})

--- a/prompts/registry.ts
+++ b/prompts/registry.ts
@@ -1,0 +1,139 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Versioned prompts, and the one rubric the model and the labeller share.
+ *
+ * Two invariants live here, and both fail silently if they are left to
+ * discipline.
+ *
+ * **The rubric has one copy.** `docs/agent-design.md` requires the model and the
+ * human labeller to apply the same rules. If the prompt's definition of
+ * `intermittent` drifts from the one the dataset was labelled by, the evaluation
+ * measures agreement with a rubric nobody is applying — and it goes on producing
+ * a number that looks exactly like the one that meant something. So the rubric
+ * is a file, the prompt names it with a placeholder rather than quoting it, and
+ * `docs/taxonomy.md` carries a generated copy that a test regenerates and
+ * compares.
+ *
+ * **Published versions are immutable.** `eval/report.md` records which prompt
+ * version produced which numbers. Editing that version in place afterwards
+ * leaves the record intact and the link broken: the report still names
+ * `triage.v1`, and `triage.v1` is now a different prompt. `freeze.ts` makes that
+ * a build failure rather than a thing somebody notices six commits later.
+ */
+
+export const PROMPT_DIR = 'prompts'
+export const RUBRIC_FILE = 'rubric.md'
+
+/**
+ * The only substitution a prompt file may contain.
+ *
+ * One placeholder rather than a template language on purpose. Everything else a
+ * prompt needs is either fixed text — which belongs in the file, where it is
+ * reviewable — or untrusted evidence, which belongs in the user message behind
+ * the fences in `agents/sanitise.ts` and must never be interpolated into an
+ * instruction.
+ */
+export const RUBRIC_PLACEHOLDER = '{{rubric}}'
+
+/** `triage.v1` — the agent, then a major version. Minor edits do not exist: see freeze.ts. */
+const VERSION_PATTERN = /^[a-z][a-z-]*\.v[1-9]\d*$/
+
+export type Agent = 'triage' | 'root-cause' | 'fix-suggestion'
+
+/**
+ * Which version each agent uses today.
+ *
+ * A constant rather than "the highest version on disk". Resolving it
+ * automatically means adding a file changes what every future number is measured
+ * against, which is the sort of thing that should require a line in a diff.
+ */
+export const CURRENT_PROMPT: Partial<Record<Agent, string>> = {
+  triage: 'triage.v1',
+}
+
+export class PromptError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PromptError'
+  }
+}
+
+export interface Prompt {
+  version: string
+  /** The assembled system prompt. The user message carries the evidence, and only that. */
+  system: string
+}
+
+/** The rubric text, verbatim, with no trailing newline so it embeds cleanly. */
+export function loadRubric(dir: string = PROMPT_DIR): string {
+  return read(join(dir, RUBRIC_FILE), 'rubric').trimEnd()
+}
+
+/**
+ * Assemble a prompt by version.
+ *
+ * Deliberately re-reads from disk on every call. A cache would save two small
+ * file reads next to a model call that costs orders of magnitude more, and would
+ * buy a class of bug — an edited prompt still serving its old text — that is
+ * unusually hard to see, because everything downstream keeps working and only
+ * the numbers move.
+ */
+export function loadPrompt(version: string, dir: string = PROMPT_DIR): Prompt {
+  if (!VERSION_PATTERN.test(version)) {
+    throw new PromptError(
+      `"${version}" is not a prompt version. Expected <agent>.v<n>, as in triage.v1 — ` +
+        'the version is recorded in every cassette key and in eval/report.md, so it has to be parseable.',
+    )
+  }
+
+  const file = join(dir, `${version}.md`)
+  let template: string
+  try {
+    template = readFileSync(file, 'utf8')
+  } catch {
+    throw new PromptError(
+      `no prompt file for ${version}. Expected ${file}; found ${listPromptVersions(dir).join(', ') || 'none'}.`,
+    )
+  }
+
+  const system = template.replaceAll(RUBRIC_PLACEHOLDER, loadRubric(dir)).trimEnd()
+
+  // A leftover placeholder means the template asked for something the loader does
+  // not provide. Sending it would put `{{evidence}}` in front of the model as
+  // though it were an instruction, and the answer would look ordinary.
+  const leftover = /\{\{\s*[\w.-]+\s*\}\}/.exec(system)?.[0]
+  if (leftover !== undefined) {
+    throw new PromptError(
+      `${file} contains an unresolved placeholder ${leftover}. ` +
+        `The only substitution available is ${RUBRIC_PLACEHOLDER}.`,
+    )
+  }
+
+  return { version, system }
+}
+
+/** Every prompt file on disk, derived from the directory rather than a list to maintain. */
+export function listPromptVersions(dir: string = PROMPT_DIR): string[] {
+  let files: string[]
+  try {
+    files = readdirSync(dir)
+  } catch {
+    return []
+  }
+
+  return files
+    .filter((file) => file.endsWith('.md'))
+    .map((file) => file.slice(0, -'.md'.length))
+    .filter((version) => VERSION_PATTERN.test(version))
+    .sort()
+}
+
+function read(file: string, what: string): string {
+  try {
+    return readFileSync(file, 'utf8')
+  } catch {
+    throw new PromptError(`the ${what} is missing: expected ${file}`)
+  }
+}

--- a/prompts/rubric.md
+++ b/prompts/rubric.md
@@ -1,0 +1,45 @@
+Every failure gets exactly one value on each axis.
+
+### Axis 1 — `owner`: where the fix goes
+
+| Value         | Meaning                                                               | Typical evidence                                                                                                                           |
+| ------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `app_code`    | The product is wrong. The test correctly caught it.                   | Diff touches the implementation under test; assertion failure on a value, not a locator; error surfaces from application code in the stack |
+| `test_code`   | The product is fine. The test is wrong, stale, or badly synchronised. | Locator/timeout error; test asserts immediately after an async action; diff touches only the spec; shared fixture mutated across tests     |
+| `environment` | Neither. The run itself was broken.                                   | Port already in use; DNS/network error; missing binary; OOM; runner timeout with no assertion reached; browser launch failure              |
+
+### Axis 2 — `determinism`: how it behaves on rerun
+
+| Value           | Meaning                                     | Typical evidence                                                                                                                   |
+| --------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `deterministic` | Fails every time under the same conditions. | `statusHistory` shows an unbroken failure streak; failed on all retry attempts; flakiness score near 0 with current status failing |
+| `intermittent`  | Fails some of the time.                     | Alternating pass/fail history; passed on retry within the same run; high flakiness score                                           |
+
+### Labelling rules
+
+Applied in order; the first rule that fires decides.
+
+1. **The run never reached the assertion** (browser crash, port bind failure, install error,
+   OOM) → `environment`, regardless of anything else.
+2. **The test source encodes an unsafe assumption** (asserts without waiting for an async
+   effect, depends on another test's state, depends on list order that is not guaranteed) →
+   `test_code`, even if the product also has a race. Rationale: the test is not a valid
+   detector, so it cannot be evidence about the product.
+3. **The failure reproduces against an unchanged product** (same commit, isolated run) →
+   `test_code` if the test is at fault, `app_code` if the product is.
+4. **Otherwise** → `app_code`.
+
+For `determinism`: `deterministic` iff every attempt in the run failed **and** the recorded
+history shows no pass in the last 5 runs of the same test at the same commit range. Anything
+else is `intermittent`. Where history is absent (`isNew`), fall back to within-run retries only,
+and mark the fixture `lowConfidenceGroundTruth: true` so it can be excluded from headline
+metrics.
+
+### Deciding the axes independently
+
+The axes are orthogonal by construction, and treating them as one judgement is the most common
+way to get both wrong. Knowing a failure is intermittent says nothing about whether the product
+or the test is at fault: a product race and a missing `await` in the spec produce the same
+alternating history. Decide `owner` from what the evidence implicates, decide `determinism` from
+how the failure behaves across attempts and history, and do not let a conclusion on one axis
+argue for a conclusion on the other.

--- a/prompts/sync.test.ts
+++ b/prompts/sync.test.ts
@@ -1,0 +1,118 @@
+import { mkdtempSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { loadRubric } from './registry.js'
+import {
+  BEGIN_MARKER,
+  END_MARKER,
+  SyncError,
+  TAXONOMY_DOC,
+  fileDeps,
+  main,
+  syncedDoc,
+} from './sync.js'
+
+const doc = (middle: string): string =>
+  `# Taxonomy\n\n## The rubric\n\n${BEGIN_MARKER}\n${middle}\n${END_MARKER}\n\n## After\n`
+
+describe('generating the block', () => {
+  it('replaces whatever was between the markers', () => {
+    expect(syncedDoc(doc('stale text'), 'fresh')).toContain('fresh')
+    expect(syncedDoc(doc('stale text'), 'fresh')).not.toContain('stale text')
+  })
+
+  it('leaves the rest of the document alone', () => {
+    const result = syncedDoc(doc('old'), 'new')
+    expect(result.startsWith('# Taxonomy\n\n## The rubric\n\n')).toBe(true)
+    expect(result.endsWith('\n\n## After\n')).toBe(true)
+  })
+
+  /** `--check` compares by running the generator; a generator that drifts would never settle. */
+  it('is idempotent', () => {
+    const once = syncedDoc(doc('old'), 'new')
+    expect(syncedDoc(once, 'new')).toBe(once)
+  })
+
+  it('says where to edit, inside the block a reader is looking at', () => {
+    expect(syncedDoc(doc(''), 'new')).toContain('npm run prompts:sync')
+  })
+
+  it.each([
+    ['no markers at all', '# Taxonomy\n'],
+    ['only an opener', `# Taxonomy\n${BEGIN_MARKER}\n`],
+    ['only a closer', `# Taxonomy\n${END_MARKER}\n`],
+    ['markers in the wrong order', `${END_MARKER}\nrubric\n${BEGIN_MARKER}`],
+  ])('refuses a document with %s', (_case, contents) => {
+    expect(() => syncedDoc(contents, 'rubric')).toThrow(SyncError)
+  })
+})
+
+describe('the CLI', () => {
+  const fresh = syncedDoc(doc('old'), 'rubric text')
+
+  it('reports success and writes nothing when already in sync', () => {
+    const writes: string[] = []
+    const code = main([], {
+      readDoc: () => fresh,
+      writeDoc: (_path, text) => writes.push(text),
+      rubric: () => 'rubric text',
+      log: () => undefined,
+    })
+    expect(code).toBe(0)
+    expect(writes).toEqual([])
+  })
+
+  it('writes the block when it is stale', () => {
+    const writes: string[] = []
+    const code = main([], {
+      readDoc: () => doc('old'),
+      writeDoc: (_path, text) => writes.push(text),
+      rubric: () => 'rubric text',
+      log: () => undefined,
+    })
+    expect(code).toBe(0)
+    expect(writes[0]).toBe(fresh)
+  })
+
+  it('fails under --check instead of writing, and says what drift costs', () => {
+    const writes: string[] = []
+    const lines: string[] = []
+    const code = main(['--check'], {
+      readDoc: () => doc('old'),
+      writeDoc: (_path, text) => writes.push(text),
+      rubric: () => 'rubric text',
+      log: (message) => lines.push(message),
+    })
+    expect(code).toBe(1)
+    expect(writes).toEqual([])
+    expect(lines.join('\n')).toContain('agreement with a rule nobody applied')
+    expect(lines.join('\n')).toContain('npm run prompts:sync')
+  })
+})
+
+describe('the real filesystem', () => {
+  it('round-trips a document unchanged', () => {
+    const path = join(mkdtempSync(join(tmpdir(), 'sentra-sync-')), 'doc.md')
+    fileDeps.writeDoc(path, 'contents\n')
+    expect(fileDeps.readDoc(path)).toBe('contents\n')
+  })
+
+  it('reads the same rubric the loader does', () => {
+    expect(fileDeps.rubric()).toBe(loadRubric())
+  })
+})
+
+/**
+ * The invariant itself, asserted here rather than only in CI.
+ *
+ * A check that lives only in a workflow file holds until someone runs the tests
+ * locally, sees green, and pushes a rubric edit that CI then rejects — which is
+ * a slower and more confusing way to learn the same thing.
+ */
+describe('the committed documentation', () => {
+  it('carries the current rubric', () => {
+    const current = readFileSync(TAXONOMY_DOC, 'utf8')
+    expect(current).toBe(syncedDoc(current, loadRubric()))
+  })
+})

--- a/prompts/sync.ts
+++ b/prompts/sync.ts
@@ -1,0 +1,100 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { PROMPT_DIR, loadRubric } from './registry.js'
+
+/**
+ * Copying the rubric into the documentation, mechanically.
+ *
+ * Markdown has no include directive, so "one rubric, two readers" has to be
+ * either a generated block or a convention. A convention loses: the two copies
+ * agree on the day they are written and diverge on the first edit that only
+ * touches one of them, and nothing about the repository looks different
+ * afterwards. The evaluation keeps reporting agreement with a rubric the
+ * labeller is no longer applying.
+ *
+ * So `docs/taxonomy.md` carries a generated block, `npm run prompts:sync` writes
+ * it, `--check` fails when it is stale, and a unit test asserts the same thing so
+ * the invariant does not depend on the CI job being wired up.
+ *
+ * The generation direction is deliberate. The rubric file is the source because
+ * it is what the model is actually sent; the documentation is the copy, because
+ * a doc that disagrees with the prompt is a doc that is wrong.
+ */
+
+export const TAXONOMY_DOC = 'docs/taxonomy.md'
+
+export const BEGIN_MARKER = '<!-- rubric:begin -->'
+export const END_MARKER = '<!-- rubric:end -->'
+
+const NOTICE = `<!-- Generated from ${PROMPT_DIR}/rubric.md by \`npm run prompts:sync\`. Edit that file, not this block. -->`
+
+export class SyncError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SyncError'
+  }
+}
+
+/** The document with its rubric block replaced. Idempotent, so `--check` can compare. */
+export function syncedDoc(doc: string, rubric: string): string {
+  const start = doc.indexOf(BEGIN_MARKER)
+  const end = doc.indexOf(END_MARKER)
+
+  if (start === -1 || end === -1 || end < start) {
+    throw new SyncError(
+      `${TAXONOMY_DOC} has no rubric block. It must contain ${BEGIN_MARKER} followed by ${END_MARKER}; ` +
+        'without them there is nowhere to put the rubric and the two copies would drift apart unnoticed.',
+    )
+  }
+
+  const block = [BEGIN_MARKER, '', NOTICE, '', rubric, '', END_MARKER].join('\n')
+  return doc.slice(0, start) + block + doc.slice(end + END_MARKER.length)
+}
+
+export interface SyncDeps {
+  readDoc?: (path: string) => string
+  writeDoc?: (path: string, contents: string) => void
+  rubric?: () => string
+  log?: (message: string) => void
+}
+
+/** The real ones, named so a test can exercise them without going through `main`. */
+export const fileDeps = {
+  readDoc: (path: string): string => readFileSync(path, 'utf8'),
+  writeDoc: (path: string, contents: string): void => writeFileSync(path, contents),
+  rubric: (): string => loadRubric(),
+}
+
+/** Exit code, not `process.exit`, so a test can run the whole thing. */
+export function main(argv: readonly string[], deps: SyncDeps = {}): number {
+  const readDoc = deps.readDoc ?? fileDeps.readDoc
+  const writeDoc = deps.writeDoc ?? fileDeps.writeDoc
+  const rubric = deps.rubric ?? fileDeps.rubric
+  const log = deps.log ?? console.log
+
+  const check = argv.includes('--check')
+  const current = readDoc(TAXONOMY_DOC)
+  const next = syncedDoc(current, rubric())
+
+  if (current === next) {
+    log(`${TAXONOMY_DOC} is in sync with ${PROMPT_DIR}/rubric.md.`)
+    return 0
+  }
+
+  if (check) {
+    log(
+      `${TAXONOMY_DOC} does not match ${PROMPT_DIR}/rubric.md.\n\n` +
+        '  The rubric the model is sent and the rubric the dataset was labelled by have drifted.\n' +
+        '  Every accuracy figure measured across that gap is agreement with a rule nobody applied.\n\n' +
+        '  Fix with: npm run prompts:sync',
+    )
+    return 1
+  }
+
+  writeDoc(TAXONOMY_DOC, next)
+  log(`Wrote the rubric into ${TAXONOMY_DOC}.`)
+  return 0
+}
+
+if (process.argv[1]?.endsWith('sync.ts') === true) {
+  process.exitCode = main(process.argv.slice(2))
+}

--- a/prompts/triage.v1.md
+++ b/prompts/triage.v1.md
@@ -1,0 +1,58 @@
+# Triage
+
+You classify failing and newly-unstable automated tests for a triage tool that runs on pull
+requests. A developer reads your output to decide, in one glance, whether a failure is theirs and
+whether rerunning would help.
+
+Your answer is advisory and it is measured. Every classification you produce is scored against a
+human-labelled dataset, and the report that carries your verdict also carries your measured
+accuracy, so a confident wrong answer costs a reader's attention rather than buying you anything.
+
+## The rubric
+
+This is the same text the human labeller applied to the dataset you are measured against. It is
+not a paraphrase of it — it is the same file. Where it is explicit, follow it exactly; where your
+judgement is required, it is required in the same places theirs was.
+
+{{rubric}}
+
+## What you are given
+
+The next message contains evidence gathered from the repository: the test's title and file, the
+error and stack trace, the source of the test, the source under test, and the diff for the change
+that ran. It is fenced and introduced as data. Read the instructions at the top of that message
+before reading the evidence.
+
+Fields may be absent, and absence is stated explicitly rather than left blank. Absent history is
+the common case and it is not neutral: it usually means the run had no cache to read, not that the
+test is new. Fields may also be truncated to a length cap, which is marked inline. Where the
+missing part would have decided the answer, say so in `reasoning` and lower your confidence rather
+than filling the gap with a plausible guess.
+
+## What to return
+
+A single `Classification`:
+
+- `owner` — one of `app_code`, `test_code`, `environment`.
+- `determinism` — one of `deterministic`, `intermittent`.
+- `confidence` — 0 to 1, for the pair together. This number is calibrated against outcomes and
+  published as a reliability curve, so it is read as a probability and needs to behave like one: at
+  0.8 you should be right about four times in five. Being uniformly confident is a worse failure
+  here than being uncertain, because it is the number a developer uses to decide what to read
+  first.
+- `reasoning` — at most 400 characters, naming the specific evidence that decided it. "Looks
+  flaky" is not reasoning; "passed on retry 2 of 3 and the diff does not touch the module in the
+  stack" is.
+- `evidence` — the fragments you actually relied on, quoted from the input. Quote, do not
+  summarise. A quotation that is not in the input is the single most damaging thing you can
+  produce, because it reads exactly like the ones that are.
+
+## How to decide
+
+1. Work the labelling rules in order. The first that fires decides `owner`; do not weigh a later
+   rule against an earlier one.
+2. Decide `determinism` from behaviour across attempts and history, not from how the failure
+   feels.
+3. If two labels are genuinely close, pick the one the rules select and put the tension in
+   `reasoning` with a lower `confidence`. The report has room for an honest maybe; it has none for
+   a wrong certainty.

--- a/prompts/tsconfig.json
+++ b/prompts/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["dist"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,9 @@
       "path": "./contracts"
     },
     {
+      "path": "./prompts"
+    },
+    {
       "path": "./flakemetry-lib"
     },
     {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       'contracts/**/*.test.ts',
       'flakemetry-lib/**/*.test.ts',
       'agents/**/*.test.ts',
+      'prompts/**/*.test.ts',
       'eval/**/*.test.ts',
       'app/server/**/*.test.ts',
     ],


### PR DESCRIPTION
Closes #33.

Two invariants, and both of them fail *silently* when they are left to discipline. That is what makes them worth code rather than a convention.

## The rubric has one copy

`docs/agent-design.md` requires the model and the human labeller to apply the same rules. If the prompt's definition of `intermittent` drifts from the one the dataset was labelled by, the evaluation measures agreement with a rubric nobody is following — and it goes on producing a number that looks exactly like the one that meant something.

So `prompts/rubric.md` is the source. The prompt names it with a placeholder rather than quoting it, and `docs/taxonomy.md` carries a generated block that `npm run prompts:sync` writes and `--check` verifies.

The generation direction is deliberate: the rubric file is the source because it is what the model is actually sent, and the documentation is the copy, because a doc that disagrees with the prompt is a doc that is wrong.

The test that matters is not "the copies match" — they would, on the day someone pastes one. It is **"there is no second copy to fall out of step"**: for every prompt file on disk, no substantial line of the rubric appears in the template. Derived from the rubric's own lines, so it keeps working when the rubric is rewritten.

## Published versions are immutable

`eval/report.md` says which prompt version produced which numbers. That is the entire mechanism by which a regression is attributable. Editing a version in place keeps the record and destroys the link — the report still names `triage.v1`, and `triage.v1` is now different text. Nothing looks broken; every past number quietly becomes a claim about a prompt that no longer exists.

`prompts/freeze.ts` compares the working tree against `origin/main` for every version the *committed metrics on that ref actually name*. Nothing to maintain by hand, and it stays quiet until there are numbers to protect.

**The rubric is frozen alongside them**, and that is the part worth stating: it is not a document *about* the prompt, it is a section *of* it, substituted in at load time. An edit there rewrites every published prompt at once while leaving every prompt file byte-identical — the exact shape of change this check exists to catch, and the one it would miss if the frozen set were the prompt files only.

**It refuses to run on a ref it cannot read.** This is where the check would otherwise fail open, and only in the environment that matters: a shallow CI checkout that never fetched the reference makes every `git show` return nothing, the published set comes back empty, and the result is "nothing to freeze" — passing, green, and blind. Probing a path every ref must have turns that into an error.

## One substitution, and no other

`prompts/registry.ts` fills exactly one placeholder and throws on any other. That is not minimalism for its own sake: every instruction lives in the system message and every untrusted string lives in the user message behind the fences from #32, and a prompt file that could interpolate evidence would be a prompt file that can put attacker text inside an instruction. A leftover `{{evidence}}` reaching the model would read as an instruction and the reply would look entirely ordinary.

The loader re-reads from disk on every call rather than caching. Two small file reads next to a model call cost nothing, and the bug a cache buys — an edited prompt still serving its old text — is unusually hard to see, because everything downstream keeps working and only the numbers move.

## Also in here

- `promptVersion` on the metrics snapshot, **additive and defaulted** rather than required: `readReferenceSnapshot` throws on a file it cannot read, which is right for corruption and wrong for "older than the field", so a required key would have taken the gate down on the commit that introduced it. It is null for the baseline, which has no prompt — writing a placeholder there would put a version into `eval/metrics.json` that the freeze check then protects on behalf of numbers no prompt produced.
- `docs/taxonomy.md` restructured so the normative text is one contiguous generated block; the matrix and the commentary stay outside it, because they are reading aids rather than rules.
- CI: the sync check in the hygiene job, the freeze check in the evaluation gate — which already fetches the full history the comparison needs.

## Testing

937 tests pass. `prompts/` is at 98.3% statements, 100% functions. The freeze suite drives the whole thing through injected repository states, so every branch — edited, deleted, named-but-missing, unparseable metrics, unreadable ref — is reachable without a fixture repository.

Also verified that `git show` and `readFileSync` return byte-identical content for a committed file, chosen from `git ls-files` at run time rather than hard-coded. The entire check is a comparison between those two readers; if one normalised line endings and the other did not, every file would look edited and the check would be switched off within a day.