### PR TITLE
feat(eval): ask whether the confidence number is worth anything

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,8 +29,13 @@ SENTRA_TOKEN_BUDGET=200000
 # Concurrent agent calls.
 SENTRA_CONCURRENCY=4
 
-# Confidence above which the root-cause agent runs. Derived from the calibration
-# curve in eval/report.md, not chosen by hand.
+# Confidence above which the root-cause agent runs.
+#
+# Read off the calibration section of eval/report.md, not chosen by hand: it is
+# the lowest confidence whose predictions are actually right often enough to be
+# worth elaborating on. That section also says when no threshold could be derived
+# — and when it says confidence carries no information, the answer is to stop
+# gating on it rather than to pick a number that looks reasonable.
 SENTRA_ROOT_CAUSE_THRESHOLD=0.7
 
 # Local dev server ports for TaskFlow.

--- a/docs/eval-methodology.md
+++ b/docs/eval-methodology.md
@@ -197,12 +197,42 @@ A model asked for a confidence number will return 0.85 for nearly everything. If
 whether the root-cause agent runs, the gate is decorative.
 
 The harness therefore bins predictions by stated confidence and measures observed accuracy per
-bin, producing a reliability curve and an **Expected Calibration Error**. Two consequences:
+bin, producing a reliability curve and an **Expected Calibration Error**.
 
-1. The root-cause confidence threshold is read off the calibration curve — the point where
-   observed accuracy actually crosses the target — rather than being guessed.
-2. If ECE is bad enough that confidence carries no information, the honest move is to drop the
-   field and gate on something else. That result would be published, not hidden.
+**ECE alone does not answer the question, and treating it as though it does is the usual mistake.**
+Two properties are being asked about and they are independent:
+
+- **Calibration** — when it says 0.8, is it right about 80% of the time? That is ECE, with the
+  worst single bin reported beside it, because an average hides the case that matters: a classifier
+  can post a respectable ECE while being wrong by 40 points in the one bin the threshold sits in.
+- **Discrimination** — does a higher number mean a better prediction _at all_? Measured as AUROC
+  over (confidence, correct), where 0.50 is a coin toss. A classifier that says 0.7 for every
+  prediction and is right 70% of the time has a **perfect ECE and is useless**, because ranking is
+  the only thing the threshold uses the number for.
+
+So the verdict leads with discrimination, and a good ECE cannot rescue an AUROC of 0.5. The report
+states the conclusion in words — usable, weakly informative, or not usable — before the tables, so
+a reader does not have to decide what the numbers mean before knowing whether the column they are
+built on carries information at all.
+
+Points are one per **prediction**, not per fixture: with sampling every sample is a classification
+the pipeline could have emitted, and each carries its own stated confidence. They are correlated,
+which is why no confidence interval is attached to ECE and why the report calls the result a
+direction rather than a measurement at this dataset size.
+
+**The threshold is read off the data.** The sweep runs over the confidence values the classifier
+actually produced — a threshold between two values it never emits behaves identically to one of
+them and looks more considered than it is — and takes the **lowest** value clearing the target
+accuracy over at least five predictions. Lower is better: the point is to run the root-cause agent
+on everything it can be right about, and a higher bar buys accuracy by answering less often.
+
+When no threshold qualifies, the report says which of the two problems it hit. "No threshold
+reaches 70%" printed next to a row showing 100% is a message a reader stops trusting; short support
+and low accuracy are different problems with different fixes — more fixtures, or a better
+classifier.
+
+If confidence carries no information, the honest move is to drop the field and gate on something
+else. That result gets published, not worked around.
 
 ## Metrics reported
 

--- a/eval/calibration.test.ts
+++ b/eval/calibration.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from 'vitest'
+import {
+  auroc,
+  binOf,
+  BIN_COUNT,
+  calibrate,
+  deriveThreshold,
+  judge,
+  MIN_SUPPORT,
+  TARGET_ACCURACY,
+  type Point,
+} from './calibration.js'
+
+const points = (...pairs: [confidence: number, correct: boolean][]): Point[] =>
+  pairs.map(([confidence, correct]) => ({ confidence, correct }))
+
+/** `n` predictions at `confidence`, of which `right` were correct. */
+const group = (confidence: number, n: number, right: number): Point[] =>
+  Array.from({ length: n }, (_, index) => ({ confidence, correct: index < right }))
+
+describe('binning', () => {
+  it.each([
+    [0, 0],
+    [0.05, 0],
+    [0.1, 1],
+    [0.55, 5],
+    [0.99, 9],
+  ])('puts %s in bin %s', (confidence, bin) => {
+    expect(binOf(confidence)).toBe(bin)
+  })
+
+  /**
+   * A lone eleventh bin holding every perfectly-confident prediction would be
+   * the most interesting bin on the page, and it would not be on the page.
+   */
+  it('puts 1.0 in the top bin rather than an eleventh', () => {
+    expect(binOf(1)).toBe(BIN_COUNT - 1)
+  })
+
+  it('keeps every bin, so an empty one is visible as empty', () => {
+    const calibration = calibrate(points([0.85, true]))
+    expect(calibration.bins).toHaveLength(BIN_COUNT)
+    expect(calibration.bins.filter((bin) => bin.count > 0)).toHaveLength(1)
+  })
+})
+
+describe('expected calibration error', () => {
+  it('is zero for a perfectly calibrated classifier', () => {
+    // Says 0.8 and is right 8 times in 10; says 0.4 and is right 4 in 10.
+    const calibration = calibrate([...group(0.8, 10, 8), ...group(0.4, 10, 4)])
+    expect(calibration.ece).toBeCloseTo(0, 10)
+  })
+
+  it('measures the gap where there is one', () => {
+    // Says 0.9 across the board and is right half the time.
+    expect(calibrate(group(0.9, 10, 5)).ece).toBeCloseTo(0.4)
+  })
+
+  it('weights bins by how many predictions are in them', () => {
+    // 90 predictions perfectly calibrated, 10 wrong by 0.5 → 0.05.
+    const calibration = calibrate([...group(0.5, 90, 45), ...group(0.9, 10, 4)])
+    expect(calibration.ece).toBeCloseTo(0.05, 3)
+  })
+
+  /**
+   * ECE is an average, and averages hide the case that matters: a classifier can
+   * post a respectable ECE while being wrong by 40 points in the one bin the
+   * threshold sits in.
+   */
+  it('reports the worst single bin beside the average', () => {
+    const calibration = calibrate([...group(0.5, 90, 45), ...group(0.9, 10, 4)])
+    expect(calibration.mce).toBeCloseTo(0.5)
+    expect(calibration.mce).toBeGreaterThan(calibration.ece)
+  })
+
+  it('is zero when there is nothing to score', () => {
+    expect(calibrate([])).toMatchObject({ n: 0, ece: 0, mce: 0, discrimination: null })
+  })
+})
+
+describe('discrimination', () => {
+  it('is 1 when confidence orders predictions perfectly', () => {
+    expect(auroc(points([0.9, true], [0.8, true], [0.3, false], [0.2, false]))).toBe(1)
+  })
+
+  it('is 0 when it orders them exactly backwards', () => {
+    expect(auroc(points([0.9, false], [0.2, true]))).toBe(0)
+  })
+
+  /**
+   * The failure this whole module exists for. A classifier that says 0.85 for
+   * everything and is right most of the time can post a fine ECE; without the
+   * tie correction it would also post an AUROC of 1.0 — a perfect ranking read
+   * off a list with no order in it.
+   */
+  it('is 0.5 when every prediction states the same confidence', () => {
+    expect(auroc(group(0.85, 10, 7))).toBe(0.5)
+  })
+
+  it('is undefined when everything was right, or everything wrong', () => {
+    expect(auroc(group(0.8, 5, 5))).toBeNull()
+    expect(auroc(group(0.8, 5, 0))).toBeNull()
+  })
+
+  it('counts the distinct values, which is the direct test of a constant', () => {
+    expect(calibrate(group(0.85, 10, 7)).distinctValues).toBe(1)
+    expect(calibrate([...group(0.85, 5, 3), ...group(0.6, 5, 2)]).distinctValues).toBe(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+
+describe('deriving the threshold', () => {
+  it('picks the lowest value that clears the target with support behind it', () => {
+    const derived = deriveThreshold([
+      ...group(0.9, 6, 6), // 100% here
+      ...group(0.7, 6, 4), // 83% at or above 0.7
+      ...group(0.4, 6, 0), // 56% at or above 0.4
+    ])
+    expect(derived.value).toBe(0.7)
+    expect(derived.countAbove).toBe(12)
+  })
+
+  /**
+   * A higher threshold clears the target too and passes fewer failures to the
+   * root-cause agent, which is a worse trade — the point is to run it on
+   * everything it can be right about.
+   */
+  it('prefers the lower of two qualifying values', () => {
+    const derived = deriveThreshold([...group(0.9, 6, 6), ...group(0.8, 6, 6)])
+    expect(derived.value).toBe(0.8)
+  })
+
+  it('sweeps only the values the classifier produced', () => {
+    const derived = deriveThreshold([...group(0.9, 3, 3), ...group(0.5, 3, 1)])
+    expect(derived.sweep.map((row) => row.threshold)).toEqual([0.5, 0.9])
+  })
+
+  it('refuses a threshold read off too few predictions', () => {
+    const derived = deriveThreshold([...group(0.9, 2, 2), ...group(0.3, 20, 0)])
+    expect(derived.value).toBeNull()
+    expect(derived.countAbove).toBe(2)
+  })
+
+  /**
+   * "No threshold reaches 70%" printed next to a row showing 100% is a message a
+   * reader stops trusting. Short support and low accuracy are different problems
+   * with different fixes — more fixtures, or a better classifier.
+   */
+  it('says which of the two problems it hit', () => {
+    const starved = deriveThreshold([...group(0.9, 2, 2), ...group(0.3, 20, 0)])
+    expect(starved.reason).toContain('fewer than 5 predictions')
+
+    const inaccurate = deriveThreshold(group(0.9, 20, 4))
+    expect(inaccurate.reason).toContain('no confidence value reaches')
+  })
+
+  it('says so plainly when there is nothing to derive from', () => {
+    const derived = deriveThreshold([])
+    expect(derived.value).toBeNull()
+    expect(derived.reason).toContain('no predictions')
+    expect(derived.sweep).toEqual([])
+  })
+
+  it('takes the target and the support floor from the caller', () => {
+    const points = [...group(0.9, 2, 2), ...group(0.3, 20, 0)]
+    expect(deriveThreshold(points, TARGET_ACCURACY, 2).value).toBe(0.9)
+    expect(deriveThreshold(points, 1.01, 1).value).toBeNull()
+  })
+
+  it('has a support floor above one, or the top value always wins', () => {
+    expect(MIN_SUPPORT).toBeGreaterThan(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+
+describe('the verdict', () => {
+  const verdict = (data: Point[]): ReturnType<typeof judge> =>
+    judge(calibrate(data), deriveThreshold(data))
+
+  /**
+   * The claim the module is built to defend: a perfect ECE cannot rescue a
+   * confidence that does not vary, because ranking is the only thing the
+   * threshold uses it for.
+   */
+  it('calls a constant confidence unusable however well calibrated it is', () => {
+    const constant = group(0.7, 20, 14)
+    expect(calibrate(constant).ece).toBeCloseTo(0, 10)
+    expect(verdict(constant).usability).toBe('unusable')
+    expect(verdict(constant).summary).toContain('cannot rank anything')
+  })
+
+  /**
+   * Two levels partition the predictions, which is real ranking information
+   * however coarse. Rejecting it out of hand would be the same unearned
+   * certainty in the other direction.
+   */
+  it('lets a two-level confidence be judged on its ranking rather than dismissed', () => {
+    const binary = [...group(0.9, 10, 9), ...group(0.4, 10, 4)]
+    expect(calibrate(binary).distinctValues).toBe(2)
+    expect(verdict(binary).usability).not.toBe('unusable')
+  })
+
+  it('calls a coin toss unusable and says to gate on something else', () => {
+    // Alternating right and wrong across a spread of confidences.
+    const noise = Array.from({ length: 20 }, (_, index) => ({
+      confidence: 0.3 + (index % 10) / 20,
+      correct: index % 2 === 0,
+    }))
+    expect(verdict(noise).usability).toBe('unusable')
+    expect(verdict(noise).summary).toContain('gate on something else')
+  })
+
+  it('calls a well-ordered, well-calibrated confidence usable', () => {
+    const good = [...group(0.9, 10, 9), ...group(0.6, 10, 6), ...group(0.3, 10, 3)]
+    const judged = verdict(good)
+    expect(judged.usability).toBe('usable')
+    expect(judged.summary).toContain('read as a probability')
+  })
+
+  it('calls a well-ordered but badly-scaled confidence weak, not usable', () => {
+    // Ranks correctly, states numbers far from the observed rate.
+    const skewed = [...group(0.95, 10, 6), ...group(0.9, 10, 3), ...group(0.85, 10, 1)]
+    const judged = verdict(skewed)
+    expect(judged.usability).toBe('weak')
+    expect(judged.summary).toContain('sortable hint')
+  })
+
+  it('reports the derived threshold in the sentence, or why there is none', () => {
+    const good = [...group(0.9, 10, 9), ...group(0.6, 10, 6), ...group(0.3, 10, 3)]
+    expect(verdict(good).summary).toMatch(/threshold derives to 0\.\d\d/)
+
+    const starved = [...group(0.9, 2, 2), ...group(0.5, 10, 3), ...group(0.3, 10, 0)]
+    expect(verdict(starved).summary).toContain('could be derived')
+  })
+
+  it('says nothing was measured when nothing was', () => {
+    expect(verdict([]).usability).toBe('unusable')
+    expect(verdict([]).summary).toContain('No predictions were scored')
+  })
+
+  it('says the dataset is too small to call it a measurement', () => {
+    const good = [...group(0.9, 10, 9), ...group(0.6, 10, 6), ...group(0.3, 10, 3)]
+    expect(verdict(good).summary).toContain('a direction, not a measurement')
+  })
+
+  it('handles a run where every prediction was right', () => {
+    const flawless = [...group(0.9, 10, 10), ...group(0.6, 10, 10), ...group(0.3, 10, 10)]
+    expect(verdict(flawless).usability).toBe('unusable')
+    expect(verdict(flawless).summary).toContain('discrimination is undefined')
+  })
+})

--- a/eval/calibration.ts
+++ b/eval/calibration.ts
@@ -1,0 +1,353 @@
+/**
+ * Is the confidence number worth anything?
+ *
+ * A model asked for a confidence returns 0.85 for nearly everything. That number
+ * decides whether the root-cause agent runs, so if it carries no information the
+ * gate is decorative and the budget is being spent arbitrarily. This module
+ * exists to answer the question rather than assume it, and to publish the answer
+ * either way.
+ *
+ * Two different questions, and conflating them is the usual mistake:
+ *
+ * **Calibration** — when it says 0.8, is it right about 80% of the time?
+ * Measured by binning predictions and comparing stated confidence to observed
+ * accuracy: the reliability curve, summarised as Expected Calibration Error.
+ *
+ * **Discrimination** — does a higher number mean a better prediction *at all*?
+ * A classifier that says 0.7 for every prediction and is right 70% of the time
+ * has a perfect ECE and is useless for ranking, which is the only thing the
+ * threshold uses it for. Measured by AUROC, where 0.5 is a coin toss.
+ *
+ * A confidence can be well calibrated and useless. It cannot be useful and
+ * undiscriminating. So the verdict this module produces leads with
+ * discrimination, and the report states it in words as well as numbers.
+ */
+
+export interface Point {
+  confidence: number
+  correct: boolean
+}
+
+/** Ten equal-width bins, the convention, so the number is comparable to published ones. */
+export const BIN_COUNT = 10
+
+export interface Bin {
+  lower: number
+  upper: number
+  count: number
+  /** Mean stated confidence of the predictions that landed here. */
+  meanConfidence: number
+  /** Share of them that were right. */
+  accuracy: number
+}
+
+export interface Calibration {
+  /** Every prediction, not every fixture — see `calibrate`. */
+  n: number
+  bins: Bin[]
+  /** Weighted mean gap between stated confidence and observed accuracy. */
+  ece: number
+  /**
+   * The worst single bin.
+   *
+   * Reported beside ECE because ECE is an average and averages hide the case
+   * that matters: a classifier can post a respectable ECE while being wrong by
+   * 40 points in the one bin the threshold sits in.
+   */
+  mce: number
+  /**
+   * AUROC over (confidence, correct). 0.5 is no information at all.
+   *
+   * Null when every prediction was right or every one wrong — the measure is
+   * undefined there, and reporting 0.5 would say "no information" about a run
+   * that simply had nothing to discriminate between.
+   */
+  discrimination: number | null
+  /**
+   * How many distinct confidence values the classifier used.
+   *
+   * The direct test of "returns 0.85 for everything". A classifier with one
+   * value cannot rank anything, whatever its ECE says.
+   */
+  distinctValues: number
+}
+
+/**
+ * Bin predictions and measure the gap.
+ *
+ * One point per **prediction**, not per fixture: with sampling, every sample is
+ * a classification the pipeline could have emitted, and each carries its own
+ * confidence. They are correlated — five samples of one fixture are not five
+ * independent observations — which is why nothing here reports a confidence
+ * interval, and why the report says the number is a direction rather than a
+ * measurement at this dataset size.
+ */
+export function calibrate(points: readonly Point[]): Calibration {
+  const bins = Array.from({ length: BIN_COUNT }, (_, index) => {
+    const lower = index / BIN_COUNT
+    const upper = (index + 1) / BIN_COUNT
+    const inBin = points.filter((point) => binOf(point.confidence) === index)
+
+    return {
+      lower,
+      upper,
+      count: inBin.length,
+      meanConfidence: average(inBin.map((point) => point.confidence)),
+      accuracy: average(inBin.map((point) => (point.correct ? 1 : 0))),
+    }
+  })
+
+  const populated = bins.filter((bin) => bin.count > 0)
+  const gaps = populated.map((bin) => Math.abs(bin.accuracy - bin.meanConfidence))
+
+  return {
+    n: points.length,
+    bins,
+    ece: populated.reduce(
+      (sum, bin, index) => sum + (bin.count / points.length) * (gaps[index] ?? 0),
+      0,
+    ),
+    mce: gaps.length === 0 ? 0 : Math.max(...gaps),
+    discrimination: auroc(points),
+    distinctValues: new Set(points.map((point) => point.confidence)).size,
+  }
+}
+
+/**
+ * Which bin a confidence lands in.
+ *
+ * 1.0 goes in the top bin rather than an eleventh. The bins are half-open on the
+ * right except the last, which is the only reading under which they partition
+ * [0, 1] — and a lone eleventh bin holding every perfectly-confident prediction
+ * would be the most interesting bin on the page, silently.
+ */
+export const binOf = (confidence: number): number =>
+  Math.min(BIN_COUNT - 1, Math.floor(confidence * BIN_COUNT))
+
+const average = (values: readonly number[]): number =>
+  values.length === 0 ? 0 : values.reduce((sum, value) => sum + value, 0) / values.length
+
+/**
+ * Area under the ROC curve, by the Mann–Whitney identity.
+ *
+ * Ties share an average rank, which matters more here than usual: a classifier
+ * that returns one value for everything is *entirely* ties, and without the
+ * correction it would score 1.0 — a perfect ranking read off a list that has no
+ * order in it.
+ */
+export function auroc(points: readonly Point[]): number | null {
+  const right = points.filter((point) => point.correct).length
+  const wrong = points.length - right
+  if (right === 0 || wrong === 0) return null
+
+  const ranked = [...points].sort((a, b) => a.confidence - b.confidence)
+  const ranks = new Array<number>(ranked.length)
+
+  for (let i = 0; i < ranked.length;) {
+    let j = i
+    while (j + 1 < ranked.length && ranked[j + 1]?.confidence === ranked[i]?.confidence) j++
+    const shared = (i + j) / 2 + 1
+    for (let k = i; k <= j; k++) ranks[k] = shared
+    i = j + 1
+  }
+
+  const rankSum = ranked.reduce(
+    (sum, point, index) => (point.correct ? sum + (ranks[index] ?? 0) : sum),
+    0,
+  )
+  return (rankSum - (right * (right + 1)) / 2) / (right * wrong)
+}
+
+// ---------------------------------------------------------------------------
+// Deriving the threshold
+// ---------------------------------------------------------------------------
+
+/**
+ * Accuracy the root-cause agent's input has to clear.
+ *
+ * The agent spends tokens elaborating on a triage verdict. Below this, most of
+ * what it elaborates on is wrong, and a confident wrong hypothesis is worse than
+ * none — it redirects attention.
+ */
+export const TARGET_ACCURACY = 0.7
+
+/**
+ * Fewest predictions a threshold may be read off.
+ *
+ * Without it the sweep picks the highest confidence value in the dataset, where
+ * two correct predictions out of two look like 100% accuracy, and the derived
+ * threshold is noise with a decimal point.
+ */
+export const MIN_SUPPORT = 5
+
+export interface SweepRow {
+  threshold: number
+  count: number
+  accuracy: number
+  /** Whether this row could be chosen: over target and over the support floor. */
+  eligible: boolean
+}
+
+export interface Threshold {
+  /** Null when no threshold reaches the target with enough support behind it. */
+  value: number | null
+  accuracyAbove: number
+  countAbove: number
+  sweep: SweepRow[]
+  reason: string
+}
+
+/**
+ * Read the threshold off the data rather than guessing it.
+ *
+ * The sweep is over the confidence values the classifier actually produced, not
+ * a grid: a threshold between two values it never emits is a threshold that
+ * behaves identically to one of them and looks more considered than it is.
+ *
+ * The **lowest** qualifying value wins. A higher one would clear the target too
+ * and pass fewer failures to the root-cause agent, which is a worse trade — the
+ * point is to run on everything it can be right about.
+ */
+export function deriveThreshold(
+  points: readonly Point[],
+  target: number = TARGET_ACCURACY,
+  minSupport: number = MIN_SUPPORT,
+): Threshold {
+  const candidates = [...new Set(points.map((point) => point.confidence))].sort((a, b) => a - b)
+
+  const sweep = candidates.map((threshold): SweepRow => {
+    const above = points.filter((point) => point.confidence >= threshold)
+    const accuracy = average(above.map((point) => (point.correct ? 1 : 0)))
+    return {
+      threshold,
+      count: above.length,
+      accuracy,
+      eligible: accuracy >= target && above.length >= minSupport,
+    }
+  })
+
+  const chosen = sweep.find((row) => row.eligible)
+  if (chosen === undefined) {
+    const best = sweep.reduce<SweepRow | null>(
+      (a, b) => (a === null || b.accuracy > a.accuracy ? b : a),
+      null,
+    )
+
+    // Two different failures, and saying the wrong one is worse than saying
+    // nothing: "no threshold reaches 70%" printed next to a row showing 100% is
+    // a message a reader stops trusting. Short support and low accuracy are
+    // separate problems with separate fixes — more fixtures, or a better
+    // classifier.
+    const starved = sweep.filter((row) => row.accuracy >= target && row.count < minSupport)
+    const reason =
+      points.length === 0
+        ? 'there were no predictions to derive one from'
+        : starved.length > 0
+          ? `the only thresholds reaching ${pct(target)} do so over fewer than ${String(minSupport)} predictions ` +
+            `(best: ${pct(starved[0]?.accuracy ?? 0)} over ${String(starved[0]?.count ?? 0)}), which is noise with a decimal point`
+          : `no confidence value reaches ${pct(target)} accuracy at all; the best any threshold managed was ${pct(best?.accuracy ?? 0)}`
+
+    return {
+      value: null,
+      accuracyAbove: best?.accuracy ?? 0,
+      countAbove: best?.count ?? 0,
+      sweep,
+      reason,
+    }
+  }
+
+  return {
+    value: chosen.threshold,
+    accuracyAbove: chosen.accuracy,
+    countAbove: chosen.count,
+    sweep,
+    reason:
+      `predictions at or above ${chosen.threshold.toFixed(2)} are right ${pct(chosen.accuracy)} of the time ` +
+      `over ${String(chosen.count)} predictions, the lowest value that clears ${pct(target)}`,
+  }
+}
+
+const pct = (value: number): string => `${(value * 100).toFixed(1)}%`
+
+// ---------------------------------------------------------------------------
+// The verdict, in words
+// ---------------------------------------------------------------------------
+
+export type Usability = 'unusable' | 'weak' | 'usable'
+
+export interface Verdict {
+  usability: Usability
+  /** A sentence a reader can act on without reading the table above it. */
+  summary: string
+}
+
+/**
+ * Discrimination decides, then calibration.
+ *
+ * A confidence can be well calibrated and useless — one value for everything,
+ * right at exactly that rate — and the threshold uses it only for ranking. So a
+ * good ECE cannot rescue an AUROC of 0.5, and this function refuses to let it.
+ *
+ * The bands are deliberately coarse. At this dataset size an AUROC of 0.63
+ * against one of 0.67 is not a distinction anyone should act on, and printing
+ * three of them would invite exactly that.
+ */
+export function judge(calibration: Calibration, threshold: Threshold): Verdict {
+  const { discrimination, ece, distinctValues, n } = calibration
+
+  if (n === 0) {
+    return {
+      usability: 'unusable',
+      summary: 'No predictions were scored, so nothing was measured.',
+    }
+  }
+
+  // One value, not two. Two levels partition the predictions, which is real
+  // ranking information however coarse, and AUROC below judges how good it is.
+  // Rejecting two here would call a usable binary signal unusable, which is the
+  // same kind of unearned certainty this module exists to avoid.
+  if (distinctValues <= 1) {
+    return {
+      usability: 'unusable',
+      summary:
+        `The classifier stated one confidence value across all ${String(n)} predictions. ` +
+        'A number that does not vary cannot rank anything, whatever its calibration error. ' +
+        'Gate the root-cause agent on something else.',
+    }
+  }
+
+  if (discrimination === null) {
+    return {
+      usability: 'unusable',
+      summary:
+        'Every prediction was right, or every one wrong, so discrimination is undefined. ' +
+        'Nothing here says whether confidence carries information.',
+    }
+  }
+
+  if (discrimination < 0.6) {
+    return {
+      usability: 'unusable',
+      summary:
+        `Confidence ranks predictions at AUROC ${discrimination.toFixed(2)}, near the 0.50 of a coin toss. ` +
+        'It carries no usable signal about whether a classification is right, so gating on it would ' +
+        'spend the root-cause budget arbitrarily. The honest move is to gate on something else.',
+    }
+  }
+
+  const band = discrimination >= 0.7 && ece <= 0.15 ? 'usable' : 'weak'
+  return {
+    usability: band,
+    summary:
+      `Confidence ranks predictions at AUROC ${discrimination.toFixed(2)} with an expected calibration error of ${ece.toFixed(3)}. ` +
+      (band === 'usable'
+        ? `The stated number is close enough to the observed rate to read as a probability. ${describe(threshold)}`
+        : `It orders predictions better than chance but the stated number is not the observed rate — treat it as a sortable hint, not a probability. ${describe(threshold)}`) +
+      ` At ${String(n)} predictions from a stratified dataset this is a direction, not a measurement.`,
+  }
+}
+
+const describe = (threshold: Threshold): string =>
+  threshold.value === null
+    ? `No root-cause threshold could be derived: ${threshold.reason}.`
+    : `The root-cause threshold derives to ${threshold.value.toFixed(2)}.`

--- a/eval/report.md
+++ b/eval/report.md
@@ -47,6 +47,46 @@ Scored once per fixture (`--n=1`), so there is no spread to report.
 
 The baseline is a pure function: repeating it produces identical runs, and a self-consistency of 1 would say nothing about anything.
 
+## Calibration
+
+**Confidence is weakly informative.** Confidence ranks predictions at AUROC 0.70 with an expected calibration error of 0.216. It orders predictions better than chance but the stated number is not the observed rate — treat it as a sortable hint, not a probability. No root-cause threshold could be derived: the only thresholds reaching 70.0% do so over fewer than 5 predictions (best: 100.0% over 1), which is noise with a decimal point. At 22 predictions from a stratified dataset this is a direction, not a measurement.
+
+|                              |                                                                                                                                                 |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| predictions scored           | 22                                                                                                                                              |
+| distinct confidence values   | 4                                                                                                                                               |
+| discrimination (AUROC)       | 0.696 — 0.50 is a coin toss                                                                                                                     |
+| expected calibration error   | 0.216                                                                                                                                           |
+| worst single bin             | 0.350                                                                                                                                           |
+| derived root-cause threshold | not derived — the only thresholds reaching 70.0% do so over fewer than 5 predictions (best: 100.0% over 1), which is noise with a decimal point |
+
+### Reliability curve
+
+Stated confidence against observed accuracy. A perfectly calibrated classifier has the
+two columns equal in every row. Empty bins are omitted; where the classifier never says
+0.3, there is nothing to be right or wrong about.
+
+| confidence | predictions | stated | observed |    gap |
+| ---------- | ----------: | -----: | -------: | -----: |
+| 0.3–0.4    |           1 |  0.350 |    0.000 | -0.350 |
+| 0.5–0.6    |           9 |  0.500 |    0.222 | -0.278 |
+| 0.6–0.7    |          11 |  0.600 |    0.455 | -0.145 |
+| 0.7–0.8    |           1 |  0.700 |    1.000 | +0.300 |
+
+### Deriving the threshold
+
+Each confidence value the classifier produced, with the accuracy of every prediction at
+or above it. The threshold is the lowest value clearing 70% over at least
+5 predictions — lower is better, because the point is to run the root-cause agent on
+everything it can be right about, and a higher bar buys accuracy by answering less often.
+
+| threshold | predictions at or above | accuracy |     |
+| --------: | ----------------------: | -------: | --- |
+|      0.35 |                      22 |    36.4% |     |
+|      0.50 |                      21 |    38.1% |     |
+|      0.60 |                      12 |    50.0% |     |
+|      0.70 |                       1 |   100.0% |     |
+
 ## Per quadrant
 
 | quadrant                        | support | correct |          accuracy |

--- a/eval/run-eval.ts
+++ b/eval/run-eval.ts
@@ -3,6 +3,17 @@ import { readFileSync, writeFileSync } from 'node:fs'
 import { format } from 'prettier'
 import type { FixtureLabels } from '@sentra/contracts'
 import { cost, formatUsd, MODEL_CONFIG, type Cost } from '@sentra/agents'
+import {
+  calibrate,
+  deriveThreshold,
+  judge,
+  MIN_SUPPORT,
+  TARGET_ACCURACY,
+  type Calibration,
+  type Point,
+  type Threshold,
+  type Verdict,
+} from './calibration.js'
 import { chooseClassifier, type ClassifierContext, type ClassifierDeps } from './classifier.js'
 import { consensus, summarise, type Prediction, type SamplingSummary } from './consistency.js'
 import {
@@ -255,6 +266,10 @@ export interface Evaluation {
   classifier: ClassifierContext
   /** Mean single-run accuracy, its spread, and which fixtures flipped. */
   sampling: SamplingSummary
+  /** Whether the stated confidence is worth anything, and what follows if it is. */
+  calibration: Calibration
+  threshold: Threshold
+  verdict: Verdict
   /** Tokens and dollars. Zero everywhere for the baseline, which makes no calls. */
   cost: Cost
   metrics: Metrics
@@ -345,12 +360,41 @@ export async function evaluate(options: Options, deps: ClassifierDeps = {}): Pro
       })),
     ),
     cost: cost(chosen.usage),
+    ...calibrationOf(headline),
     metrics: score(headline.map((f) => f.judgement)),
     // Over the whole dataset, not the slice being scored, so the dev report can
     // say what is being withheld from it.
     composition: sliceComposition(every),
     datasetRevision: datasetRevision(fixtures),
   }
+}
+
+/**
+ * Every prediction the run produced, as a confidence and a verdict.
+ *
+ * One point per sample rather than per fixture: with sampling, each sample is a
+ * classification the pipeline could have emitted, and each carries its own
+ * stated confidence. Fixtures with arguable ground truth are already excluded by
+ * the caller — a calibration measured against a label the project itself is
+ * unsure of would be measuring the dataset.
+ */
+function calibrationOf(fixtures: readonly EvaluatedFixture[]): {
+  calibration: Calibration
+  threshold: Threshold
+  verdict: Verdict
+} {
+  const points: Point[] = fixtures.flatMap((fixture) =>
+    fixture.samples.map((sample) => ({
+      confidence: sample.confidence,
+      correct:
+        sample.owner === fixture.judgement.actual.owner &&
+        sample.determinism === fixture.judgement.actual.determinism,
+    })),
+  )
+
+  const calibration = calibrate(points)
+  const threshold = deriveThreshold(points)
+  return { calibration, threshold, verdict: judge(calibration, threshold) }
 }
 
 // ---------------------------------------------------------------------------
@@ -379,6 +423,10 @@ export function renderReport(evaluation: Evaluation): string {
     '## Stability',
     '',
     renderStability(evaluation),
+    '',
+    '## Calibration',
+    '',
+    renderCalibration(evaluation),
     '',
     '## Per quadrant',
     '',
@@ -429,6 +477,103 @@ export function renderReport(evaluation: Evaluation): string {
  * actually gets is the single-run mean, and it belongs on the page rather than
  * in a footnote. The gap between the two is the price of instability.
  */
+/**
+ * Whether the confidence number means anything, said in words first.
+ *
+ * The words lead because they are the part that changes what anybody does. A
+ * reliability table is only actionable once someone has decided whether the
+ * column it is built on carries information, and that decision belongs on the
+ * page rather than in the reader.
+ */
+function renderCalibration(evaluation: Evaluation): string {
+  const { calibration, threshold, verdict } = evaluation
+
+  const headline = [
+    `**${LABEL[verdict.usability]}** ${verdict.summary}`,
+    '',
+    markdownTable(
+      ['', ''],
+      [
+        ['predictions scored', String(calibration.n)],
+        ['distinct confidence values', String(calibration.distinctValues)],
+        [
+          'discrimination (AUROC)',
+          calibration.discrimination === null
+            ? `${NOT_MEASURED} — every prediction landed the same way`
+            : `${calibration.discrimination.toFixed(3)} — 0.50 is a coin toss`,
+        ],
+        ['expected calibration error', calibration.ece.toFixed(3)],
+        ['worst single bin', calibration.mce.toFixed(3)],
+        [
+          'derived root-cause threshold',
+          threshold.value === null
+            ? `not derived — ${threshold.reason}`
+            : threshold.value.toFixed(2),
+        ],
+      ],
+      ['left', 'left'],
+    ),
+  ]
+
+  const populated = calibration.bins.filter((bin) => bin.count > 0)
+  const curve =
+    populated.length === 0
+      ? ['No predictions to bin.']
+      : [
+          '### Reliability curve',
+          '',
+          'Stated confidence against observed accuracy. A perfectly calibrated classifier has the',
+          'two columns equal in every row. Empty bins are omitted; where the classifier never says',
+          '0.3, there is nothing to be right or wrong about.',
+          '',
+          markdownTable(
+            ['confidence', 'predictions', 'stated', 'observed', 'gap'],
+            populated.map((bin) => [
+              `${bin.lower.toFixed(1)}–${bin.upper.toFixed(1)}`,
+              String(bin.count),
+              bin.meanConfidence.toFixed(3),
+              bin.accuracy.toFixed(3),
+              signed(bin.accuracy - bin.meanConfidence),
+            ]),
+            ['left', 'right', 'right', 'right', 'right'],
+          ),
+        ]
+
+  const derivation =
+    threshold.sweep.length === 0
+      ? []
+      : [
+          '',
+          '### Deriving the threshold',
+          '',
+          `Each confidence value the classifier produced, with the accuracy of every prediction at`,
+          `or above it. The threshold is the lowest value clearing ${(TARGET_ACCURACY * 100).toFixed(0)}% over at least`,
+          `${String(MIN_SUPPORT)} predictions — lower is better, because the point is to run the root-cause agent on`,
+          'everything it can be right about, and a higher bar buys accuracy by answering less often.',
+          '',
+          markdownTable(
+            ['threshold', 'predictions at or above', 'accuracy', ''],
+            threshold.sweep.map((row) => [
+              row.threshold.toFixed(2),
+              String(row.count),
+              `${(row.accuracy * 100).toFixed(1)}%`,
+              row.threshold === threshold.value ? '**chosen**' : row.eligible ? 'eligible' : '',
+            ]),
+            ['right', 'right', 'right', 'left'],
+          ),
+        ]
+
+  return [...headline, '', ...curve, ...derivation].join('\n')
+}
+
+const LABEL: Record<Verdict['usability'], string> = {
+  unusable: 'Confidence is not usable.',
+  weak: 'Confidence is weakly informative.',
+  usable: 'Confidence is usable.',
+}
+
+const signed = (value: number): string => `${value >= 0 ? '+' : ''}${value.toFixed(3)}`
+
 function renderStability(evaluation: Evaluation): string {
   const { sampling, cost: spend, options } = evaluation
 


### PR DESCRIPTION
Closes #37.

A model asked for a confidence returns 0.85 for nearly everything. That number decides whether the root-cause agent runs, so if it carries no information the gate is decorative and the budget is being spent arbitrarily.

## ECE alone does not answer the question

Treating it as though it does is the usual mistake. Two independent properties are being asked about:

- **Calibration** — when it says 0.8, is it right about 80% of the time? That is ECE.
- **Discrimination** — does a higher number mean a better prediction *at all*? That is AUROC over (confidence, correct), where 0.50 is a coin toss.

A classifier that says 0.7 for every prediction and is right 70% of the time has a **perfect ECE and is useless**, because ranking is the only thing the threshold uses the number for. So the verdict leads with discrimination, a good ECE cannot rescue an AUROC of 0.5, and the report states the conclusion **in words** — usable, weakly informative, or not usable — before any table. A reader should not have to decide what the numbers mean before knowing whether the column they are built on carries information.

The **worst single bin** is reported beside ECE, because an average hides the case that matters: a classifier can post a respectable ECE while being wrong by 40 points in the one bin the threshold sits in.

## The threshold is read off the data

The sweep runs over the confidence values the classifier **actually produced** — a threshold between two values it never emits behaves identically to one of them and looks more considered than it is. It takes the **lowest** value clearing the target accuracy over at least five predictions: lower is better, because the point is to run the root-cause agent on everything it can be right about, and a higher bar buys accuracy by answering less often.

When nothing qualifies, the report says **which of the two problems it hit**. "No threshold reaches 70%" printed next to a sweep row showing 100% is a message a reader stops trusting — short support and low accuracy are different problems with different fixes (more fixtures, or a better classifier).

## Two implementation details that are load-bearing

**AUROC uses average ranks for ties.** This matters more here than usual: a constant confidence is *entirely* ties, and without the correction it would score 1.0 — a perfect ranking read off a list with no order in it. There is a test for exactly that.

**The "unusable" guard fires at one distinct value, not two.** I wrote it at two first and a test caught it: two levels partition the predictions, which is real ranking information however coarse, and dismissing it out of hand would be the same unearned certainty in the other direction. AUROC judges it instead.

Points are one per **prediction**, not per fixture — with sampling, every sample is a classification the pipeline could have emitted, each with its own stated confidence. They are correlated, which is why no interval is attached to ECE and why the verdict says "a direction, not a measurement".

## What it says about the baseline today

Unflattering, and true:

```
Confidence is weakly informative. Confidence ranks predictions at AUROC 0.70 with an
expected calibration error of 0.216. It orders predictions better than chance but the
stated number is not the observed rate — treat it as a sortable hint, not a probability.
No root-cause threshold could be derived: the only thresholds reaching 70.0% do so over
fewer than 5 predictions (best: 100.0% over 1), which is noise with a decimal point.
At 22 predictions from a stratified dataset this is a direction, not a measurement.
```

The reliability curve shows the shape: the baseline is systematically over-confident in its two populated bins (−0.278 and −0.145) and hits 1.000 in a bin containing one prediction.

`.env.example` now says what to do when the report says confidence carries no information: stop gating on it, rather than pick a number that looks reasonable.

## Testing

1124 tests pass. `eval/calibration.ts` is at 100% statements, functions and lines; the remaining branches are `?? 0` fallbacks on indexed access.

The suite drives the failure modes directly: a perfectly calibrated constant (unusable), a coin toss across a spread of confidences (unusable), a well-ordered and well-scaled confidence (usable), and one that ranks correctly while stating numbers far from the observed rate (weak, not usable).