### PR TITLE
feat(server): TaskFlow's API — five routes, one table, no service layer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,15 @@ updates:
         patterns: ['vitest', '@vitest/*', '@playwright/*', 'playwright']
       otel:
         patterns: ['@opentelemetry/*']
+      # TaskFlow's runtime. Grouped because it is the system under test rather
+      # than the product: a bump here can only break the application the pipeline
+      # is pointed at, and reviewing those together is the whole of the review.
+      taskflow:
+        patterns:
+          - 'express'
+          - '@types/express'
+          - 'better-sqlite3'
+          - '@types/better-sqlite3'
     ignore:
       # The SDK version is pinned deliberately — a bump can move classifier behaviour,
       # so it is upgraded manually with an eval run attached to the PR.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ yarn-error.log*
 .eslintcache
 /eval/report-all.md
 /eval/metrics-all.json
+
+# TaskFlow's development database. State, not source — the seed script rebuilds it.
+.taskflow/

--- a/app/server/api.test.ts
+++ b/app/server/api.test.ts
@@ -1,0 +1,329 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { createApp } from './app.js'
+import { clear, open, type Db } from './db.js'
+import { serve } from './index.js'
+import { seed, SEED, SEED_TIME } from './seed.js'
+
+/**
+ * The API over real HTTP, on a real port.
+ *
+ * Not because a request object could not be faked, but because everything that
+ * consumes this API — the client, the Playwright specs, the flaky ones
+ * especially — reaches it that way. A test that calls the handler directly
+ * verifies the handler; the interesting failures in an app that exists to be
+ * flaky live in the layer above it: status codes, JSON parsing, what a malformed
+ * body does.
+ *
+ * `listen(0)` for the port. Hard-coding one would make this suite fail whenever
+ * a dev server was running, which is a flaky test with a very boring cause — in
+ * a repository about flaky tests.
+ */
+
+const db: Db = open(':memory:')
+const server = createApp({ db, now: () => SEED_TIME }).listen(0)
+const port = (server.address() as { port: number }).port
+const base = `http://127.0.0.1:${String(port)}`
+
+const api = async (
+  path: string,
+  init: RequestInit = {},
+): Promise<{ status: number; body: unknown }> => {
+  const response = await fetch(`${base}${path}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', ...init.headers },
+  })
+  const text = await response.text()
+  return { status: response.status, body: text === '' ? null : JSON.parse(text) }
+}
+
+const post = (path: string, body: unknown): ReturnType<typeof api> =>
+  api(path, { method: 'POST', body: JSON.stringify(body) })
+const patch = (path: string, body: unknown): ReturnType<typeof api> =>
+  api(path, { method: 'PATCH', body: JSON.stringify(body) })
+
+interface TaskBody {
+  task: { id: number; title: string; description: string; status: string; position: number }
+}
+interface ListBody {
+  tasks: TaskBody['task'][]
+}
+
+beforeEach(() => {
+  clear(db)
+})
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+  db.close()
+})
+
+describe('reading', () => {
+  it('answers health without touching the database', async () => {
+    expect(await api('/api/health')).toEqual({ status: 200, body: { status: 'ok' } })
+  })
+
+  it('starts empty', async () => {
+    expect(await api('/api/tasks')).toEqual({ status: 200, body: { tasks: [] } })
+  })
+
+  it('returns one task by id', async () => {
+    const created = (await post('/api/tasks', { title: 'read me' })).body as TaskBody
+    const found = await api(`/api/tasks/${String(created.task.id)}`)
+    expect((found.body as TaskBody).task.title).toBe('read me')
+  })
+
+  it('404s for an id that is not there', async () => {
+    expect((await api('/api/tasks/999')).status).toBe(404)
+  })
+
+  /** `/api/tasks/abc` reaching the database as `NaN` is how a 404 becomes a 500. */
+  it('404s for an id that is not a number', async () => {
+    expect((await api('/api/tasks/abc')).status).toBe(404)
+    expect((await api('/api/tasks/-1')).status).toBe(404)
+  })
+
+  it('404s for a route nobody defined', async () => {
+    const response = await api('/api/nope')
+    expect(response.status).toBe(404)
+    expect(response.body).toMatchObject({ error: { code: 'not_found' } })
+  })
+})
+
+describe('creating', () => {
+  it('returns 201 and the created task', async () => {
+    const response = await post('/api/tasks', { title: 'write the postmortem' })
+    expect(response.status).toBe(201)
+    expect((response.body as TaskBody).task).toMatchObject({
+      title: 'write the postmortem',
+      description: '',
+      status: 'active',
+      position: 1,
+    })
+  })
+
+  it('appends to the end of the list', async () => {
+    await post('/api/tasks', { title: 'first' })
+    await post('/api/tasks', { title: 'second' })
+    const positions = ((await api('/api/tasks')).body as ListBody).tasks.map((t) => t.position)
+    expect(positions).toEqual([1, 2])
+  })
+
+  it('trims a title rather than storing the whitespace', async () => {
+    const response = await post('/api/tasks', { title: '  padded  ' })
+    expect((response.body as TaskBody).task.title).toBe('padded')
+  })
+
+  it.each([
+    ['no title', {}],
+    ['an empty title', { title: '' }],
+    ['a whitespace title', { title: '   ' }],
+    ['a title of the wrong type', { title: 42 }],
+  ])('rejects %s', async (_case, body) => {
+    const response = await post('/api/tasks', body)
+    expect(response.status).toBe(400)
+    expect(response.body).toMatchObject({ error: { code: 'invalid_request' } })
+  })
+
+  /**
+   * A silently ignored field is how a test asserts on something the server never
+   * stored, then fails a week later for reasons nobody can reconstruct.
+   */
+  it('rejects a field it does not know, rather than ignoring it', async () => {
+    const response = await post('/api/tasks', { title: 'ok', colour: 'red' })
+    expect(response.status).toBe(400)
+    const details = (response.body as { error: { details: { path: string }[] } }).error.details
+    expect(details.map((d) => d.path)).toContain('colour')
+  })
+
+  it('names the field in a 400, so the caller knows what to change', async () => {
+    const response = await post('/api/tasks', { title: '' })
+    const details = (response.body as { error: { details: { path: string }[] } }).error.details
+    expect(details[0]?.path).toBe('title')
+  })
+
+  it('answers a malformed body with 400, not a stack trace', async () => {
+    const response = await fetch(`${base}/api/tasks`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{ not json',
+    })
+    expect(response.status).toBe(400)
+    expect(await response.json()).toMatchObject({ error: { code: 'invalid_json' } })
+  })
+})
+
+describe('updating', () => {
+  const create = async (): Promise<number> =>
+    ((await post('/api/tasks', { title: 'original' })).body as TaskBody).task.id
+
+  it('changes only what the patch names', async () => {
+    const id = await create()
+    await patch(`/api/tasks/${String(id)}`, { description: 'now with detail' })
+    const task = ((await api(`/api/tasks/${String(id)}`)).body as TaskBody).task
+    expect(task).toMatchObject({ title: 'original', description: 'now with detail' })
+  })
+
+  it('404s for an id that is not there', async () => {
+    expect((await patch('/api/tasks/999', { title: 'ghost' })).status).toBe(404)
+  })
+
+  /** `PATCH {}` would touch `updated_at`, answer 200, and tell the caller the write worked. */
+  it('rejects an empty patch', async () => {
+    const id = await create()
+    expect((await patch(`/api/tasks/${String(id)}`, {})).status).toBe(400)
+  })
+
+  it('rejects a status it does not have', async () => {
+    const id = await create()
+    expect((await patch(`/api/tasks/${String(id)}`, { status: 'nearly' })).status).toBe(400)
+  })
+
+  it('completes a task through its own route', async () => {
+    const id = await create()
+    const response = await patch(`/api/tasks/${String(id)}/complete`, {})
+    expect(response.status).toBe(200)
+    expect((response.body as TaskBody).task.status).toBe('completed')
+  })
+
+  it('404s when completing something that is gone', async () => {
+    expect((await patch('/api/tasks/999/complete', {})).status).toBe(404)
+  })
+})
+
+describe('deleting', () => {
+  it('returns 204 and removes the row', async () => {
+    const id = ((await post('/api/tasks', { title: 'temporary' })).body as TaskBody).task.id
+    expect((await api(`/api/tasks/${String(id)}`, { method: 'DELETE' })).status).toBe(204)
+    expect((await api(`/api/tasks/${String(id)}`)).status).toBe(404)
+  })
+
+  it('404s the second time, because there is nothing left to delete', async () => {
+    const id = ((await post('/api/tasks', { title: 'temporary' })).body as TaskBody).task.id
+    await api(`/api/tasks/${String(id)}`, { method: 'DELETE' })
+    expect((await api(`/api/tasks/${String(id)}`, { method: 'DELETE' })).status).toBe(404)
+  })
+})
+
+describe('ordering', () => {
+  it('sorts by position', async () => {
+    await post('/api/tasks', { title: 'third', position: 3 })
+    await post('/api/tasks', { title: 'first', position: 1 })
+    await post('/api/tasks', { title: 'second', position: 2 })
+
+    const titles = ((await api('/api/tasks')).body as ListBody).tasks.map((t) => t.title)
+    expect(titles).toEqual(['first', 'second', 'third'])
+  })
+
+  it('accepts a fractional position, which is what makes reordering one write', async () => {
+    await post('/api/tasks', { title: 'a', position: 1 })
+    await post('/api/tasks', { title: 'c', position: 2 })
+    await post('/api/tasks', { title: 'b', position: 1.5 })
+
+    const titles = ((await api('/api/tasks')).body as ListBody).tasks.map((t) => t.title)
+    expect(titles).toEqual(['a', 'b', 'c'])
+  })
+
+  /**
+   * `position-collision-orders-by-insertion-id` in the golden dataset is a real
+   * failure this application is meant to be able to produce, so the tie-break has
+   * to be defined rather than left to SQLite.
+   */
+  it('breaks a tie by insertion order', async () => {
+    await post('/api/tasks', { title: 'earlier', position: 1 })
+    await post('/api/tasks', { title: 'later', position: 1 })
+
+    const titles = ((await api('/api/tasks')).body as ListBody).tasks.map((t) => t.title)
+    expect(titles).toEqual(['earlier', 'later'])
+  })
+})
+
+describe('the seed', () => {
+  it('produces the same ids and the same order every time', () => {
+    const first = seed(db).map((task) => ({ id: task.id, title: task.title }))
+    const second = seed(db).map((task) => ({ id: task.id, title: task.title }))
+    expect(second).toEqual(first)
+    expect(first[0]?.id).toBe(1)
+  })
+
+  /**
+   * A seed on the wall clock makes every snapshot depend on when the suite ran,
+   * and the failures look exactly like the flakiness this project classifies —
+   * except they would be the fixture's fault, which is the one kind of noise the
+   * dataset must not contain.
+   */
+  it('uses a fixed timestamp rather than the clock', () => {
+    expect(seed(db).map((task) => task.createdAt)).toEqual(SEED.map(() => SEED_TIME))
+  })
+
+  it('leaves one task completed, so a status filter has something to hide', () => {
+    expect(seed(db).filter((task) => task.status === 'completed')).toHaveLength(1)
+  })
+
+  it('replaces whatever was there rather than appending', () => {
+    seed(db)
+    expect(seed(db)).toHaveLength(SEED.length)
+  })
+})
+
+/**
+ * The one thing a 500 must not do is explain itself.
+ *
+ * Express's default handler renders the stack into the response body, which on
+ * an application whose failures are meant to be *read by an AI triage agent*
+ * would put a server stack trace into a prompt and into a public PR comment.
+ */
+describe('when something unexpected breaks', () => {
+  it('answers 500 without leaking the stack', async () => {
+    const broken = createApp({
+      db: {
+        prepare: () => {
+          throw new Error('the disk is on fire at /Users/someone/secrets')
+        },
+      } as unknown as Db,
+    })
+    const listening = broken.listen(0)
+    const brokenPort = (listening.address() as { port: number }).port
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${String(brokenPort)}/api/tasks`)
+      expect(response.status).toBe(500)
+      const body = await response.text()
+      expect(JSON.parse(body)).toEqual({
+        error: { code: 'internal', message: 'something went wrong' },
+      })
+      expect(body).not.toContain('disk is on fire')
+      expect(body).not.toContain('/Users/')
+    } finally {
+      await new Promise<void>((resolve) => listening.close(() => resolve()))
+    }
+  })
+})
+
+/**
+ * E2E setup time is paid on every run, by every spec, forever. A server that
+ * takes three seconds to come up is three seconds added to the feedback loop the
+ * whole project is about shortening — so the budget is asserted rather than
+ * assumed.
+ */
+describe('starting up', () => {
+  it('binds and answers in well under a second', async () => {
+    const started = Date.now()
+    const running = serve({ port: 0, database: ':memory:', reseed: true, log: () => undefined })
+
+    const response = await fetch(`http://127.0.0.1:${String(running.port)}/api/tasks`)
+    const elapsed = Date.now() - started
+    const body = (await response.json()) as ListBody
+
+    await running.close()
+
+    expect(body.tasks).toHaveLength(SEED.length)
+    expect(elapsed).toBeLessThan(1000)
+  })
+
+  it('picks a free port when asked for one, so a running dev server is not a failure', async () => {
+    const a = serve({ port: 0, database: ':memory:', log: () => undefined })
+    const b = serve({ port: 0, database: ':memory:', log: () => undefined })
+    expect(a.port).not.toBe(b.port)
+    await Promise.all([a.close(), b.close()])
+  })
+})

--- a/app/server/app.ts
+++ b/app/server/app.ts
@@ -1,0 +1,175 @@
+import express, { type Express, type NextFunction, type Request, type Response } from 'express'
+import { z } from 'zod'
+import { create, find, list, remove, update, type Db, type Task } from './db.js'
+
+/**
+ * The TaskFlow API. Five routes, no service layer, no abstraction to speak of.
+ *
+ * Routes talk to the database module directly, which for an application this
+ * size is not a shortcut but the honest shape: a layer whose every method
+ * forwards one call is a layer that makes the code longer and the behaviour no
+ * clearer.
+ *
+ * Two things here are not throwaway, because the rest of the project depends on
+ * them. Validation is by schema and rejects unknown keys, so a client typo is a
+ * 400 rather than a silently ignored field — a test asserting on a field the
+ * server never stored is a flaky test with a very boring cause. And every error
+ * has the same shape, so the client has one thing to render and the E2E specs
+ * have one thing to assert on.
+ */
+
+export interface AppDeps {
+  db: Db
+  /** Injected so a test can pin timestamps rather than assert around them. */
+  now?: () => string
+}
+
+const TitleSchema = z.string().trim().min(1).max(200)
+
+const CreateSchema = z
+  .object({
+    title: TitleSchema,
+    description: z.string().max(2000).optional(),
+    position: z.number().finite().optional(),
+  })
+  .strict()
+
+/**
+ * At least one field, because `PATCH {}` is almost always a bug at the caller.
+ *
+ * Accepting it would touch `updated_at` and return 200, and the client would
+ * conclude the write worked.
+ */
+const PatchSchema = z
+  .object({
+    title: TitleSchema.optional(),
+    description: z.string().max(2000).optional(),
+    status: z.enum(['active', 'completed']).optional(),
+    position: z.number().finite().optional(),
+  })
+  .strict()
+  .refine((patch) => Object.keys(patch).length > 0, {
+    message: 'a patch must change at least one field',
+  })
+
+export interface ApiError {
+  error: { code: string; message: string; details?: unknown }
+}
+
+export function createApp(deps: AppDeps): Express {
+  const { db } = deps
+  const now = deps.now ?? (() => new Date().toISOString())
+
+  const app = express()
+  app.use(express.json({ limit: '64kb' }))
+
+  app.get('/api/health', (_request, response) => {
+    response.json({ status: 'ok' })
+  })
+
+  app.get('/api/tasks', (_request, response) => {
+    response.json({ tasks: list(db) })
+  })
+
+  app.get('/api/tasks/:id', (request, response) => {
+    const task = byId(db, request, response)
+    if (task !== null) response.json({ task })
+  })
+
+  app.post('/api/tasks', (request, response) => {
+    const parsed = CreateSchema.safeParse(request.body)
+    if (!parsed.success) return invalid(response, parsed.error)
+
+    response.status(201).json({ task: create(db, parsed.data, now()) })
+  })
+
+  app.patch('/api/tasks/:id', (request, response) => {
+    const parsed = PatchSchema.safeParse(request.body)
+    if (!parsed.success) return invalid(response, parsed.error)
+
+    const id = identifier(request)
+    const updated = id === null ? null : update(db, id, parsed.data, now())
+    if (updated === null) return notFound(response)
+    response.json({ task: updated })
+  })
+
+  /**
+   * Its own route rather than `PATCH {status}`.
+   *
+   * The client's completion path is the one that races a title save, and giving
+   * it a distinct endpoint is what lets the chaos layer in #47 delay exactly
+   * that request without touching every other write.
+   */
+  app.patch('/api/tasks/:id/complete', (request, response) => {
+    const id = identifier(request)
+    const updated = id === null ? null : update(db, id, { status: 'completed' }, now())
+    if (updated === null) return notFound(response)
+    response.json({ task: updated })
+  })
+
+  app.delete('/api/tasks/:id', (request, response) => {
+    const id = identifier(request)
+    if (id === null || !remove(db, id)) return notFound(response)
+    response.status(204).end()
+  })
+
+  app.use((_request, response) => {
+    response.status(404).json(error('not_found', 'no such route'))
+  })
+
+  // Four parameters, because that is how Express recognises an error handler —
+  // dropping the unused `next` turns this into ordinary middleware that never
+  // runs, and every malformed body becomes an HTML stack trace.
+  app.use((thrown: Error, _request: Request, response: Response, _next: NextFunction) => {
+    const status = 'status' in thrown && typeof thrown.status === 'number' ? thrown.status : 500
+    response
+      .status(status === 400 ? 400 : 500)
+      .json(
+        status === 400
+          ? error('invalid_json', 'the request body is not valid JSON')
+          : error('internal', 'something went wrong'),
+      )
+  })
+
+  return app
+}
+
+const identifier = (request: Request): number | null => {
+  const id = Number(request.params.id)
+  return Number.isInteger(id) && id > 0 ? id : null
+}
+
+function byId(db: Db, request: Request, response: Response): Task | null {
+  const id = identifier(request)
+  const task = id === null ? null : find(db, id)
+  if (task === null) {
+    notFound(response)
+    return null
+  }
+  return task
+}
+
+const error = (code: string, message: string, details?: unknown): ApiError => ({
+  error: { code, message, ...(details !== undefined && { details }) },
+})
+
+const notFound = (response: Response): void => {
+  response.status(404).json(error('not_found', 'no task with that id'))
+}
+
+/**
+ * The field paths, so a 400 says what to change rather than that something is wrong.
+ *
+ * An unrecognised key is reported per key rather than as one issue at the root,
+ * which is where Zod puts it. `path: ""` with the offending name buried in a
+ * sentence is the difference between a caller fixing a typo and a caller reading
+ * the source.
+ */
+const invalid = (response: Response, failure: z.ZodError): void => {
+  const details = failure.issues.flatMap((issue) =>
+    issue.code === 'unrecognized_keys'
+      ? issue.keys.map((key) => ({ path: key, message: 'unrecognised field' }))
+      : [{ path: issue.path.join('.'), message: issue.message }],
+  )
+  response.status(400).json(error('invalid_request', 'the request body is not valid', details))
+}

--- a/app/server/db.ts
+++ b/app/server/db.ts
@@ -1,0 +1,178 @@
+import Database from 'better-sqlite3'
+
+/**
+ * TaskFlow's database. One file, one table, no migrations framework.
+ *
+ * TaskFlow is the system under test, not the product. It exists to produce
+ * genuine async-UI flakiness for the pipeline to triage, and every hour spent
+ * making it good software is an hour not spent on the part of the project that
+ * carries the value. So: no auth, no pagination, no soft deletes, no service
+ * layer, and a schema that fits on a screen.
+ *
+ * `better-sqlite3` rather than `node:sqlite`, which would have been one fewer
+ * dependency. Node 22 — the floor this repository sets, and the version CI pins
+ * — still prints an ExperimentalWarning for the built-in on every process start.
+ * A warning on every test run is noise, and noise on stderr is how people learn
+ * to stop reading stderr.
+ */
+
+export interface Task {
+  id: number
+  title: string
+  description: string
+  status: 'active' | 'completed'
+  /**
+   * Sort key, fractional on purpose.
+   *
+   * Reordering (#42) then means writing one row rather than renumbering the
+   * list, and a client that drops an item between two neighbours can compute the
+   * midpoint without asking. Ties are possible and are broken by `id` — which is
+   * not a detail: `position-collision-orders-by-insertion-id` in the golden
+   * dataset is a real failure this application is meant to be able to produce.
+   */
+  position: number
+  createdAt: string
+  updatedAt: string
+}
+
+const SCHEMA = `
+  CREATE TABLE IF NOT EXISTS tasks (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    title       TEXT    NOT NULL,
+    description TEXT    NOT NULL DEFAULT '',
+    status      TEXT    NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'completed')),
+    position    REAL    NOT NULL,
+    created_at  TEXT    NOT NULL,
+    updated_at  TEXT    NOT NULL
+  );
+`
+
+export type Db = Database.Database
+
+/**
+ * Open a database and make sure the schema is there.
+ *
+ * The path is a parameter with no default, so a test cannot reach the
+ * development database by forgetting to set something. `:memory:` is the usual
+ * argument in tests; the CLI passes a real file.
+ */
+export function open(path: string): Db {
+  const db = new Database(path)
+
+  // Without this SQLite runs with foreign keys off and, more importantly here,
+  // with a rollback journal — WAL is what lets a read during a write return
+  // rather than block, which is the behaviour the flaky specs need to exist.
+  db.pragma('journal_mode = WAL')
+  db.pragma('foreign_keys = ON')
+  db.exec(SCHEMA)
+  return db
+}
+
+/** Every row, oldest position first. Ties break by insertion order — see `Task.position`. */
+export function list(db: Db): Task[] {
+  return rows(db.prepare('SELECT * FROM tasks ORDER BY position ASC, id ASC').all())
+}
+
+export function find(db: Db, id: number): Task | null {
+  const row = db.prepare('SELECT * FROM tasks WHERE id = ?').get(id)
+  return row === undefined ? null : toTask(row)
+}
+
+/**
+ * `| undefined` on each optional field, not just `?`.
+ *
+ * `exactOptionalPropertyTypes` is on, so `{ description: undefined }` and
+ * `{}` are different types — and a parsed request body produces the first.
+ * Writing it out here is what lets a route hand its validated input straight in
+ * rather than reassembling the object to satisfy the compiler.
+ */
+export interface NewTask {
+  title: string
+  description?: string | undefined
+  /** Appended to the end when absent, which is what a list UI means by "add". */
+  position?: number | undefined
+}
+
+export function create(db: Db, task: NewTask, now: string): Task {
+  const position = task.position ?? nextPosition(db)
+  const { lastInsertRowid } = db
+    .prepare(
+      `INSERT INTO tasks (title, description, status, position, created_at, updated_at)
+       VALUES (?, ?, 'active', ?, ?, ?)`,
+    )
+    .run(task.title, task.description ?? '', position, now, now)
+
+  const created = find(db, Number(lastInsertRowid))
+  if (created === null) throw new Error('the row that was just inserted is not there')
+  return created
+}
+
+export interface TaskPatch {
+  title?: string | undefined
+  description?: string | undefined
+  status?: Task['status'] | undefined
+  position?: number | undefined
+}
+
+/** Null when the row does not exist, so the route can answer 404 without a second query. */
+export function update(db: Db, id: number, patch: TaskPatch, now: string): Task | null {
+  const existing = find(db, id)
+  if (existing === null) return null
+
+  db.prepare(
+    `UPDATE tasks SET title = ?, description = ?, status = ?, position = ?, updated_at = ?
+     WHERE id = ?`,
+  ).run(
+    patch.title ?? existing.title,
+    patch.description ?? existing.description,
+    patch.status ?? existing.status,
+    patch.position ?? existing.position,
+    now,
+    id,
+  )
+  return find(db, id)
+}
+
+/** True when a row was deleted. False means it was already gone, which is not an error twice. */
+export function remove(db: Db, id: number): boolean {
+  return db.prepare('DELETE FROM tasks WHERE id = ?').run(id).changes > 0
+}
+
+export function clear(db: Db): void {
+  db.exec('DELETE FROM tasks')
+  // AUTOINCREMENT keeps its high-water mark in sqlite_sequence, so a seeded
+  // database would otherwise hand out different ids on every reseed and no
+  // fixture could name a row.
+  db.exec("DELETE FROM sqlite_sequence WHERE name = 'tasks'")
+}
+
+const nextPosition = (db: Db): number => {
+  const row = db.prepare('SELECT MAX(position) AS max FROM tasks').get()
+  const max = (row as { max: number | null }).max
+  return (max ?? 0) + 1
+}
+
+interface Row {
+  id: number
+  title: string
+  description: string
+  status: string
+  position: number
+  created_at: string
+  updated_at: string
+}
+
+const rows = (values: unknown[]): Task[] => values.map(toTask)
+
+const toTask = (value: unknown): Task => {
+  const row = value as Row
+  return {
+    id: row.id,
+    title: row.title,
+    description: row.description,
+    status: row.status === 'completed' ? 'completed' : 'active',
+    position: row.position,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}

--- a/app/server/index.ts
+++ b/app/server/index.ts
@@ -1,11 +1,67 @@
+import { createApp } from './app.js'
+import { open } from './db.js'
+import { seed } from './seed.js'
+
 /**
  * @sentra/taskflow-server
  *
  * TaskFlow API — the system under test. Express and SQLite, deliberately small.
  *
- * The implementation lands in M4; this file exists so the
- * workspace, its TypeScript project reference and its public entry point are
- * in place before anything depends on them.
+ * The entry point does the three things a module cannot: reads the environment,
+ * opens a file, and binds a port. Everything it calls takes what it needs as an
+ * argument, which is what lets the whole API be tested against `:memory:`
+ * without a port or a temporary directory.
  */
 
-export {}
+export * from './db.js'
+export * from './app.js'
+export * from './seed.js'
+
+/** Defaults to a file, never to `:memory:` — a dev server that forgets everything on restart. */
+export const DEFAULT_DB = '.taskflow/tasks.db'
+export const DEFAULT_PORT = 3001
+
+export interface ServeOptions {
+  port?: number
+  database?: string
+  /** Replace the contents with the deterministic seed before serving. */
+  reseed?: boolean
+  log?: (message: string) => void
+}
+
+export function serve(options: ServeOptions = {}): { close: () => Promise<void>; port: number } {
+  const log = options.log ?? console.log
+  const path = options.database ?? process.env.SENTRA_DB ?? DEFAULT_DB
+  const port = options.port ?? Number(process.env.PORT ?? DEFAULT_PORT)
+
+  const db = open(path)
+  if (options.reseed === true) seed(db)
+
+  const server = createApp({ db }).listen(port)
+  const bound = address(server, port)
+  log(`  TaskFlow API on http://localhost:${String(bound)} (${path})`)
+
+  return {
+    port: bound,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((failure) => {
+          db.close()
+          if (failure) reject(failure)
+          else resolve()
+        })
+      }),
+  }
+}
+
+/** `listen(0)` picks a free port, which is how tests avoid the collision they exist to simulate. */
+function address(server: { address: () => unknown }, fallback: number): number {
+  const bound = server.address()
+  return typeof bound === 'object' && bound !== null && 'port' in bound
+    ? (bound as { port: number }).port
+    : fallback
+}
+
+if (process.argv[1]?.endsWith('index.ts') === true) {
+  serve({ reseed: process.argv.includes('--seed') })
+}

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -2,7 +2,7 @@
   "name": "@sentra/taskflow-server",
   "version": "0.1.0",
   "private": true,
-  "description": "TaskFlow API — the system under test. Express and SQLite, deliberately small.",
+  "description": "TaskFlow API \u2014 the system under test. Express and SQLite, deliberately small.",
   "license": "MIT",
   "type": "module",
   "exports": {
@@ -10,5 +10,10 @@
       "types": "./dist/index.d.ts",
       "default": "./index.ts"
     }
+  },
+  "dependencies": {
+    "better-sqlite3": "^13.0.3",
+    "express": "^5.2.1",
+    "zod": "*"
   }
 }

--- a/app/server/seed.ts
+++ b/app/server/seed.ts
@@ -1,0 +1,49 @@
+import { clear, create, update, type Db, type Task } from './db.js'
+
+/**
+ * A deterministic starting state.
+ *
+ * Deterministic in every respect that a test could assert on: the same ids, the
+ * same order, the same timestamps. A seed that used the wall clock would make
+ * every snapshot and every "most recent" assertion depend on when the suite ran,
+ * and the resulting failures would look exactly like the flakiness this project
+ * exists to classify — with the difference that they would be the fixture's
+ * fault, which is the one kind of noise the dataset must not contain.
+ *
+ * Small on purpose. Five rows is enough for ordering, filtering and drag targets,
+ * and few enough to read in a failure message.
+ */
+
+export const SEED_TIME = '2026-01-15T09:00:00.000Z'
+
+interface SeedRow {
+  title: string
+  description: string
+  completed?: boolean
+}
+
+export const SEED: readonly SeedRow[] = [
+  { title: 'Write the incident postmortem', description: 'Due Friday. Include the timeline.' },
+  { title: 'Review the migration plan', description: 'Second pass — check the rollback path.' },
+  { title: 'Renew the staging certificate', description: '', completed: true },
+  { title: 'Draft the release notes', description: 'Wait for the eval numbers first.' },
+  { title: 'Triage the flaky board spec', description: 'It has failed four times this week.' },
+]
+
+/** Replaces whatever was there. Returns the rows so a caller can assert on ids without re-reading. */
+export function seed(db: Db): Task[] {
+  clear(db)
+
+  const created = SEED.map((row, index) => {
+    const task = create(
+      db,
+      { title: row.title, description: row.description, position: index + 1 },
+      SEED_TIME,
+    )
+    return row.completed === true
+      ? (update(db, task.id, { status: 'completed' }, SEED_TIME) ?? task)
+      : task
+  })
+
+  return created
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,8 @@
         "@commitlint/config-conventional": "21.2.0",
         "@eslint/js": "10.0.1",
         "@playwright/test": "1.62.1",
+        "@types/better-sqlite3": "^9.6.0",
+        "@types/express": "^5.0.6",
         "@types/node": "^22.10.2",
         "@vitest/coverage-v8": "4.1.10",
         "eslint": "10.8.0",
@@ -61,7 +63,12 @@
     "app/server": {
       "name": "@sentra/taskflow-server",
       "version": "0.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "better-sqlite3": "^13.0.3",
+        "express": "^5.2.1",
+        "zod": "*"
+      }
     },
     "contracts": {
       "name": "@sentra/contracts",
@@ -1491,6 +1498,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+      "integrity": "sha512-ZEEwBSgMu7GYJOynoagg5X9JbxfL6dTJDsgViJIqh67jV44kyOr9RXfmFjLK5rzC4MWssP06t9hu/JwGDnUbCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1500,6 +1528,16 @@
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -1523,6 +1561,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.3.tgz",
+      "integrity": "sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1538,6 +1608,41 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1914,6 +2019,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
@@ -2048,6 +2166,55 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/better-sqlite3": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
+      "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.9",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
@@ -2059,6 +2226,44 @@
       },
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -2164,6 +2369,28 @@
         "node": ">=20"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/conventional-changelog-angular": {
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-9.2.1.tgz",
@@ -2213,6 +2440,24 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.2",
@@ -2278,7 +2523,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2299,6 +2543,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2309,12 +2562,41 @@
         "node": ">=8"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
@@ -2349,12 +2631,42 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
       "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es-toolkit": {
       "version": "1.50.0",
@@ -2419,6 +2731,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -2726,6 +3044,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
@@ -2741,6 +3068,49 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2818,6 +3188,27 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -2839,6 +3230,24 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -2852,6 +3261,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-caller-file": {
@@ -2875,6 +3293,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -2919,6 +3374,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2929,12 +3396,56 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/husky": {
       "version": "9.1.7",
@@ -2950,6 +3461,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -2999,6 +3526,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/ini": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
@@ -3007,6 +3540,15 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-arrayish": {
@@ -3051,6 +3593,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3604,6 +4152,65 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -3637,7 +4244,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3666,6 +4272,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
@@ -3678,6 +4314,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -3746,6 +4403,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -3754,6 +4420,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -3870,6 +4546,19 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3878,6 +4567,50 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/require-from-string": {
@@ -3957,6 +4690,28 @@
         "@rolldown/binding-win32-x64-msvc": "1.2.3"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -3969,6 +4724,57 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3991,6 +4797,78 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -4071,6 +4949,15 @@
       "dependencies": {
         "@stablelib/base64": "^1.0.0",
         "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/std-env": {
@@ -4180,6 +5067,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
@@ -4246,6 +5142,37 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -4291,6 +5218,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4299,6 +5235,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vite": {
@@ -4562,6 +5507,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sentra",
   "version": "0.1.0",
   "private": true,
-  "description": "An AI triage layer for CI test failures \u2014 packaged as a pipeline step, not a service.",
+  "description": "An AI triage layer for CI test failures — packaged as a pipeline step, not a service.",
   "license": "MIT",
   "author": "Andrii Kohut",
   "repository": {
@@ -60,6 +60,8 @@
     "@commitlint/config-conventional": "21.2.0",
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.62.1",
+    "@types/better-sqlite3": "^9.6.0",
+    "@types/express": "^5.0.6",
     "@types/node": "^22.10.2",
     "@vitest/coverage-v8": "4.1.10",
     "eslint": "10.8.0",


### PR DESCRIPTION
Closes #41. First issue of M4.

TaskFlow is the **system under test, not the product**. It exists to produce genuine async-UI flakiness for the pipeline to triage, and the issue is explicit that every hour spent making it good software is an hour not spent on the part that carries the value. So: no auth, no pagination, no soft deletes, no service layer, and a schema that fits on a screen. Routes call the database module directly — a layer whose every method forwards one call makes the code longer and the behaviour no clearer.

## Three things that are load-bearing for the rest of the project

**`position` is `REAL`, and ties break by insertion id.** Fractional positions make reordering (#42) one write instead of a renumber, and a client dropping an item between two neighbours can compute the midpoint without asking. The tie-break is not a detail: `position-collision-orders-by-insertion-id` is a fixture in the golden dataset, so this application has to be *able* to produce that failure.

**Completion has its own route** rather than `PATCH {status}`. It is the write that races a title save, and a distinct endpoint is what lets the chaos layer in #47 delay exactly that request without touching every other one.

**The seed is deterministic in every respect a test could assert on** — same ids, same order, same timestamps. A seed on the wall clock would make every snapshot and every "most recent" assertion depend on when the suite ran, and those failures would look exactly like the flakiness this project classifies, except they would be the fixture's fault. That is the one kind of noise the dataset must not contain.

## `better-sqlite3` over `node:sqlite`

The built-in would have been one dependency fewer. Node 22 — the floor this repository sets and the version CI pins — still prints an `ExperimentalWarning` for it on every process start, and noise on stderr is how people learn to stop reading stderr.

## Two error-handling choices

**Unknown keys are rejected, and reported by name.** A silently ignored field is how a test asserts on something the server never stored and then fails a week later for reasons nobody can reconstruct. Zod reports unrecognised keys as one issue at the root, so the handler expands them per key — `path: ""` with the offending name buried in a sentence is the difference between a caller fixing a typo and a caller reading the source.

**An unexpected throw answers 500 with no stack.** This matters more here than usual: an application whose failures are read *by an AI triage agent* would otherwise put a server stack trace into a prompt and into a public PR comment. There is a test that breaks the database and asserts the response contains neither the message nor a filesystem path.

## Tested over real HTTP

Not because a request object could not be faked, but because everything that consumes this API — the client, the Playwright specs, the flaky ones especially — reaches it that way.

The port comes from `listen(0)`. Hard-coding one would fail whenever a dev server was running, which is a flaky test with a very boring cause, in a repository about flaky tests.

Startup is **asserted under a second**, per the acceptance criterion. E2E setup time is paid on every run, by every spec, forever.

34 tests here, 1204 overall. `app/server` at 96.9% statements, 99.1% lines.

## Also

`.taskflow/` is gitignored — state, not source; the seed rebuilds it. Express and better-sqlite3 are grouped in Dependabot as `taskflow`: a bump there can only break the application the pipeline is pointed at, and reviewing those together is the whole of the review.