### PR TITLE
feat(server): reorder by target index, with the race written down

### DIFF
--- a/app/server/api.test.ts
+++ b/app/server/api.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 import { createApp } from './app.js'
-import { clear, open, type Db } from './db.js'
+import { clear, create, open, reorder, type Db } from './db.js'
 import { serve } from './index.js'
 import { seed, SEED, SEED_TIME } from './seed.js'
 
@@ -325,5 +325,190 @@ describe('starting up', () => {
     const b = serve({ port: 0, database: ':memory:', log: () => undefined })
     expect(a.port).not.toBe(b.port)
     await Promise.all([a.close(), b.close()])
+  })
+})
+
+describe('reordering', () => {
+  const titles = async (): Promise<string[]> =>
+    ((await api('/api/tasks')).body as ListBody).tasks.map((t) => t.title)
+
+  const three = async (): Promise<Record<string, number>> => {
+    const ids: Record<string, number> = {}
+    for (const title of ['a', 'b', 'c']) {
+      ids[title] = ((await post('/api/tasks', { title })).body as TaskBody).task.id
+    }
+    return ids
+  }
+
+  it('moves a task to the front', async () => {
+    const ids = await three()
+    await patch('/api/tasks/reorder', { id: ids.c, index: 0 })
+    expect(await titles()).toEqual(['c', 'a', 'b'])
+  })
+
+  it('moves a task to the end', async () => {
+    const ids = await three()
+    await patch('/api/tasks/reorder', { id: ids.a, index: 2 })
+    expect(await titles()).toEqual(['b', 'c', 'a'])
+  })
+
+  it('moves a task into the middle', async () => {
+    const ids = await three()
+    await patch('/api/tasks/reorder', { id: ids.c, index: 1 })
+    expect(await titles()).toEqual(['a', 'c', 'b'])
+  })
+
+  it('returns the resulting order rather than the moved row', async () => {
+    const ids = await three()
+    const response = await patch('/api/tasks/reorder', { id: ids.c, index: 0 })
+    expect((response.body as ListBody).tasks.map((t) => t.title)).toEqual(['c', 'a', 'b'])
+  })
+
+  /** An index past the end is what a drag to the bottom of a list sends. */
+  it('clamps an index beyond the end', async () => {
+    const ids = await three()
+    await patch('/api/tasks/reorder', { id: ids.a, index: 99 })
+    expect(await titles()).toEqual(['b', 'c', 'a'])
+  })
+
+  it('leaves the order alone when a task is moved where it already is', async () => {
+    const ids = await three()
+    await patch('/api/tasks/reorder', { id: ids.b, index: 1 })
+    expect(await titles()).toEqual(['a', 'b', 'c'])
+  })
+
+  it('writes one row, not the whole list', async () => {
+    const ids = await three()
+    const before = ((await api('/api/tasks')).body as ListBody).tasks
+    await patch('/api/tasks/reorder', { id: ids.c, index: 0 })
+    const after = ((await api('/api/tasks')).body as ListBody).tasks
+
+    const moved = (position: number, id: number): boolean =>
+      before.find((t) => t.id === id)?.position !== position
+    expect(after.filter((t) => moved(t.position, t.id)).map((t) => t.id)).toEqual([ids.c])
+  })
+
+  it('handles a single task without dividing by nothing', async () => {
+    const id = ((await post('/api/tasks', { title: 'only' })).body as TaskBody).task.id
+    const response = await patch('/api/tasks/reorder', { id, index: 0 })
+    expect(response.status).toBe(200)
+    expect(await titles()).toEqual(['only'])
+  })
+
+  it('404s for a task that is not there', async () => {
+    expect((await patch('/api/tasks/reorder', { id: 999, index: 0 })).status).toBe(404)
+  })
+
+  it.each([
+    ['a missing index', { id: 1 }],
+    ['a negative index', { id: 1, index: -1 }],
+    ['a fractional index', { id: 1, index: 1.5 }],
+    ['an unknown field', { id: 1, index: 0, animate: true }],
+  ])('rejects %s', async (_case, body) => {
+    expect((await patch('/api/tasks/reorder', body)).status).toBe(400)
+  })
+
+  /**
+   * Express matches in declaration order. Registered the other way round, `:id`
+   * captures the literal "reorder", the handler cannot parse it as a number, and
+   * every reorder answers 404 — a routing bug that reads as a missing task.
+   */
+  it('is not read as a task id', async () => {
+    const ids = await three()
+    const response = await patch('/api/tasks/reorder', { id: ids.a, index: 1 })
+    expect(response.status).toBe(200)
+  })
+})
+
+/**
+ * The outcomes the issue asks to be written down rather than discovered — and
+ * asserted, because a documented behaviour nothing checks is a comment.
+ */
+describe('reordering under a race', () => {
+  const titles = async (): Promise<string[]> =>
+    ((await api('/api/tasks')).body as ListBody).tasks.map((t) => t.title)
+
+  const four = async (): Promise<Record<string, number>> => {
+    const ids: Record<string, number> = {}
+    for (const title of ['a', 'b', 'c', 'd']) {
+      ids[title] = ((await post('/api/tasks', { title })).body as TaskBody).task.id
+    }
+    return ids
+  }
+
+  /**
+   * Both clients read the same list and both say "put mine at index 1". Applied
+   * in sequence, the second index means something different once the first move
+   * has landed — so the final order is one neither client painted. This is the
+   * race #46 reproduces, and it is genuine product behaviour.
+   */
+  it('gives an order neither client asked for when both move against a stale read', async () => {
+    const ids = await four()
+
+    await Promise.all([
+      patch('/api/tasks/reorder', { id: ids.c, index: 1 }),
+      patch('/api/tasks/reorder', { id: ids.d, index: 1 }),
+    ])
+
+    const order = await titles()
+    // Every task is still present exactly once — the race loses intent, not rows.
+    expect([...order].sort()).toEqual(['a', 'b', 'c', 'd'])
+    // And neither client's picture survives intact: they cannot both be at index 1.
+    expect(order.indexOf('c') === 1 && order.indexOf('d') === 1).toBe(false)
+  })
+
+  /**
+   * Two moves into the same gap compute the same midpoint and store the same
+   * position, so order between them falls to `id` rather than to who was later —
+   * a client that moved a task after another can find it rendered before it.
+   */
+  it('breaks a position collision by id, not by who wrote last', async () => {
+    const ids = await four()
+
+    // Both computed against the same list: the gap between a and b.
+    await patch('/api/tasks/reorder', { id: ids.d, index: 1 })
+    const positions = ((await api('/api/tasks')).body as ListBody).tasks
+    const target = positions.find((t) => t.id === ids.d)?.position ?? 0
+
+    // c lands on exactly the same position, later in time but earlier by id.
+    await patch(`/api/tasks/${String(ids.c)}`, { position: target })
+
+    const order = await titles()
+    expect(order.indexOf('c')).toBeLessThan(order.indexOf('d'))
+  })
+
+  /** A list that reorders itself between reads would swamp the interesting signal. */
+  it('returns the same order on repeated reads', async () => {
+    await four()
+    const reads = await Promise.all([titles(), titles(), titles()])
+    expect(reads[1]).toEqual(reads[0])
+    expect(reads[2]).toEqual(reads[0])
+  })
+})
+
+/**
+ * The documented limit of fractional positioning, pinned rather than estimated.
+ *
+ * The gap only halves when each inserted task becomes a neighbour of the next —
+ * dragging item after item to just below the same row. Driven against the
+ * database rather than over HTTP: fifty-two round trips to assert an arithmetic
+ * property would be slow for no extra confidence, and the property belongs to
+ * `reorder` rather than to the route.
+ */
+describe('the limit of halving a gap', () => {
+  it('collapses onto the neighbour after 52 insertions below the same row', () => {
+    clear(db)
+    const top = create(db, { title: 'top', position: 1 }, SEED_TIME)
+    create(db, { title: 'bottom', position: 2 }, SEED_TIME)
+
+    let inserted = 0
+    for (; inserted < 200; inserted++) {
+      const task = create(db, { title: `dragged ${String(inserted)}` }, SEED_TIME)
+      const after = reorder(db, task.id, 1, SEED_TIME)
+      const landed = after?.find((row) => row.id === task.id)?.position ?? 0
+      if (landed === top.position) break
+    }
+
+    expect(inserted).toBe(52)
   })
 })

--- a/app/server/app.ts
+++ b/app/server/app.ts
@@ -1,6 +1,6 @@
 import express, { type Express, type NextFunction, type Request, type Response } from 'express'
 import { z } from 'zod'
-import { create, find, list, remove, update, type Db, type Task } from './db.js'
+import { create, find, list, remove, reorder, update, type Db, type Task } from './db.js'
 
 /**
  * The TaskFlow API. Five routes, no service layer, no abstraction to speak of.
@@ -52,6 +52,23 @@ const PatchSchema = z
     message: 'a patch must change at least one field',
   })
 
+/**
+ * A target **index**, not a position.
+ *
+ * The server computes the fractional position from its own current list. A
+ * client sending a position would be sending one it computed from a list that
+ * may already have moved, and the resulting order would depend on how stale that
+ * read was — which is unpredictable rather than merely racy. An index computed
+ * against a stale list is still surprising, and that surprise is documented in
+ * `reorder`; it is at least a defined function of what the server holds.
+ */
+const ReorderSchema = z
+  .object({
+    id: z.number().int().positive(),
+    index: z.number().int().min(0),
+  })
+  .strict()
+
 export interface ApiError {
   error: { code: string; message: string; details?: unknown }
 }
@@ -81,6 +98,25 @@ export function createApp(deps: AppDeps): Express {
     if (!parsed.success) return invalid(response, parsed.error)
 
     response.status(201).json({ task: create(db, parsed.data, now()) })
+  })
+
+  /**
+   * Registered before `/api/tasks/:id`, and that order is the whole of it.
+   *
+   * Express matches in declaration order, so the other way round `:id` captures
+   * the literal string "reorder", the handler fails to parse it as a number, and
+   * every reorder answers 404 — a routing bug that reads as a missing task. A
+   * test pins the order rather than the comment.
+   */
+  app.patch('/api/tasks/reorder', (request, response) => {
+    const parsed = ReorderSchema.safeParse(request.body)
+    if (!parsed.success) return invalid(response, parsed.error)
+
+    const tasks = reorder(db, parsed.data.id, parsed.data.index, now())
+    if (tasks === null) return notFound(response)
+    // The resulting list, not the moved row: a reordering client needs the order,
+    // and making it ask again is the request that races the next drag.
+    response.json({ tasks })
   })
 
   app.patch('/api/tasks/:id', (request, response) => {

--- a/app/server/db.ts
+++ b/app/server/db.ts
@@ -133,6 +133,58 @@ export function update(db: Db, id: number, patch: TaskPatch, now: string): Task 
   return find(db, id)
 }
 
+/**
+ * Move a task so that it lands at `index` in the resulting list.
+ *
+ * Fractional insertion rather than renumbering: one row is written, and the
+ * partial-update behaviour under a race is what makes the failure in #46
+ * interesting rather than simulated.
+ *
+ * **The defined outcome under concurrency**, which the issue asks to be written
+ * down rather than discovered:
+ *
+ * 1. Requests serialise — the handlers are synchronous and SQLite is
+ *    single-writer — so the second reorder computes against the list the first
+ *    one produced. Last write wins, applied to current state.
+ * 2. That is *not* the same as last intent winning. Two clients that both read
+ *    the list, then both say "put mine at index 2", produce a final order
+ *    neither of them painted optimistically: the second index means something
+ *    different once the first move has landed. This is the race #46 exists to
+ *    reproduce, and it is a genuine product behaviour, not an injected one.
+ * 3. Two moves to the same gap compute the same midpoint and store the same
+ *    position. Order between them is then decided by `id`, not by who was later
+ *    — so a client that moved a task *after* another can find it rendered
+ *    before it.
+ *
+ * The known limit: each insertion into a gap halves it only when the inserted
+ * task becomes a neighbour of the next one — dragging item after item to just
+ * below the same row, which is an ordinary thing to do. After 52 of those the
+ * midpoint equals the neighbour below and case 3 applies permanently. A
+ * production system would renumber; this one is a demonstration app and would
+ * rather have the collision. A test pins the 52, because a number in a comment
+ * is a guess somebody later relies on.
+ */
+export function reorder(db: Db, id: number, index: number, now: string): Task[] | null {
+  if (find(db, id) === null) return null
+
+  const others = list(db).filter((task) => task.id !== id)
+  const at = Math.min(Math.max(Math.trunc(index), 0), others.length)
+  const before = others[at - 1]
+  const after = others[at]
+
+  const position =
+    before === undefined && after === undefined
+      ? 1
+      : before === undefined
+        ? (after?.position ?? 1) - 1
+        : after === undefined
+          ? before.position + 1
+          : (before.position + after.position) / 2
+
+  db.prepare('UPDATE tasks SET position = ?, updated_at = ? WHERE id = ?').run(position, now, id)
+  return list(db)
+}
+
 /** True when a row was deleted. False means it was already gone, which is not an error twice. */
 export function remove(db: Db, id: number): boolean {
   return db.prepare('DELETE FROM tasks WHERE id = ?').run(id).changes > 0


### PR DESCRIPTION
Closes #42.

`PATCH /api/tasks/reorder` takes a task and a **target index**; the server computes the fractional position from its own current list.

A client sending a *position* would be sending one it computed from a list that may already have moved, and the outcome would then depend on how stale that read was — unpredictable rather than merely racy. An index against a stale list is still surprising, but it is at least a defined function of what the server holds.

## The two properties are in tension, and both are required

The issue is explicit about this:

- **The order must be stable.** A list that reorders itself between reads produces flakiness that is genuinely the app's fault and completely uninteresting, and it would swamp the signal the pipeline is meant to find.
- **The reorder must still be racy in a realistic way**, or the optimistic-update failure in #46 is simulated rather than real.

So the concurrent outcomes are **documented and asserted** rather than discovered:

1. Requests serialise, so **last write wins applied to current state**.
2. That is not *last intent* winning. Two clients that both read the list and both say "put mine at index 1" produce a final order **neither painted optimistically** — the second index means something different once the first move has landed. This is the race #46 reproduces, and it is genuine product behaviour rather than an injected one.
3. Two moves into the same gap compute the same midpoint and store the same position, so order between them falls to `id`, not to who was later. A client that moved a task *after* another can find it rendered *before* it.

Each of the three has a test. A documented behaviour nothing checks is a comment.

## Route order is the whole of the routing

`/api/tasks/reorder` is registered **before** `/api/tasks/:id`. The other way round, `:id` captures the literal string `"reorder"`, the handler cannot parse it as a number, and every reorder answers 404 — a routing bug that reads as a missing task.

I swapped the two registrations to check: **six tests fail**, so the order is pinned by behaviour and not by the comment.

## The precision limit is pinned, not estimated

My first draft of that comment said "roughly fifty moves". The test I wrote to pin it **failed at 1** — because repeatedly moving the same task into the same gap does not halve anything; the neighbours never move. The gap only halves when each inserted task becomes a neighbour of the next, which is what dragging item after item to just below the same row does.

Corrected in both places, and the number is **52**, asserted. A number in a comment is a guess somebody later relies on.

## Testing

52 tests in `app/server`, 1222 overall. `app/server` at 97.3% statements, 99.2% lines.

Boundary cases covered: front, end, middle, no-op move, an index past the end (what a drag to the bottom sends), a single-task list, a task that does not exist, and the four malformed bodies.