### PR TITLE
fix(docs): make the repository's claims true again after M3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,30 +18,48 @@ commitlint because a well-formed history needs them, but they are not release no
 
 ### Features
 
+- **agents:** add cassette record and replay for model calls ([#142](https://github.com/AKogut/ai-flaky-test-triage/pull/142))
 - **agents:** add Classification, RootCause and FixSuggestion schemas ([#106](https://github.com/AKogut/ai-flaky-test-triage/pull/106))
+- **agents:** add the model client every call goes through ([#140](https://github.com/AKogut/ai-flaky-test-triage/pull/140))
+- **agents:** assemble the context bundle, and split it by trust ([#145](https://github.com/AKogut/ai-flaky-test-triage/pull/145))
+- **agents:** fence, cap and scrub untrusted text before it reaches a prompt ([#143](https://github.com/AKogut/ai-flaky-test-triage/pull/143))
+- **agents:** npm run demo, on a clean clone, with no key ([#149](https://github.com/AKogut/ai-flaky-test-triage/pull/149))
+- **agents:** the triage agent, and the seam that scores it like the control ([#146](https://github.com/AKogut/ai-flaky-test-triage/pull/146))
 - **ci:** define the npm script contract ([#98](https://github.com/AKogut/ai-flaky-test-triage/pull/98))
 - **dataset:** add the golden-dataset fixture and label format ([#107](https://github.com/AKogut/ai-flaky-test-triage/pull/107))
 - **dataset:** add the golden-dataset hygiene lint ([#115](https://github.com/AKogut/ai-flaky-test-triage/pull/115))
 - **dataset:** author the 10 hard-quadrant fixtures ([#111](https://github.com/AKogut/ai-flaky-test-triage/pull/111))
 - **dataset:** author the 15 baseline golden-dataset fixtures ([#109](https://github.com/AKogut/ai-flaky-test-triage/pull/109))
 - **dataset:** author the 8 adversarial fixtures ([#114](https://github.com/AKogut/ai-flaky-test-triage/pull/114))
+- **eval:** add confusion matrices, quadrants and grouped breakdowns ([#131](https://github.com/AKogut/ai-flaky-test-triage/pull/131))
 - **eval:** add TestRun domain types and Zod schemas ([#102](https://github.com/AKogut/ai-flaky-test-triage/pull/102))
 - **eval:** add the non-LLM baseline classifier ([#110](https://github.com/AKogut/ai-flaky-test-triage/pull/110))
+- **eval:** add the run-eval CLI and commit the first report ([#135](https://github.com/AKogut/ai-flaky-test-triage/pull/135))
+- **eval:** ask whether the confidence number is worth anything ([#148](https://github.com/AKogut/ai-flaky-test-triage/pull/148))
+- **eval:** gate merges on evaluation thresholds ([#138](https://github.com/AKogut/ai-flaky-test-triage/pull/138))
+- **eval:** measure the variance instead of pretending it is not there ([#147](https://github.com/AKogut/ai-flaky-test-triage/pull/147))
 - **eval:** normalise Playwright JSON reporter output ([#103](https://github.com/AKogut/ai-flaky-test-triage/pull/103))
 - **eval:** normalise Vitest JSON reporter output ([#104](https://github.com/AKogut/ai-flaky-test-triage/pull/104))
+- **eval:** score classifiers with joint accuracy and Wilson intervals ([#128](https://github.com/AKogut/ai-flaky-test-triage/pull/128))
+- **eval:** split the dataset into development and held-out slices ([#137](https://github.com/AKogut/ai-flaky-test-triage/pull/137))
 - **flakemetry:** add FlakySignal and analysis.json schemas ([#105](https://github.com/AKogut/ai-flaky-test-triage/pull/105))
+- **prompts:** give the rubric one copy and make published versions immutable ([#144](https://github.com/AKogut/ai-flaky-test-triage/pull/144))
 - **release:** generate the changelog from Conventional Commits ([#100](https://github.com/AKogut/ai-flaky-test-triage/pull/100))
 
 ### Fixes
 
+- **agents:** cover the transport, and stop documenting a parameter that 400s ([#141](https://github.com/AKogut/ai-flaky-test-triage/pull/141))
 - **docs:** stop the wiki claiming unbuilt commands work ([#120](https://github.com/AKogut/ai-flaky-test-triage/pull/120))
 - **eval:** stop the baseline reading documentation as product source ([#113](https://github.com/AKogut/ai-flaky-test-triage/pull/113))
+- **eval:** test the guards nothing was watching, and set a coverage floor ([#139](https://github.com/AKogut/ai-flaky-test-triage/pull/139))
 
 ### Documentation
 
 - add architecture, taxonomy, evaluation methodology and ADRs ([cac77dc](https://github.com/AKogut/ai-flaky-test-triage/commit/cac77dcee2b2df2e4e6329e93df80dd2a066a5d7))
 - add wiki source pages and publish script ([98dccc8](https://github.com/AKogut/ai-flaky-test-triage/commit/98dccc82265c4dd5fbf128d6838126320082d63a))
 - derive the README status banner from ROADMAP.md ([#101](https://github.com/AKogut/ai-flaky-test-triage/pull/101))
+- **ci:** record Evaluation gate as a required check ([#136](https://github.com/AKogut/ai-flaky-test-triage/pull/136))
+- **ci:** write down who can merge and gate CI for outside contributors ([#133](https://github.com/AKogut/ai-flaky-test-triage/pull/133))
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ Everything else runs today. `npm run help` prints this table from the terminal.
 │   └── CODEOWNERS
 ├── contracts/                   # Zod schemas + inferred types for every artifact
 │                                #   the pipeline reads or writes
+├── prompts/                     # versioned prompt files + the rubric they share
+│                                #   with docs/taxonomy.md, and the loader
+├── demo/                        # the bundled run `npm run demo` classifies
 ├── app/                         # TaskFlow — the system under test
 │   ├── client/                  # React + TypeScript
 │   └── server/                  # Express + SQLite

--- a/agents/replay/cassettes/README.md
+++ b/agents/replay/cassettes/README.md
@@ -4,7 +4,10 @@ Recorded model responses, committed so the pipeline runs with no API key and no 
 claim [ADR-0005](../../../docs/adr/0005-replay-cassettes-for-credential-free-demo.md) exists to
 make true, and what makes the integration tests free and deterministic.
 
-Empty until the triage agent lands in #35. The machinery that reads and writes these files is
+Empty until the first recorded evaluation lands in #38 — recording needs credentials, so it is a
+deliberate act with a cost rather than something that happens on the way past. Until then
+`npm run demo` runs the model-free baseline and says so, and the integration tests drive the agent
+through stub transports instead. The machinery that reads and writes these files is
 `agents/cassettes.ts`.
 
 ## Recording

--- a/docs/adr/0005-replay-cassettes-for-credential-free-demo.md
+++ b/docs/adr/0005-replay-cassettes-for-credential-free-demo.md
@@ -34,10 +34,18 @@ in the environment to detect. Somebody authenticated that way would silently get
 what `SENTRA_LIVE=1` exists to override.
 
 Cassettes live in `agents/replay/cassettes/`, are committed, and are keyed by a stable hash of
-(prompt version, model, normalised request body). A replay miss is a loud error, never a silent
-fallthrough to a live call.
+(prompt version, model, effort, token ceiling, response-schema digest, system, prompt, **sample
+index**). A replay miss is a loud error, never a silent fallthrough to a live call.
 
-`npm run demo` runs the full pipeline in replay mode against a bundled fixture run.
+The sample index is in the key because self-consistency sampling (#36) asks the same question five
+times and the answers differ. Without it every sample of a fixture would hash to one cassette,
+replay would hand back the same answer five times, and the harness would report perfect stability
+for a classifier nobody measured. A recorded distribution has to replay as a distribution.
+
+`npm run demo` runs the full pipeline against a bundled fixture run. Until the first recorded
+evaluation lands (#38) there is nothing to replay, so it runs the model-free baseline and prints
+that — the demo degrades honestly rather than failing on a clean clone, which is the one thing it
+exists not to do.
 
 ## Options considered
 

--- a/eval/run-eval.ts
+++ b/eval/run-eval.ts
@@ -314,10 +314,12 @@ export async function evaluate(options: Options, deps: ClassifierDeps = {}): Pro
     const { payload, hash } = loadPayload(name)
     const labels = loadLabels(name)
 
-    // Sample-major per fixture rather than run-major over the dataset: a budget
-    // that runs out then leaves whole fixtures unscored instead of leaving every
-    // fixture with a different number of samples, which nothing downstream could
-    // interpret.
+    // All N samples of a fixture before moving on, rather than sweeping the
+    // dataset N times. It changes which fixtures a run reaches when it stops
+    // early — a budget ceiling or a refusal aborts the whole evaluation today,
+    // so nothing is half-scored, and if that ever becomes a partial result it
+    // will be whole fixtures missing rather than every fixture carrying a
+    // different number of samples, which nothing downstream could interpret.
     const samples: Prediction[] = []
     let reasoning = ''
     for (let sample = 0; sample < options.samples; sample++) {

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -16,6 +16,7 @@
  */
 import { execFileSync } from 'node:child_process'
 import { readFileSync, writeFileSync } from 'node:fs'
+import { format } from 'prettier'
 
 const REPO = 'https://github.com/AKogut/ai-flaky-test-triage'
 const START = '<!-- changelog:start -->'
@@ -144,7 +145,7 @@ function git(args: string[], { quiet = false }: { quiet?: boolean } = {}): strin
   })
 }
 
-function main(): void {
+async function main(): Promise<void> {
   const all = process.argv.includes('--all')
   const check = process.argv.includes('--check')
 
@@ -170,7 +171,12 @@ function main(): void {
 
   const generated = renderChangelog(parseCommits(raw), heading)
   const existing = readFileSync('CHANGELOG.md', 'utf8')
-  const next = splice(existing, generated)
+
+  // Formatted before it is compared or written, for the same reason
+  // eval/report.md is: this file sits in a tree `npm run format:check` reads, so
+  // output Prettier would rewrite breaks CI on the commit that regenerates it —
+  // and `--check` would report a diff that is only whitespace.
+  const next = await format(splice(existing, generated), { parser: 'markdown' })
 
   if (check) {
     if (next !== existing) {
@@ -185,4 +191,4 @@ function main(): void {
   console.log(`CHANGELOG.md regenerated (${heading})`)
 }
 
-if (process.argv[1]?.endsWith('changelog.ts') === true) main()
+if (process.argv[1]?.endsWith('changelog.ts') === true) await main()

--- a/scripts/demo.ts
+++ b/scripts/demo.ts
@@ -174,13 +174,13 @@ function render(
     '| ---- | ------- | ---------: | --- |',
     ...sorted.map((row) => {
       const { owner, determinism, confidence, reasoning } = row.classification
-      return `| \`${row.subject.result.title}\` | ${QUADRANT[`${owner}/${determinism}`] ?? ''} <br> \`${owner}\` + \`${determinism}\` | ${confidence.toFixed(2)} | ${escape(reasoning)} |`
+      return `| ${escape(row.subject.result.title)} | ${QUADRANT[`${owner}/${determinism}`] ?? ''} <br> \`${owner}\` + \`${determinism}\` | ${confidence.toFixed(2)} | ${escape(reasoning)} |`
     }),
     '',
     ...sorted.flatMap((row) => [
-      `### \`${row.subject.result.title}\``,
+      `### ${escape(row.subject.result.title)}`,
       '',
-      `\`${row.subject.result.file}\` — ${row.subject.result.status}, ` +
+      `${escape(row.subject.result.file)} — ${row.subject.result.status}, ` +
         `${String(row.subject.result.attempts)} attempt(s), history \`${row.subject.signal.statusHistory}\``,
       '',
       'Evidence the classifier says it relied on:',
@@ -197,15 +197,24 @@ const order = (row: Row): number =>
 const name = (row: Row): string => row.subject.result.testId
 
 /**
- * Agent output is escaped before it reaches markdown.
+ * Everything the repository wrote is escaped before it reaches markdown.
  *
- * Every string in a classification originates in text a contributor wrote, so an
- * unescaped one can forge a table row or open a `<details>` the report never
- * closed. The worst case is cosmetic, which is exactly why it would go
- * unnoticed.
+ * Agent output *and* the run's own strings. Test titles and file paths are as
+ * attacker-controlled as a classification is — a fork pull request names its own
+ * tests — and escaping only the model's half is the version of this that looks
+ * careful and is not. The first draft here did exactly that.
+ *
+ * Backticks are neutralised rather than escaped, and untrusted strings are not
+ * wrapped in code spans. A backslash does not escape a backtick inside a code
+ * span, so `\`` in a title would end the span and let everything after it render
+ * as markup; there is no way to make a code span safe for arbitrary text, so it
+ * is not used for arbitrary text.
+ *
+ * The worst achievable outcome is a mangled report, which is precisely why it
+ * would go unnoticed.
  */
 const escape = (text: string): string =>
-  text.replaceAll('|', '\\|').replaceAll('<', '&lt;').replaceAll('\n', ' ')
+  text.replaceAll('|', '\\|').replaceAll('<', '&lt;').replaceAll('`', '&#96;').replaceAll('\n', ' ')
 
 if (process.argv[1]?.endsWith('demo.ts') === true) {
   process.exitCode = await main()

--- a/tests/unit/changelog.test.ts
+++ b/tests/unit/changelog.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { format } from 'prettier'
 import { describe, expect, it } from 'vitest'
 import {
   FIELD_SEP,
@@ -133,5 +135,26 @@ describe('splice', () => {
 
   it('refuses to guess when the markers are missing', () => {
     expect(() => splice('# Changelog\n', 'x')).toThrow(/markers/)
+  })
+})
+
+/**
+ * The generator writes into a tree `npm run format:check` reads.
+ *
+ * It did not always format its output, so `npm run changelog` — a documented
+ * release step — produced a file Prettier would rewrite, and `--check` reported
+ * a difference that was only a blank line. A release step that breaks the
+ * formatting gate is a release step somebody skips.
+ */
+describe('the committed changelog', () => {
+  it('is formatted the way Prettier formats it', async () => {
+    const committed = readFileSync('CHANGELOG.md', 'utf8')
+    expect(await format(committed, { parser: 'markdown' })).toBe(committed)
+  })
+
+  it('still carries the markers regeneration splices between', () => {
+    const committed = readFileSync('CHANGELOG.md', 'utf8')
+    expect(committed).toContain('<!-- changelog:start -->')
+    expect(committed).toContain('<!-- changelog:end -->')
   })
 })

--- a/tests/unit/demo.test.ts
+++ b/tests/unit/demo.test.ts
@@ -109,6 +109,54 @@ describe('running the demo', () => {
   })
 })
 
+/**
+ * Test titles and file paths are as attacker-controlled as a classification is —
+ * a fork pull request names its own tests. Escaping only the model's half is the
+ * version of this that looks careful and is not, and the first draft did exactly
+ * that.
+ */
+describe('escaping what the repository wrote', () => {
+  const hostile = (title: string): Parameters<typeof main>[0] => ({
+    read: (path: string) => {
+      const raw = readFileSync(path, 'utf8')
+      if (!path.endsWith('analysis.json')) return raw
+      const doc = JSON.parse(raw) as { tests: { result: { title: string } }[] }
+      const first = doc.tests[0]
+      if (first) first.result.title = title
+      return JSON.stringify(doc)
+    },
+  })
+
+  it('cannot let a title forge a table row', async () => {
+    await run(hostile('renders | evil | 1.00 | injected row'))
+    const report = written.get(OUTPUT) ?? ''
+    expect(report).toContain('renders \\| evil')
+    // Every row still has the four cells the header declares.
+    for (const line of report.split('\n').filter((l) => l.startsWith('| ') && !l.includes('---'))) {
+      expect(line.split(/(?<!\\)\|/).filter((cell) => cell.trim() !== '')).toHaveLength(4)
+    }
+  })
+
+  /**
+   * A backslash does not escape a backtick inside a code span, so a title
+   * wrapped in one could end the span and let the rest render as markup. The
+   * answer is not to wrap arbitrary text in code spans at all.
+   */
+  it('cannot let a title escape a code span', async () => {
+    await run(hostile('renders ` <img src=x> `'))
+    const report = written.get(OUTPUT) ?? ''
+    expect(report).toContain('&#96;')
+    expect(report).toContain('&lt;img')
+    expect(report).not.toContain('<img')
+  })
+
+  it('keeps an injected heading out of the document structure', async () => {
+    await run(hostile('renders\n\n## Verdict: everything is fine'))
+    const report = written.get(OUTPUT) ?? ''
+    expect(report.split('\n').filter((line) => line.startsWith('## '))).toEqual([])
+  })
+})
+
 describe('which classifier the demo can run', () => {
   it('replays recorded responses when there are any', () => {
     expect(pick('replay', 12)).toMatchObject({ classifier: 'agent' })


### PR DESCRIPTION
An audit pass over what the project asserts about itself. Four real findings, each fixed rather than noted.

## The demo escaped the model's output and not the run's own strings

`scripts/demo.ts` carefully escaped `reasoning` and `evidence` — and interpolated test titles and file paths raw, inside code spans.

Those are **equally attacker-controlled**: a fork pull request names its own tests. Escaping only the model's half is the version of this that looks careful and is not.

Two fixes:

- Titles and paths go through `escape()` like everything else.
- Backticks are neutralised (`&#96;`) and untrusted text is **no longer wrapped in code spans at all**. A backslash does not escape a backtick inside a code span, so a title containing one would end the span and let the rest render as markup. There is no way to make a code span safe for arbitrary text, so it is not used for arbitrary text.

Three tests pin the properties — a forged table row, an escaped code span, an injected `##` heading — and **all three fail against the previous code**; I checked by reverting the fix.

## `npm run changelog` broke `npm run format:check`

The generator wrote output Prettier would rewrite. So the documented release step failed the formatting gate on the very commit that ran it, and `changelog:check` reported a difference that turned out to be a single blank line.

It now formats what it writes, exactly as the eval report already did, and a test asserts the committed file is Prettier-stable.

## The changelog was thirteen entries behind

Regenerated. Deliberately **not** wired into per-PR CI: `docs/branching-strategy.md` already states that it is regenerated by hand at release rather than per PR, and gives the reason (merge conflicts on a shared generated file). A new gate here would contradict a decision the project already made and wrote down. The finding is the drift; the fix is the regeneration.

## Three stale claims

- `agents/replay/cassettes/README.md` said "empty until the triage agent lands in #35" — #35 landed. It now says what is actually true: empty until the first recorded evaluation in #38, because recording costs money and is a deliberate act.
- **ADR-0005** described a cassette key that no longer matches the code — the sample index joined it in #36, and that is a substantive decision worth recording, not an implementation detail. It also promised a demo behaviour that changed: the demo now degrades to the baseline rather than failing when there is nothing to replay.
- The README's repository layout omitted `prompts/` and `demo/`, both of which are real directories now.

## One comment that claimed a benefit the code does not deliver

`evaluate` samples fixture-major, and the comment said this leaves whole fixtures unscored when a budget runs out — but a budget ceiling aborts the entire evaluation, so nothing is half-scored. Reworded to say what is true today and what the ordering would buy if partial results ever exist.

## Housekeeping

#38 and #40 move from `status: backlog` to `status: ready`. Both are specified and unblocked; #38's only dependency is a decision about spending, not about code.

## Verification

1143 tests, 97.6% statements. `lint`, `typecheck`, `format:check`, `docs:status:check`, `eval:lint`, `eval -- --gate` and `changelog:check` all clean.