### PR TITLE
feat(agents): npm run demo, on a clean clone, with no key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,18 @@ jobs:
       # runs is the one a contributor can run locally by name. The thresholds in
       # vitest.config.ts fail the job on their own.
       - run: npm run test:coverage
+
+      # The README's headline claim, run the way a stranger runs it: a clean
+      # checkout, `npm ci`, and nothing else. The unit tests already drive the
+      # demo's `main`, but only this proves the *command* works — a broken
+      # binary, a missing bundled file or a script rename would pass every test
+      # in the suite and fail the first person who tried it.
+      #
+      # No ANTHROPIC_API_KEY is set on this job on purpose. If the demo ever
+      # needs one, it fails here rather than in a reader's terminal.
+      - name: The credential-free demo still runs
+        run: npm run demo
+
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ npm run lint && npm run typecheck
 And what does not yet, with the milestone it arrives in:
 
 ```bash
-npm run demo            # 🚧 M3 · #39 — full pipeline in replay mode, no API key
+npm run demo            # full pipeline, no API key — writes report.md
 npm run dev             # 🚧 M4 · #48 — start TaskFlow locally
 npm test                # 🚧 M5 · #50 — unit and e2e together
 ```

--- a/README.md
+++ b/README.md
@@ -116,12 +116,18 @@ cd ai-flaky-test-triage
 npm install
 ```
 
-**Run the full pipeline with no API key** (replays recorded model responses — deterministic,
-free, offline):
+**Run the full pipeline with no API key** — no configuration, no network, no build:
 
 ```bash
-npm run demo            # 🚧 M3
+npm run demo            # writes report.md
 ```
+
+It classifies the bundled run in [`demo/`](demo/) and says which classifier produced the
+output. Until the first recorded evaluation lands (#38) there are no cassettes to replay, so it
+runs the model-free baseline and prints that rather than implying a live classification happened.
+Replay proves the plumbing — context assembly, the fences around untrusted text, the forced output
+schema, the report — never the model's behaviour today; that is measured separately in
+[`eval/report.md`](eval/report.md).
 
 **Run against live models:**
 
@@ -154,7 +160,7 @@ cat eval/report.md
 | `npm run analyze`            | M8 🚧     | flakemetry and agents in sequence                             |
 | `npm run eval`               | M2        | Golden-dataset evaluation → eval/report.md                    |
 | `npm run eval:ablation`      | M9 🚧     | Context-ablation study → eval/ablation.md                     |
-| `npm run demo`               | M3 🚧     | Full pipeline in replay mode, no credentials                  |
+| `npm run demo`               | M3        | Full pipeline in replay mode, no credentials                  |
 
 🚧 marks a script that is not implemented yet; running it says so and names its issue.
 Everything else runs today. `npm run help` prints this table from the terminal.

--- a/demo/analysis.json
+++ b/demo/analysis.json
@@ -1,0 +1,201 @@
+{
+  "schemaVersion": 1,
+  "runId": "demo-run-2026-08-12",
+  "commitSha": "3f9c1ab7d2e4508b6c1f0a95d3e7b2c4a80e1f66",
+  "branch": "feature/optimistic-updates",
+  "analysedAt": "2026-08-12T09:41:07.000Z",
+  "historyAvailable": true,
+  "historyDepth": 74,
+  "tests": [
+    {
+      "result": {
+        "testId": "tests/e2e/board.spec.ts›board › completing a task while its title is saved keeps both changes",
+        "title": "board › completing a task while its title is saved keeps both changes",
+        "file": "tests/e2e/board.spec.ts",
+        "status": "failed",
+        "attempts": 2,
+        "flakyWithinRun": false,
+        "durationMs": 4120,
+        "annotations": [],
+        "error": {
+          "message": "Error: expect(received).toHaveText(expected)\n\nExpected string:  \"Done\"\nReceived string:  \"In progress\"",
+          "stack": "    at applyOptimistic (app/client/src/useTasks.ts:64:18)\n    at tests/e2e/board.spec.ts:41:5",
+          "snippet": "  await Promise.all([page.getByRole('checkbox').click(), saveTitle('Ship it')])\n> await expect(status).toHaveText('Done')"
+        }
+      },
+      "signal": {
+        "testId": "tests/e2e/board.spec.ts›board › completing a task while its title is saved keeps both changes",
+        "flakinessScore": 0.31,
+        "consecutiveFailures": 2,
+        "totalRuns": 74,
+        "firstSeenAt": "2026-05-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-11T09:14:02.000Z",
+        "statusHistory": "PPPFPPPPFF",
+        "isNew": false
+      }
+    },
+    {
+      "result": {
+        "testId": "tests/e2e/filters.spec.ts›filters › hides completed tasks when the toggle is off",
+        "title": "filters › hides completed tasks when the toggle is off",
+        "file": "tests/e2e/filters.spec.ts",
+        "status": "failed",
+        "attempts": 3,
+        "flakyWithinRun": false,
+        "durationMs": 30011,
+        "annotations": [],
+        "error": {
+          "message": "TimeoutError: locator.click: Timeout 30000ms exceeded.\nCall log:\n  - waiting for getByTestId('filter-completed')",
+          "stack": "    at tests/e2e/filters.spec.ts:18:44",
+          "snippet": "  await page.goto('/')\n> await page.getByTestId('filter-completed').click()"
+        }
+      },
+      "signal": {
+        "testId": "tests/e2e/filters.spec.ts›filters › hides completed tasks when the toggle is off",
+        "flakinessScore": 0.05,
+        "consecutiveFailures": 4,
+        "totalRuns": 74,
+        "firstSeenAt": "2026-05-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-11T09:14:02.000Z",
+        "statusHistory": "PPPPPPFFFF",
+        "isNew": false
+      }
+    },
+    {
+      "result": {
+        "testId": "tests/e2e/smoke.spec.ts›smoke › the application responds on the configured port",
+        "title": "smoke › the application responds on the configured port",
+        "file": "tests/e2e/smoke.spec.ts",
+        "status": "failed",
+        "attempts": 1,
+        "flakyWithinRun": false,
+        "durationMs": 812,
+        "annotations": [],
+        "error": {
+          "message": "Error: listen EADDRINUSE: address already in use :::3001",
+          "stack": "    at Server.setupListenHandle [as _listen2] (node:net:1898:16)"
+        }
+      },
+      "signal": {
+        "testId": "tests/e2e/smoke.spec.ts›smoke › the application responds on the configured port",
+        "flakinessScore": 0.02,
+        "consecutiveFailures": 1,
+        "totalRuns": 74,
+        "firstSeenAt": "2026-05-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-11T09:14:02.000Z",
+        "statusHistory": "PPPPPPPPPF",
+        "isNew": false
+      }
+    },
+    {
+      "result": {
+        "testId": "tests/unit/tasks.repository.test.ts›repository › paginates without dropping the boundary row",
+        "title": "repository › paginates without dropping the boundary row",
+        "file": "tests/unit/tasks.repository.test.ts",
+        "status": "passed",
+        "attempts": 2,
+        "flakyWithinRun": true,
+        "durationMs": 143,
+        "annotations": []
+      },
+      "signal": {
+        "testId": "tests/unit/tasks.repository.test.ts›repository › paginates without dropping the boundary row",
+        "flakinessScore": 0.44,
+        "consecutiveFailures": 0,
+        "totalRuns": 74,
+        "firstSeenAt": "2026-05-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-11T09:14:02.000Z",
+        "statusHistory": "PFPFPPPFPP",
+        "isNew": false
+      }
+    },
+    {
+      "result": {
+        "testId": "tests/unit/tasks.service.test.ts›service › rejects an empty title",
+        "title": "service › rejects an empty title",
+        "file": "tests/unit/tasks.service.test.ts",
+        "status": "passed",
+        "attempts": 1,
+        "flakyWithinRun": false,
+        "durationMs": 12,
+        "annotations": []
+      },
+      "signal": {
+        "testId": "tests/unit/tasks.service.test.ts›service › rejects an empty title",
+        "flakinessScore": 0.0,
+        "consecutiveFailures": 0,
+        "totalRuns": 74,
+        "firstSeenAt": "2026-05-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-11T09:14:02.000Z",
+        "statusHistory": "PPPPPPPPPP",
+        "isNew": false
+      }
+    },
+    {
+      "result": {
+        "testId": "tests/unit/tasks.service.test.ts›service › trims whitespace from a title",
+        "title": "service › trims whitespace from a title",
+        "file": "tests/unit/tasks.service.test.ts",
+        "status": "passed",
+        "attempts": 1,
+        "flakyWithinRun": false,
+        "durationMs": 9,
+        "annotations": []
+      },
+      "signal": {
+        "testId": "tests/unit/tasks.service.test.ts›service › trims whitespace from a title",
+        "flakinessScore": 0.0,
+        "consecutiveFailures": 0,
+        "totalRuns": 74,
+        "firstSeenAt": "2026-05-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-11T09:14:02.000Z",
+        "statusHistory": "PPPPPPPPPP",
+        "isNew": false
+      }
+    },
+    {
+      "result": {
+        "testId": "tests/e2e/board.spec.ts›board › renders every task in the list",
+        "title": "board › renders every task in the list",
+        "file": "tests/e2e/board.spec.ts",
+        "status": "passed",
+        "attempts": 1,
+        "flakyWithinRun": false,
+        "durationMs": 1804,
+        "annotations": []
+      },
+      "signal": {
+        "testId": "tests/e2e/board.spec.ts›board › renders every task in the list",
+        "flakinessScore": 0.0,
+        "consecutiveFailures": 0,
+        "totalRuns": 74,
+        "firstSeenAt": "2026-05-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-11T09:14:02.000Z",
+        "statusHistory": "PPPPPPPPPP",
+        "isNew": false
+      }
+    },
+    {
+      "result": {
+        "testId": "tests/unit/tasks.repository.test.ts›repository › returns an empty page for an unknown cursor",
+        "title": "repository › returns an empty page for an unknown cursor",
+        "file": "tests/unit/tasks.repository.test.ts",
+        "status": "passed",
+        "attempts": 1,
+        "flakyWithinRun": false,
+        "durationMs": 7,
+        "annotations": []
+      },
+      "signal": {
+        "testId": "tests/unit/tasks.repository.test.ts›repository › returns an empty page for an unknown cursor",
+        "flakinessScore": 0.0,
+        "consecutiveFailures": 0,
+        "totalRuns": 74,
+        "firstSeenAt": "2026-05-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-11T09:14:02.000Z",
+        "statusHistory": "PPPPPPPPPP",
+        "isNew": false
+      }
+    }
+  ]
+}

--- a/demo/diff.patch
+++ b/demo/diff.patch
@@ -1,0 +1,22 @@
+diff --git a/app/client/src/useTasks.ts b/app/client/src/useTasks.ts
+--- a/app/client/src/useTasks.ts
++++ b/app/client/src/useTasks.ts
+@@ -58,11 +58,12 @@ export function useTasks() {
+   async function complete(id: string) {
+-    const updated = await api.completeTask(id)
+-    setTasks((current) => current.map((t) => (t.id === id ? updated : t)))
++    // Optimistic: paint the change before the request settles.
++    setTasks((current) => current.map((t) => (t.id === id ? { ...t, status: 'done' } : t)))
++    await api.completeTask(id)
+   }
+ 
+   async function rename(id: string, title: string) {
+     const updated = await api.updateTask(id, { title })
+     setTasks((current) => current.map((t) => (t.id === id ? updated : t)))
+   }
+diff --git a/app/client/src/TaskRow.tsx b/app/client/src/TaskRow.tsx
+--- a/app/client/src/TaskRow.tsx
++++ b/app/client/src/TaskRow.tsx
+@@ -12,7 +12,7 @@ export function TaskRow({ task }: { task: Task }) {
+-      <input type="checkbox" data-testid="filter-completed" />
++      <input type="checkbox" data-testid="filter-done" />

--- a/demo/sources/tests/e2e/board.spec.ts
+++ b/demo/sources/tests/e2e/board.spec.ts
@@ -1,0 +1,8 @@
+test('completing a task while its title is saved keeps both changes', async ({ page }) => {
+  await page.goto('/')
+  const row = page.getByRole('listitem').filter({ hasText: 'Ship it' })
+  const status = row.getByTestId('status')
+
+  await Promise.all([page.getByRole('checkbox').click(), saveTitle('Ship it')])
+  await expect(status).toHaveText('Done')
+})

--- a/demo/sources/tests/e2e/filters.spec.ts
+++ b/demo/sources/tests/e2e/filters.spec.ts
@@ -1,0 +1,5 @@
+test('hides completed tasks when the toggle is off', async ({ page }) => {
+  await page.goto('/')
+  await page.getByTestId('filter-completed').click()
+  await expect(page.getByRole('listitem')).toHaveCount(2)
+})

--- a/demo/sources/tests/e2e/smoke.spec.ts
+++ b/demo/sources/tests/e2e/smoke.spec.ts
@@ -1,0 +1,4 @@
+test('the application responds on the configured port', async ({ request }) => {
+  const response = await request.get('/health')
+  expect(response.status()).toBe(200)
+})

--- a/demo/sources/tests/unit/tasks.repository.test.ts
+++ b/demo/sources/tests/unit/tasks.repository.test.ts
@@ -1,0 +1,6 @@
+it('paginates without dropping the boundary row', async () => {
+  await seed(30)
+  const first = await repository.page({ limit: 10 })
+  const second = await repository.page({ limit: 10, after: first.cursor })
+  expect(new Set([...first.rows, ...second.rows].map((r) => r.id)).size).toBe(20)
+})

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,10 @@ export default tseslint.config(
       '**/dist/**',
       '**/node_modules/**',
       'coverage/**',
+      // Bundled fixture data for `npm run demo`, not project source. These are
+      // the *contents* of a test file in an imaginary repository, read as text
+      // and passed into a prompt — linting them would be linting the input.
+      'demo/sources/**',
       'playwright-report/**',
       'test-results/**',
       '**/*.d.ts',

--- a/eval/index.ts
+++ b/eval/index.ts
@@ -3,11 +3,16 @@
  *
  * Golden-dataset evaluation: the baseline heuristic, the metrics, and the harness that scores a classifier against ground truth.
  *
- * The harness and report writer land later in M2; the pieces below are the ones
- * that exist.
+ * `run-eval.ts` is a CLI rather than a library entry point and is deliberately
+ * not re-exported: it reads and writes committed files as a side effect of being
+ * imported for its `main`, which is not something a consumer should get by
+ * asking for the classifier seam.
  */
 
 export * from './dataset.js'
 export * from './baseline.js'
 export * from './metrics.js'
 export * from './confusion.js'
+export * from './classifier.js'
+export * from './consistency.js'
+export * from './calibration.js'

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build": "node scripts/pending.mjs build",
     "changelog": "tsx scripts/changelog.ts",
     "changelog:check": "tsx scripts/changelog.ts --check",
-    "demo": "node scripts/pending.mjs demo",
+    "demo": "tsx scripts/demo.ts",
     "dev": "node scripts/pending.mjs dev",
     "docs:status": "tsx scripts/status-banner.ts",
     "docs:status:check": "tsx scripts/status-banner.ts --check",
@@ -73,7 +73,7 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js,mjs,cjs}": [
-      "eslint --fix --max-warnings=0",
+      "eslint --fix --max-warnings=0 --no-warn-ignored",
       "prettier --write"
     ],
     "*.{json,md,yml,yaml}": [

--- a/scripts/demo.ts
+++ b/scripts/demo.ts
@@ -1,0 +1,212 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { resolveMode, listCassettes, type Mode } from '@sentra/agents'
+import {
+  parseAnalysis,
+  selectForTriage,
+  type AnalysedTest,
+  type Classification,
+  type ClassificationInput,
+} from '@sentra/contracts'
+import { chooseClassifier, type ClassifierDeps } from '@sentra/eval'
+
+/**
+ * `npm run demo` — the pipeline, end to end, on a clean clone.
+ *
+ * This is the README's headline claim and the reason replay exists. Somebody
+ * evaluating this repository will not provision an API key; if the demo needs
+ * one, the project is unreadable to the audience it was written for. So: no key,
+ * no network, no build, no configuration, and a real `report.md` at the end.
+ *
+ * **It is honest about what it is showing.** Replay proves the plumbing — the
+ * bundle, the fences, the schema, the report — not the model's behaviour today.
+ * A demo that implied a live classification had just happened would be the same
+ * kind of quiet dishonesty this project spends its time removing elsewhere, so
+ * the banner says which classifier ran and why.
+ *
+ * The renderer here is deliberately small and is not the report writer. That is
+ * #68, and it belongs with the orchestrator in #66; this file exists to prove the
+ * path is joined up, not to be the product.
+ */
+
+export const DEMO_DIR = 'demo'
+export const OUTPUT = 'report.md'
+
+interface DemoDeps extends ClassifierDeps {
+  /** Injected so a test can drive replay, record or live without touching the process. */
+  read?: (path: string) => string
+  write?: (path: string, contents: string) => void
+  log?: (message: string) => void
+  cassettes?: () => number
+}
+
+/**
+ * Which classifier the demo can actually run.
+ *
+ * Replay needs cassettes, and until the first recorded evaluation lands there
+ * are none. Rather than fail on a clean clone — the one thing this script exists
+ * not to do — it falls back to the baseline heuristic and says so in the banner
+ * and in the report. A degraded run that announces itself is worth more than a
+ * broken one, and far more than a polished one that quietly ran something else.
+ */
+export function pick(
+  mode: Mode,
+  cassettes: number,
+): { classifier: 'baseline' | 'agent'; why: string } {
+  if (mode !== 'replay') {
+    return {
+      classifier: 'agent',
+      why: `credentials are present, so this run is live (${mode}) and costs money`,
+    }
+  }
+  return cassettes > 0
+    ? {
+        classifier: 'agent',
+        why: `replaying ${String(cassettes)} recorded response(s) — no network, no key, no cost`,
+      }
+    : {
+        classifier: 'baseline',
+        why: 'no cassettes are recorded yet, so the model-free baseline ran instead (#38 records them)',
+      }
+}
+
+export async function main(deps: DemoDeps = {}): Promise<number> {
+  const read = deps.read ?? ((path: string) => readFileSync(path, 'utf8'))
+  const write = deps.write ?? ((path: string, text: string) => writeFileSync(path, text))
+  const log = deps.log ?? console.log
+  const countCassettes = deps.cassettes ?? (() => listCassettes().length)
+
+  const analysis = parseAnalysis(
+    JSON.parse(read(join(DEMO_DIR, 'analysis.json'))),
+    join(DEMO_DIR, 'analysis.json'),
+  )
+  const diff = read(join(DEMO_DIR, 'diff.patch'))
+
+  const mode = resolveMode(deps.env ?? process.env)
+  const chosen = pick(mode, countCassettes())
+  const classifier = chooseClassifier(chosen.classifier, deps)
+
+  log(banner(analysis.runId, chosen.why))
+
+  const failing = selectForTriage(analysis)
+  const rows: Row[] = []
+  for (const subject of failing) {
+    const input: ClassificationInput = {
+      subject,
+      diff,
+      historyAvailable: analysis.historyAvailable,
+      ...source(read, subject),
+    }
+    rows.push({ subject, classification: await classifier.classify(input, 0) })
+  }
+
+  write(OUTPUT, render(analysis.branch, analysis.commitSha, chosen, rows, failing.length))
+
+  log(`  Classified ${String(rows.length)} of ${String(analysis.tests.length)} tests.`)
+  log(`  Wrote ${OUTPUT}.\n`)
+  return 0
+}
+
+/** Read by the caller and passed in, so nothing under `agents/` touches the disk. */
+function source(read: (path: string) => string, subject: AnalysedTest): { testSource?: string } {
+  try {
+    return { testSource: read(join(DEMO_DIR, 'sources', subject.result.file)) }
+  } catch {
+    // A missing source is an ordinary state in production too — a renamed file,
+    // a shallow checkout — and the bundle says "not available" rather than
+    // pretending it was considered.
+    return {}
+  }
+}
+
+const banner = (runId: string, why: string): string =>
+  [
+    '',
+    '  Sentra — flaky-test triage, end to end',
+    '',
+    `  Input:      ${DEMO_DIR}/analysis.json (bundled run ${runId})`,
+    `  Classifier: ${why}`,
+    '',
+    '  Replay proves the plumbing — context assembly, the fences around untrusted',
+    '  text, the forced output schema, the report — not what the model would say',
+    '  today. The accuracy of whatever ran is measured separately, in eval/report.md,',
+    '  and this report states it rather than asking you to assume it.',
+    '',
+  ].join('\n')
+
+// ---------------------------------------------------------------------------
+// The report
+// ---------------------------------------------------------------------------
+
+interface Row {
+  subject: AnalysedTest
+  classification: Classification
+}
+
+const QUADRANT: Record<string, string> = {
+  'app_code/deterministic': 'Regression — ship-blocking',
+  'app_code/intermittent': 'Product race — looks flaky, is a bug',
+  'test_code/deterministic': 'Stale test — fix or delete it',
+  'test_code/intermittent': 'Unsynchronised test — missing wait or shared state',
+  'environment/deterministic': 'Broken setup — fix CI',
+  'environment/intermittent': 'Infra noise — rerun, then track it',
+}
+
+function render(
+  branch: string,
+  commit: string,
+  chosen: { classifier: string; why: string },
+  rows: readonly Row[],
+  selected: number,
+): string {
+  const sorted = [...rows].sort((a, b) => order(a) - order(b) || name(a).localeCompare(name(b)))
+
+  return [
+    '# Flaky-test triage',
+    '',
+    `Branch \`${branch}\` at \`${commit.slice(0, 12)}\`. ${String(selected)} failing or newly-unstable test(s).`,
+    '',
+    `> Produced by \`npm run demo\` with the **${chosen.classifier}** classifier — ${chosen.why}.`,
+    `> This output is advisory. The classifier's measured accuracy is published in`,
+    `> [eval/report.md](eval/report.md); read it before trusting a row below.`,
+    '',
+    '| test | verdict | confidence | why |',
+    '| ---- | ------- | ---------: | --- |',
+    ...sorted.map((row) => {
+      const { owner, determinism, confidence, reasoning } = row.classification
+      return `| \`${row.subject.result.title}\` | ${QUADRANT[`${owner}/${determinism}`] ?? ''} <br> \`${owner}\` + \`${determinism}\` | ${confidence.toFixed(2)} | ${escape(reasoning)} |`
+    }),
+    '',
+    ...sorted.flatMap((row) => [
+      `### \`${row.subject.result.title}\``,
+      '',
+      `\`${row.subject.result.file}\` — ${row.subject.result.status}, ` +
+        `${String(row.subject.result.attempts)} attempt(s), history \`${row.subject.signal.statusHistory}\``,
+      '',
+      'Evidence the classifier says it relied on:',
+      '',
+      ...row.classification.evidence.map((quote) => `- ${escape(quote)}`),
+      '',
+    ]),
+  ].join('\n')
+}
+
+const order = (row: Row): number =>
+  row.classification.owner === 'app_code' ? 0 : row.classification.owner === 'test_code' ? 1 : 2
+
+const name = (row: Row): string => row.subject.result.testId
+
+/**
+ * Agent output is escaped before it reaches markdown.
+ *
+ * Every string in a classification originates in text a contributor wrote, so an
+ * unescaped one can forge a table row or open a `<details>` the report never
+ * closed. The worst case is cosmetic, which is exactly why it would go
+ * unnoticed.
+ */
+const escape = (text: string): string =>
+  text.replaceAll('|', '\\|').replaceAll('<', '&lt;').replaceAll('\n', ' ')
+
+if (process.argv[1]?.endsWith('demo.ts') === true) {
+  process.exitCode = await main()
+}

--- a/scripts/script-manifest.json
+++ b/scripts/script-manifest.json
@@ -24,7 +24,7 @@
     },
     {
       "name": "test:unit",
-      "description": "Vitest — API, flakemetry-lib, prompt builders, contracts",
+      "description": "Vitest \u2014 API, flakemetry-lib, prompt builders, contracts",
       "milestone": "M0",
       "issue": 9,
       "status": "implemented"
@@ -38,7 +38,7 @@
     },
     {
       "name": "test:e2e",
-      "description": "Playwright — TaskFlow UI flows including the flaky specs",
+      "description": "Playwright \u2014 TaskFlow UI flows including the flaky specs",
       "milestone": "M5",
       "issue": 50,
       "status": "pending"
@@ -52,14 +52,14 @@
     },
     {
       "name": "flakemetry:analyze",
-      "description": "Test report + history → analysis.json",
+      "description": "Test report + history \u2192 analysis.json",
       "milestone": "M6",
       "issue": 59,
       "status": "pending"
     },
     {
       "name": "agents:analyze",
-      "description": "analysis.json → report.md",
+      "description": "analysis.json \u2192 report.md",
       "milestone": "M7",
       "issue": 66,
       "status": "pending"
@@ -73,14 +73,14 @@
     },
     {
       "name": "eval",
-      "description": "Golden-dataset evaluation → eval/report.md",
+      "description": "Golden-dataset evaluation \u2192 eval/report.md",
       "milestone": "M2",
       "issue": 27,
       "status": "implemented"
     },
     {
       "name": "eval:ablation",
-      "description": "Context-ablation study → eval/ablation.md",
+      "description": "Context-ablation study \u2192 eval/ablation.md",
       "milestone": "M9",
       "issue": 78,
       "status": "pending"
@@ -90,7 +90,7 @@
       "description": "Full pipeline in replay mode, no credentials",
       "milestone": "M3",
       "issue": 39,
-      "status": "pending"
+      "status": "implemented"
     }
   ]
 }

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -6,5 +6,16 @@
     "types": ["node"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["dist"]
+  "exclude": ["dist"],
+  "references": [
+    {
+      "path": "../contracts"
+    },
+    {
+      "path": "../agents"
+    },
+    {
+      "path": "../eval"
+    }
+  ]
 }

--- a/tests/unit/demo.test.ts
+++ b/tests/unit/demo.test.ts
@@ -1,0 +1,157 @@
+import { readFileSync } from 'node:fs'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { DEMO_DIR, main, OUTPUT, pick } from '../../scripts/demo.js'
+
+/**
+ * The demo, exercised the way a stranger runs it.
+ *
+ * This is the README's headline claim, so the tests are about the claim rather
+ * than about the code: it finishes, it writes a real report, it says what it
+ * ran, and it does not touch the network. The last one is asserted rather than
+ * assumed — a demo that quietly reached the API would still look like it worked,
+ * right up until somebody without a key tried it.
+ */
+
+const written = new Map<string, string>()
+
+const run = (over: Parameters<typeof main>[0] = {}): Promise<number> =>
+  main({
+    env: { SENTRA_REPLAY: '1' },
+    write: (path, contents) => void written.set(path, contents),
+    log: () => undefined,
+    ...over,
+  })
+
+afterEach(() => {
+  written.clear()
+  vi.restoreAllMocks()
+})
+
+describe('running the demo', () => {
+  it('completes and writes a report', async () => {
+    expect(await run()).toBe(0)
+    expect(written.get(OUTPUT)).toContain('# Flaky-test triage')
+  })
+
+  /**
+   * Asserted, not assumed. `fetch` is what the SDK reaches for, so replacing it
+   * with a throwing stub turns "no network" from a property of the environment
+   * into a property of the code.
+   */
+  it('makes no network call', async () => {
+    const fetch = vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+      throw new Error('the demo reached the network')
+    })
+    expect(await run()).toBe(0)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  /**
+   * The stronger version of the same claim: force the agent path with a cassette
+   * count, and replay still cannot fall through to a live request. It fails with
+   * a miss instead — which is the behaviour that makes a credential-free run
+   * trustworthy rather than lucky.
+   */
+  it('cannot reach the network even on the agent path', async () => {
+    const fetch = vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+      throw new Error('the demo reached the network')
+    })
+    await expect(run({ cassettes: () => 3 })).rejects.toThrow(/no cassette for/)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('finishes well inside the thirty seconds the demo promises', async () => {
+    const started = Date.now()
+    await run()
+    expect(Date.now() - started).toBeLessThan(30_000)
+  })
+
+  it('classifies every failing and newly-unstable test in the bundle', async () => {
+    await run()
+    const report = written.get(OUTPUT) ?? ''
+    expect(report).toContain('4 failing or newly-unstable test(s)')
+    // The passing tests are not in the report; there is nothing to triage about them.
+    expect(report).not.toContain('rejects an empty title')
+  })
+
+  it('says which classifier ran and links the accuracy of it', async () => {
+    await run()
+    const report = written.get(OUTPUT) ?? ''
+    expect(report).toContain('**baseline** classifier')
+    expect(report).toContain('eval/report.md')
+    expect(report).toContain('advisory')
+  })
+
+  /**
+   * A renamed file or a shallow checkout produces this in production too. The
+   * bundle then says the source is unavailable rather than pretending it was
+   * read and found unremarkable.
+   */
+  it('carries on when a test source is not on disk', async () => {
+    const read = (path: string): string => {
+      if (path.includes('sources')) throw new Error('ENOENT')
+      return readFileSync(path, 'utf8')
+    }
+    expect(await run({ read })).toBe(0)
+    expect(written.get(OUTPUT)).toContain('# Flaky-test triage')
+  })
+
+  it('quotes the evidence each verdict rests on', async () => {
+    await run()
+    expect(written.get(OUTPUT)).toContain('Evidence the classifier says it relied on')
+  })
+
+  it('explains what replay does and does not prove', async () => {
+    const lines: string[] = []
+    await run({ log: (message) => lines.push(message) })
+    expect(lines.join('\n')).toContain('Replay proves the plumbing')
+    expect(lines.join('\n')).toContain('not what the model would say')
+  })
+})
+
+describe('which classifier the demo can run', () => {
+  it('replays recorded responses when there are any', () => {
+    expect(pick('replay', 12)).toMatchObject({ classifier: 'agent' })
+    expect(pick('replay', 12).why).toContain('no network, no key, no cost')
+  })
+
+  /**
+   * The one thing this script exists not to do is fail on a clean clone. Until
+   * the first recorded evaluation lands there are no cassettes, so it runs the
+   * heuristic and says so — a degraded run that announces itself is worth more
+   * than a broken one, and far more than a polished one that quietly ran
+   * something else.
+   */
+  it('falls back to the baseline rather than failing when there are none', () => {
+    expect(pick('replay', 0)).toMatchObject({ classifier: 'baseline' })
+    expect(pick('replay', 0).why).toContain('no cassettes are recorded yet')
+  })
+
+  it('says plainly when a run will cost money', () => {
+    expect(pick('live', 0).why).toContain('costs money')
+    expect(pick('record', 0).why).toContain('costs money')
+  })
+})
+
+describe('the bundled run', () => {
+  it('is committed, so a clean clone has something to classify', () => {
+    const analysis = JSON.parse(readFileSync(`${DEMO_DIR}/analysis.json`, 'utf8')) as {
+      tests: unknown[]
+    }
+    expect(analysis.tests.length).toBeGreaterThan(4)
+    expect(readFileSync(`${DEMO_DIR}/diff.patch`, 'utf8')).toContain('diff --git')
+  })
+
+  /**
+   * Not decoration. The bundle carries the two cases the project is about — a
+   * product race that looks like a flaky test, and a stale selector that looks
+   * like a regression — so the demo shows the problem even when the classifier
+   * on it is the weak one.
+   */
+  it('contains the failures worth arguing about', () => {
+    const analysis = readFileSync(`${DEMO_DIR}/analysis.json`, 'utf8')
+    expect(analysis).toContain('completing a task while its title is saved keeps both changes')
+    expect(analysis).toContain('EADDRINUSE')
+    expect(analysis).toContain('filter-completed')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,12 +16,37 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text-summary', 'lcov'],
       reportsDirectory: 'coverage',
-      exclude: ['**/dist/**', '**/*.config.*', 'scripts/**', 'tests/**'],
+      /**
+       * `scripts/` is no longer excluded wholesale.
+       *
+       * It was, when it held only glue. It now holds `demo.ts`, which is the
+       * README's headline command and therefore product surface — and code
+       * nobody measures is code nobody notices breaking.
+       *
+       * The line is product surface in, repository maintenance out.
+       * `changelog.ts` and `status-banner.ts` each have a `--check` mode that CI
+       * runs against the committed files, which is a stronger claim about them
+       * than a percentage. A script added later is measured by default, which is
+       * the safe direction for this list to rot in.
+       *
+       * `demo/` holds bundled fixture data — the contents of test files in an
+       * imaginary repository, read as text and fed to a prompt. Measuring
+       * coverage of an input is a category error.
+       */
+      exclude: [
+        '**/dist/**',
+        '**/*.config.*',
+        '**/scripts/*.mjs',
+        '**/scripts/changelog.ts',
+        '**/scripts/status-banner.ts',
+        'tests/**',
+        'demo/**',
+      ],
 
       /**
        * A floor, not a target.
        *
-       * Set a few points below what is measured today (96.8% statements, 83.4%
+       * Set a few points below what is measured today (97.5% statements, 87.4%
        * branches) on purpose. A threshold pinned to the current number fails on
        * the first honest refactor that deletes a well-covered file, and a gate
        * that fires on noise is one somebody switches off — at which point the

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -22,7 +22,7 @@ npm install
 npm run help            # every command, and whether it exists yet
 npm run test:coverage   # the full suite, with the coverage floor enforced
 npm run eval            # score the baseline against the golden dataset
-npm run demo            # 🚧 M3 · #39 — full pipeline in replay mode
+npm run demo            # full pipeline, no API key — writes report.md
 ```
 
 Node ≥ 22.13. A key is only required for live model calls, and nothing that works today needs one.

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -40,7 +40,7 @@ npm run typecheck
 ### What does not, and why it is described anyway
 
 ```bash
-npm run demo          # 🚧 M3 · #39
+npm run demo          # writes report.md
 ```
 
 The intent: run the entire pipeline — flakiness analysis, triage, root cause, fix suggestion,


### PR DESCRIPTION
Closes #39.

This is the README's headline claim and the reason replay exists. Somebody evaluating this repository will not provision an API key; if the demo needs one, the project is unreadable to the audience it was written for. So: **no key, no network, no build, no configuration**, and a real `report.md` at the end.

```
  Sentra — flaky-test triage, end to end

  Input:      demo/analysis.json (bundled run demo-run-2026-08-12)
  Classifier: no cassettes are recorded yet, so the model-free baseline ran instead (#38 records them)

  Replay proves the plumbing — context assembly, the fences around untrusted
  text, the forced output schema, the report — not what the model would say
  today. …

  Classified 4 of 8 tests.
  Wrote report.md.
```

## It is honest about what it is showing

Replay proves the *plumbing* — context assembly, the fences around untrusted text, the forced output schema, the report — never the model's behaviour today. A demo implying a live classification had just happened would be the same quiet dishonesty this project spends its time removing elsewhere.

Until the first recorded evaluation lands (#38) there are no cassettes, so the demo runs the model-free baseline and **says so**, in the banner and in the report. Failing on a clean clone is the one thing this script exists not to do; a degraded run that announces itself is worth more than a broken one, and far more than a polished one that quietly ran something else.

## "Makes no network call" is asserted, not assumed

Two tests, because the claim has two halves:

1. Stub `globalThis.fetch` to throw, run the demo, assert it completes and `fetch` was never called.
2. Force the **agent** path with a cassette count, and show replay fails with a cassette miss rather than falling through to a live request — with `fetch` still untouched.

The second is the one that makes a credential-free run trustworthy rather than lucky.

## The bundled run carries the failures worth arguing about

`demo/` holds an `analysis.json`, a `diff.patch`, and the sources of the failing specs — read by the script and passed into the pure assembler, exactly as production will.

Eight tests: a **product race** written correctly (optimistic update loses the write), a **stale selector** the diff renamed out from under it, a **port collision**, and a test that **passed on retry**, plus four ordinary passes.

The baseline calls the stale selector a regression and gives it 0.60. That is the project's entire argument showing up in its own demo output, which is a better advertisement for the eval harness than a screenshot of everything being right.

## Scope

The renderer here is deliberately small and is **not** the report writer — that is #68, with the orchestrator in #66. This exists to prove the path is joined up end to end, and says so in the file.

## Coverage now measures `scripts/demo.ts`

The directory was excluded wholesale when it held only glue. The line drawn now is **product surface in, repository maintenance out**: `changelog.ts` and `status-banner.ts` each have a `--check` mode that CI runs against the committed files, which is a stronger claim about them than a percentage. A script added later is measured by default, which is the safe direction for that list to rot in.

1138 tests, 97.6% statements. `demo.ts` at 95.8%.

## CI runs the command, not just its `main`

On a job with **no** `ANTHROPIC_API_KEY`. The unit tests already drive `main`, but only running `npm run demo` catches a rename, a missing bundled file, or a broken binary — all of which would pass the whole suite and fail the first person who tried it.

## Two small things found on the way

`eslint --no-warn-ignored` in the pre-commit hook: lint-staged passes staged paths explicitly, eslint warns when an explicitly-named file is one it ignores, and `--max-warnings=0` made that fatal — so committing the bundled fixtures failed the hook *for being ignored on purpose*.

`demo/sources/**` is excluded from linting: those files are the contents of test files in an imaginary repository, read as text and fed to a prompt. Linting them would be linting the input.