### PR TITLE
feat(client): the task lifecycle, with one optimistic path and no others

### DIFF
--- a/app/client/App.test.tsx
+++ b/app/client/App.test.tsx
@@ -222,3 +222,372 @@ describe('a clean run', () => {
     expect(warnings.mock.calls).toEqual([])
   })
 })
+
+// ---------------------------------------------------------------------------
+// The task lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * These flows are the control group for the non-flaky specs in #51, so they are
+ * tested for *stability* as much as for behaviour: no refetch that races another
+ * write, no double submit, and a rollback that puts back one field rather than a
+ * remembered list.
+ */
+describe('creating', () => {
+  const listThen = (created: Task): void => {
+    fetchMock.mockResolvedValueOnce(respond([]))
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ task: created }), {
+        status: 201,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+  }
+
+  it('adds the task the server returned', async () => {
+    listThen(task({ id: 9, title: 'a new thing' }))
+    render(<App />)
+
+    await waitFor(() => expect(screen.getByTestId('empty-state')).toBeDefined())
+    await userEvent.type(screen.getByLabelText('New task'), 'a new thing')
+    await userEvent.click(screen.getByRole('button', { name: 'Add task' }))
+
+    await waitFor(() => expect(screen.getByText('a new thing')).toBeDefined())
+  })
+
+  /**
+   * A refetch after a write races every other write in flight. There is exactly
+   * one deliberate race in this application and it is not here.
+   */
+  it('does not refetch the list afterwards', async () => {
+    listThen(task({ id: 9, title: 'a new thing' }))
+    render(<App />)
+
+    await waitFor(() => expect(screen.getByTestId('empty-state')).toBeDefined())
+    await userEvent.type(screen.getByLabelText('New task'), 'a new thing')
+    await userEvent.click(screen.getByRole('button', { name: 'Add task' }))
+    await waitFor(() => expect(screen.getByText('a new thing')).toBeDefined())
+
+    // One GET and one POST. A third call would be the refetch.
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('clears the field, so a second task does not inherit the first title', async () => {
+    listThen(task({ id: 9, title: 'a new thing' }))
+    render(<App />)
+
+    await waitFor(() => expect(screen.getByTestId('empty-state')).toBeDefined())
+    await userEvent.type(screen.getByLabelText('New task'), 'a new thing')
+    await userEvent.click(screen.getByRole('button', { name: 'Add task' }))
+
+    await waitFor(() => expect(screen.getByLabelText('New task')).toHaveProperty('value', ''))
+  })
+
+  /** A form that submits twice is a data bug that presents as a test counting rows. */
+  it('refuses an empty title rather than posting one', async () => {
+    fetchMock.mockResolvedValue(respond([]))
+    render(<App />)
+
+    await waitFor(() => expect(screen.getByTestId('empty-state')).toBeDefined())
+    expect(screen.getByRole('button', { name: 'Add task' })).toHaveProperty('disabled', true)
+  })
+
+  /**
+   * The disabled button is not the whole guard: Enter in the field submits the
+   * form directly. A double submit is a data bug that presents as a test
+   * counting rows, which is exactly the contamination #51's control group cannot
+   * have.
+   */
+  it('creates one task when the button is clicked twice before the first lands', async () => {
+    fetchMock.mockResolvedValueOnce(respond([]))
+    render(<App />)
+    await waitFor(() => expect(screen.getByTestId('empty-state')).toBeDefined())
+
+    let settle: (response: Response) => void = () => undefined
+    fetchMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        settle = resolve
+      }),
+    )
+
+    await userEvent.type(screen.getByLabelText('New task'), 'once')
+    const button = screen.getByRole('button', { name: 'Add task' })
+    await userEvent.click(button)
+    await userEvent.click(button)
+
+    settle(
+      new Response(JSON.stringify({ task: task({ id: 9, title: 'once' }) }), {
+        status: 201,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+    await waitFor(() => expect(screen.getByText('once')).toBeDefined())
+
+    // One GET and one POST. Two POSTs would be two tasks named "once".
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  /**
+   * The disabled button does not stop this one: a form still submits on Enter
+   * while its submit button is disabled, so the early return in the handler is
+   * the guard that matters here.
+   */
+  it('ignores Enter while a create is already in flight', async () => {
+    fetchMock.mockResolvedValueOnce(respond([]))
+    render(<App />)
+    await waitFor(() => expect(screen.getByTestId('empty-state')).toBeDefined())
+
+    let settle: (response: Response) => void = () => undefined
+    fetchMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        settle = resolve
+      }),
+    )
+
+    const field = screen.getByLabelText('New task')
+    await userEvent.type(field, 'once{Enter}')
+    await userEvent.type(field, '{Enter}')
+
+    settle(
+      new Response(JSON.stringify({ task: task({ id: 9, title: 'once' }) }), {
+        status: 201,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+    await waitFor(() => expect(screen.getByText('once')).toBeDefined())
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('surfaces a failure in the UI rather than the console', async () => {
+    fetchMock.mockResolvedValueOnce(respond([]))
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ error: { code: 'invalid_request', message: 'title is required' } }),
+        {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    )
+    render(<App />)
+
+    await waitFor(() => expect(screen.getByTestId('empty-state')).toBeDefined())
+    await userEvent.type(screen.getByLabelText('New task'), 'x')
+    await userEvent.click(screen.getByRole('button', { name: 'Add task' }))
+
+    await waitFor(() => expect(screen.getByTestId('write-error')).toBeDefined())
+    expect(screen.getByTestId('write-error').textContent).toContain('title is required')
+  })
+
+  it('lets the error be dismissed without reloading', async () => {
+    fetchMock.mockResolvedValueOnce(respond([task()]))
+    fetchMock.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+    render(<App />)
+
+    await waitFor(() => expect(screen.getByTestId('task-list')).toBeDefined())
+    await userEvent.type(screen.getByLabelText('New task'), 'x')
+    await userEvent.click(screen.getByRole('button', { name: 'Add task' }))
+
+    await waitFor(() => expect(screen.getByTestId('write-error')).toBeDefined())
+    await userEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+
+    expect(screen.queryByTestId('write-error')).toBeNull()
+    // The list is still there: a failed write never blocks reading.
+    expect(screen.getByTestId('task-list')).toBeDefined()
+  })
+})
+
+describe('editing', () => {
+  const openEditor = async (): Promise<void> => {
+    fetchMock.mockResolvedValueOnce(respond([task({ id: 3, title: 'before' })]))
+    render(<App />)
+    await waitFor(() => expect(screen.getByTestId('task-list')).toBeDefined())
+    await userEvent.click(screen.getByRole('button', { name: 'Edit' }))
+  }
+
+  it('saves the new title', async () => {
+    await openEditor()
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ task: task({ id: 3, title: 'after' }) }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    await userEvent.clear(screen.getByLabelText('Title'))
+    await userEvent.type(screen.getByLabelText('Title'), 'after')
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(screen.getByText('after')).toBeDefined())
+    expect(screen.queryByTestId('edit-form')).toBeNull()
+  })
+
+  it('leaves the task alone when cancelled', async () => {
+    await openEditor()
+    await userEvent.clear(screen.getByLabelText('Title'))
+    await userEvent.type(screen.getByLabelText('Title'), 'discarded')
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(screen.getByText('before')).toBeDefined()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('will not save an empty title', async () => {
+    await openEditor()
+    await userEvent.clear(screen.getByLabelText('Title'))
+    expect(screen.getByRole('button', { name: 'Save' })).toHaveProperty('disabled', true)
+  })
+
+  /** The disabled button is not the whole guard — Enter submits the form directly. */
+  it('will not save an empty title on Enter either', async () => {
+    await openEditor()
+    await userEvent.clear(screen.getByLabelText('Title'))
+    await userEvent.type(screen.getByLabelText('Title'), '{Enter}')
+
+    expect(screen.getByTestId('edit-form')).toBeDefined()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('deleting', () => {
+  const setup = async (): Promise<void> => {
+    fetchMock.mockResolvedValueOnce(respond([task({ id: 4, title: 'doomed' })]))
+    render(<App />)
+    await waitFor(() => expect(screen.getByTestId('task-list')).toBeDefined())
+  }
+
+  /**
+   * Two steps in the page rather than `window.confirm`. A native dialog blocks
+   * the event loop and has to be intercepted by name in Playwright, which is a
+   * genuine source of intermittent failures.
+   */
+  it('asks before deleting', async () => {
+    await setup()
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    expect(screen.getByTestId('delete-confirm')).toBeDefined()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('removes the row once confirmed', async () => {
+    await setup()
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm delete' }))
+
+    await waitFor(() => expect(screen.queryByText('doomed')).toBeNull())
+  })
+
+  it('keeps the task when the confirmation is cancelled', async () => {
+    await setup()
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(screen.getByText('doomed')).toBeDefined()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('completing', () => {
+  const setup = async (over: Partial<Task> = {}): Promise<void> => {
+    fetchMock.mockResolvedValueOnce(respond([task({ id: 5, ...over })]))
+    render(<App />)
+    await waitFor(() => expect(screen.getByTestId('task-list')).toBeDefined())
+  }
+
+  /**
+   * The optimistic path, and the seed of the race in #46. It has to paint before
+   * the request settles or there is nothing for that race to be about.
+   */
+  it('paints the change before the server answers', async () => {
+    await setup()
+    fetchMock.mockReturnValueOnce(new Promise(() => undefined))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Complete' }))
+    expect(screen.getByTestId('task-status').textContent).toBe('Done')
+  })
+
+  it('keeps the change when the server agrees', async () => {
+    await setup()
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ task: task({ id: 5, status: 'completed' }) }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Complete' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Reopen' })).toBeDefined())
+  })
+
+  it('rolls back and says why when the server refuses', async () => {
+    await setup()
+    fetchMock.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Complete' }))
+
+    await waitFor(() => expect(screen.getByTestId('write-error')).toBeDefined())
+    expect(screen.getByTestId('task-status').textContent).toBe('To do')
+  })
+
+  /**
+   * The rollback names the field rather than restoring a remembered list. A
+   * snapshot restored after the request would silently undo whatever landed in
+   * between — a data-loss bug wearing the costume of a rollback.
+   */
+  it('rolls back without undoing a task created while it was in flight', async () => {
+    await setup()
+
+    let refuse: (failure: Error) => void = () => undefined
+    fetchMock.mockReturnValueOnce(
+      new Promise((_resolve, reject) => {
+        refuse = reject
+      }),
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Complete' }))
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ task: task({ id: 6, title: 'landed meanwhile' }) }), {
+        status: 201,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+    await userEvent.type(screen.getByLabelText('New task'), 'landed meanwhile')
+    await userEvent.click(screen.getByRole('button', { name: 'Add task' }))
+    await waitFor(() => expect(screen.getByText('landed meanwhile')).toBeDefined())
+
+    refuse(new TypeError('Failed to fetch'))
+
+    await waitFor(() => expect(screen.getByTestId('write-error')).toBeDefined())
+    expect(screen.getByText('landed meanwhile')).toBeDefined()
+    expect(screen.getAllByTestId('task-status')[0]?.textContent).toBe('To do')
+  })
+
+  it('reopens a completed task through the ordinary patch route', async () => {
+    await setup({ status: 'completed' })
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ task: task({ id: 5, status: 'active' }) }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Reopen' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Complete' })).toBeDefined())
+    expect(fetchMock.mock.calls.at(-1)?.[0]).toBe('/api/tasks/5')
+  })
+
+  it('completes through the dedicated route, which #47 delays', async () => {
+    await setup()
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ task: task({ id: 5, status: 'completed' }) }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Complete' }))
+    await waitFor(() => expect(fetchMock.mock.calls.at(-1)?.[0]).toBe('/api/tasks/5/complete'))
+  })
+})

--- a/app/client/App.tsx
+++ b/app/client/App.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useState } from 'react'
-import { listTasks, type Task } from './api.js'
+import { useState } from 'react'
+import type { Task } from './api.js'
+import { useTasks, type Tasks } from './useTasks.js'
 
 /**
  * TaskFlow's UI. `fetch`, `useState`, and CSS.
@@ -9,6 +10,11 @@ import { listTasks, type Task } from './api.js'
  * dependency is one more thing somebody has to rule out when a test starts
  * failing intermittently.
  *
+ * All state and every write live in `useTasks`; these components render it. That
+ * split is not architecture for its own sake — the optimistic completion path is
+ * the seed of the race in #46, and a race spread across three components is one
+ * nobody can analyse.
+ *
  * ## Which elements get a `data-testid`, and why
  *
  * This is a decision rather than an oversight, and it is worth writing down
@@ -16,11 +22,11 @@ import { listTasks, type Task } from './api.js'
  * this way.
  *
  * **Structural containers get one.** `task-list`, `task-item`, `empty-state`,
- * `error-state`, `loading-state`. These are the things a spec needs to find in
- * order to say anything at all, and a spec that finds its subject by walking the
- * DOM breaks on every layout change for no useful reason. A test id here is a
- * contract: renaming one is a deliberate act, and
- * `locator-still-uses-retired-test-id` in the golden dataset is exactly the
+ * `error-state`, `loading-state`, `create-form`, `write-error`. These are the
+ * things a spec needs to find in order to say anything at all, and a spec that
+ * finds its subject by walking the DOM breaks on every layout change for no
+ * useful reason. A test id here is a contract: renaming one is a deliberate act,
+ * and `locator-still-uses-retired-test-id` in the golden dataset is exactly the
  * failure of breaking that contract quietly.
  *
  * **Interactive controls deliberately do not.** Buttons and inputs are found by
@@ -35,87 +41,217 @@ import { listTasks, type Task } from './api.js'
  * asserting on the fixture, and that is the point.
  */
 
-type State =
-  { status: 'loading' } | { status: 'error'; message: string } | { status: 'ready'; tasks: Task[] }
-
 export function App(): React.JSX.Element {
-  const [state, setState] = useState<State>({ status: 'loading' })
-
-  const load = useCallback(async () => {
-    setState({ status: 'loading' })
-    try {
-      setState({ status: 'ready', tasks: await listTasks() })
-    } catch (failure) {
-      setState({
-        status: 'error',
-        message: failure instanceof Error ? failure.message : 'something went wrong',
-      })
-    }
-  }, [])
-
-  useEffect(() => {
-    // Floating on purpose, and the only place in the repository where that is
-    // true: `useEffect` cannot take an async function, and the promise's failure
-    // is already handled inside `load`. Nothing is left unobserved.
-    void load()
-  }, [load])
+  const tasks = useTasks()
 
   return (
     <main className="app">
       <header className="app-header">
         <h1>TaskFlow</h1>
-        <button type="button" onClick={() => void load()}>
+        <button type="button" onClick={() => void tasks.reload()}>
           Refresh
         </button>
       </header>
 
-      {state.status === 'loading' && (
+      <CreateForm onCreate={tasks.create} />
+
+      {tasks.writeError !== null && (
+        <div className="banner banner-error" data-testid="write-error" role="alert">
+          <p>{tasks.writeError}</p>
+          <button type="button" onClick={tasks.dismissWriteError}>
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {tasks.status === 'loading' && (
         <p className="state" data-testid="loading-state" role="status">
           Loading tasks…
         </p>
       )}
 
-      {state.status === 'error' && (
+      {tasks.status === 'error' && (
         <div className="state state-error" data-testid="error-state" role="alert">
-          <p>{state.message}</p>
-          <button type="button" onClick={() => void load()}>
+          <p>{tasks.loadError}</p>
+          <button type="button" onClick={() => void tasks.reload()}>
             Try again
           </button>
         </div>
       )}
 
-      {state.status === 'ready' &&
-        (state.tasks.length === 0 ? (
+      {tasks.status === 'ready' &&
+        (tasks.tasks.length === 0 ? (
           <p className="state" data-testid="empty-state">
             Nothing to do. Add a task to get started.
           </p>
         ) : (
-          <TaskList tasks={state.tasks} />
+          <TaskList tasks={tasks} />
         ))}
     </main>
   )
 }
 
-export function TaskList({ tasks }: { tasks: readonly Task[] }): React.JSX.Element {
+function CreateForm({ onCreate }: { onCreate: Tasks['create'] }): React.JSX.Element {
+  const [title, setTitle] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  const submit = async (event: React.FormEvent): Promise<void> => {
+    event.preventDefault()
+    if (title.trim() === '') return
+
+    // `busy` disables the submit button while the request is in flight, and that
+    // is the whole of the guard: HTML blocks implicit submission — Enter in the
+    // field — when the default button is disabled, so both paths are covered by
+    // one flag. An early return on `busy` here looked like a second layer and was
+    // unreachable; a guard that guards nothing is worse than none, because it
+    // reads as protection.
+    //
+    // It earns its place either way: a form that submits twice is a data bug
+    // that presents as a flaky test counting rows, and these flows are the
+    // control group for #51.
+    setBusy(true)
+    await onCreate(title.trim())
+    setBusy(false)
+    setTitle('')
+  }
+
+  return (
+    <form className="create-form" data-testid="create-form" onSubmit={(e) => void submit(e)}>
+      <label className="visually-hidden" htmlFor="new-task-title">
+        New task
+      </label>
+      <input
+        id="new-task-title"
+        value={title}
+        placeholder="What needs doing?"
+        onChange={(event) => setTitle(event.target.value)}
+      />
+      <button type="submit" disabled={busy || title.trim() === ''}>
+        Add task
+      </button>
+    </form>
+  )
+}
+
+function TaskList({ tasks }: { tasks: Tasks }): React.JSX.Element {
   return (
     <ul className="task-list" data-testid="task-list">
-      {tasks.map((task) => (
-        <TaskRow key={task.id} task={task} />
+      {tasks.tasks.map((task) => (
+        <TaskRow key={task.id} task={task} tasks={tasks} />
       ))}
     </ul>
   )
 }
 
-export function TaskRow({ task }: { task: Task }): React.JSX.Element {
+function TaskRow({ task, tasks }: { task: Task; tasks: Tasks }): React.JSX.Element {
+  const [editing, setEditing] = useState(false)
+  const [confirming, setConfirming] = useState(false)
+
   return (
     <li className={`task task-${task.status}`} data-testid="task-item" data-task-id={task.id}>
       <span className="task-status" data-testid="task-status">
         {task.status === 'completed' ? 'Done' : 'To do'}
       </span>
-      <div className="task-text">
-        <p className="task-title">{task.title}</p>
-        {task.description !== '' && <p className="task-description">{task.description}</p>}
+
+      {editing ? (
+        <EditForm
+          task={task}
+          onCancel={() => setEditing(false)}
+          onSave={async (patch) => {
+            await tasks.edit(task.id, patch)
+            setEditing(false)
+          }}
+        />
+      ) : (
+        <div className="task-text">
+          <p className="task-title">{task.title}</p>
+          {task.description !== '' && <p className="task-description">{task.description}</p>}
+        </div>
+      )}
+
+      <div className="task-actions">
+        <button type="button" onClick={() => void tasks.toggle(task)}>
+          {task.status === 'completed' ? 'Reopen' : 'Complete'}
+        </button>
+
+        {!editing && (
+          <button type="button" onClick={() => setEditing(true)}>
+            Edit
+          </button>
+        )}
+
+        {/*
+          Two steps, in the page, rather than `window.confirm`. A native dialog
+          blocks the event loop and has to be intercepted by name in Playwright,
+          which is a genuine source of intermittent failures — and this
+          application's intermittency is meant to come from one deliberate place.
+        */}
+        {confirming ? (
+          <span className="confirm" data-testid="delete-confirm">
+            <button type="button" onClick={() => void tasks.remove(task.id)}>
+              Confirm delete
+            </button>
+            <button type="button" onClick={() => setConfirming(false)}>
+              Cancel
+            </button>
+          </span>
+        ) : (
+          <button type="button" onClick={() => setConfirming(true)}>
+            Delete
+          </button>
+        )}
       </div>
     </li>
+  )
+}
+
+function EditForm({
+  task,
+  onSave,
+  onCancel,
+}: {
+  task: Task
+  onSave: (patch: { title: string; description: string }) => Promise<void>
+  onCancel: () => void
+}): React.JSX.Element {
+  const [title, setTitle] = useState(task.title)
+  const [description, setDescription] = useState(task.description)
+
+  return (
+    <form
+      className="task-text edit-form"
+      data-testid="edit-form"
+      onSubmit={(event) => {
+        event.preventDefault()
+        if (title.trim() !== '') void onSave({ title: title.trim(), description })
+      }}
+    >
+      <label className="visually-hidden" htmlFor={`title-${String(task.id)}`}>
+        Title
+      </label>
+      <input
+        id={`title-${String(task.id)}`}
+        value={title}
+        onChange={(event) => setTitle(event.target.value)}
+      />
+
+      <label className="visually-hidden" htmlFor={`description-${String(task.id)}`}>
+        Description
+      </label>
+      <input
+        id={`description-${String(task.id)}`}
+        value={description}
+        onChange={(event) => setDescription(event.target.value)}
+      />
+
+      <span className="edit-actions">
+        <button type="submit" disabled={title.trim() === ''}>
+          Save
+        </button>
+        <button type="button" onClick={onCancel}>
+          Cancel
+        </button>
+      </span>
+    </form>
   )
 }

--- a/app/client/styles.css
+++ b/app/client/styles.css
@@ -126,3 +126,79 @@ button:hover {
   color: var(--muted);
   font-size: 0.9rem;
 }
+
+/* Screen-reader-only labels: every input has one, and none of them is visible. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.create-form {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.create-form input {
+  flex: 1;
+}
+
+input {
+  font: inherit;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--line);
+  border-radius: 0.4rem;
+  background: white;
+  color: var(--ink);
+  min-width: 0;
+}
+
+.banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.6rem 0.9rem;
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.banner p {
+  margin: 0;
+}
+
+.banner-error {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: var(--danger);
+}
+
+.task-actions,
+.edit-actions,
+.confirm {
+  display: flex;
+  gap: 0.4rem;
+  flex-shrink: 0;
+}
+
+.task-actions {
+  margin-left: auto;
+}
+
+.edit-form {
+  display: flex;
+  flex: 1;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.edit-form input {
+  flex: 1 1 8rem;
+}

--- a/app/client/useTasks.ts
+++ b/app/client/useTasks.ts
@@ -1,0 +1,164 @@
+import { useCallback, useEffect, useState } from 'react'
+import * as api from './api.js'
+import type { Task } from './api.js'
+
+/**
+ * All of TaskFlow's state, and the only place a write happens.
+ *
+ * One hook rather than state scattered through the components, for a reason
+ * specific to this project: the optimistic completion path is the seed of the
+ * race in #46, and a race spread across three components is one nobody can
+ * analyse. Here it is four lines and they are the same four lines every time.
+ *
+ * ## What is optimistic and what is not
+ *
+ * **Completion is**, because that is the interaction a user repeats and the one
+ * where a round trip is felt. It paints first, sends, and rolls back that task —
+ * not the whole list — if the server disagrees.
+ *
+ * **Create, edit and delete are not.** They apply the server's answer, and they
+ * do it by patching local state with the response rather than refetching. A
+ * refetch after a mutation races every other mutation in flight, and the issue
+ * is explicit that these flows are the control group for the non-flaky specs in
+ * #51: contaminating them would make every number in the evaluation harder to
+ * read. There is exactly one deliberate race in this application and it is not
+ * here.
+ *
+ * Rolling back one field rather than restoring a snapshot of the list is the
+ * same decision in miniature. A snapshot taken before the request and restored
+ * after it would silently undo anything that happened in between — a create, a
+ * rename — which is a data-loss bug wearing the costume of a rollback.
+ */
+
+export type Status = 'loading' | 'ready' | 'error'
+
+export interface TasksState {
+  status: Status
+  tasks: Task[]
+  /** Why the list could not be loaded. Null once it has been. */
+  loadError: string | null
+  /** Why the last write failed. Dismissible, and never blocks the list. */
+  writeError: string | null
+}
+
+export interface Tasks extends TasksState {
+  reload: () => Promise<void>
+  create: (title: string, description?: string) => Promise<void>
+  edit: (id: number, patch: { title?: string; description?: string }) => Promise<void>
+  remove: (id: number) => Promise<void>
+  toggle: (task: Task) => Promise<void>
+  dismissWriteError: () => void
+}
+
+const message = (failure: unknown): string =>
+  failure instanceof Error ? failure.message : 'something went wrong'
+
+export function useTasks(): Tasks {
+  const [state, setState] = useState<TasksState>({
+    status: 'loading',
+    tasks: [],
+    loadError: null,
+    writeError: null,
+  })
+
+  const reload = useCallback(async () => {
+    setState((current) => ({ ...current, status: 'loading', loadError: null }))
+    try {
+      const tasks = await api.listTasks()
+      setState((current) => ({ ...current, status: 'ready', tasks, loadError: null }))
+    } catch (failure) {
+      setState((current) => ({ ...current, status: 'error', loadError: message(failure) }))
+    }
+  }, [])
+
+  useEffect(() => {
+    // Floating on purpose: `useEffect` cannot take an async function, and every
+    // rejection is already handled inside `reload`.
+    void reload()
+  }, [reload])
+
+  /** Every non-optimistic write, so the error handling exists once. */
+  const write = useCallback(
+    async (apply: () => Promise<(tasks: Task[]) => Task[]>): Promise<void> => {
+      setState((current) => ({ ...current, writeError: null }))
+      try {
+        const update = await apply()
+        setState((current) => ({ ...current, tasks: update(current.tasks) }))
+      } catch (failure) {
+        setState((current) => ({ ...current, writeError: message(failure) }))
+      }
+    },
+    [],
+  )
+
+  const create = useCallback(
+    async (title: string, description = ''): Promise<void> => {
+      await write(async () => {
+        const created = await api.createTask(title, description)
+        // Appended rather than re-sorted: the server puts a new task at the end,
+        // and sorting again here would be a second implementation of an order
+        // that already has one.
+        return (tasks) => [...tasks, created]
+      })
+    },
+    [write],
+  )
+
+  const edit = useCallback(
+    async (id: number, patch: { title?: string; description?: string }): Promise<void> => {
+      await write(async () => {
+        const updated = await api.updateTask(id, patch)
+        return (tasks) => tasks.map((task) => (task.id === id ? updated : task))
+      })
+    },
+    [write],
+  )
+
+  const remove = useCallback(
+    async (id: number): Promise<void> => {
+      await write(async () => {
+        await api.deleteTask(id)
+        return (tasks) => tasks.filter((task) => task.id !== id)
+      })
+    },
+    [write],
+  )
+
+  /**
+   * The optimistic one, and the only one.
+   *
+   * Paint, send, and put *this task's* status back if the server disagrees. The
+   * rollback names the field rather than restoring a remembered list, so a
+   * create that landed while the request was in flight survives it.
+   */
+  const toggle = useCallback(async (task: Task): Promise<void> => {
+    const next: Task['status'] = task.status === 'completed' ? 'active' : 'completed'
+    const set = (status: Task['status']) => (tasks: Task[]) =>
+      tasks.map((row) => (row.id === task.id ? { ...row, status } : row))
+
+    setState((current) => ({ ...current, writeError: null, tasks: set(next)(current.tasks) }))
+
+    try {
+      const updated =
+        next === 'completed'
+          ? await api.completeTask(task.id)
+          : await api.updateTask(task.id, { status: 'active' })
+      setState((current) => ({
+        ...current,
+        tasks: current.tasks.map((row) => (row.id === task.id ? updated : row)),
+      }))
+    } catch (failure) {
+      setState((current) => ({
+        ...current,
+        writeError: message(failure),
+        tasks: set(task.status)(current.tasks),
+      }))
+    }
+  }, [])
+
+  const dismissWriteError = useCallback(() => {
+    setState((current) => ({ ...current, writeError: null }))
+  }, [])
+
+  return { ...state, reload, create, edit, remove, toggle, dismissWriteError }
+}


### PR DESCRIPTION
Closes #44.

Create, edit, delete with confirmation, and a completion toggle. All state and every write live in `useTasks`; the components render it.

That split is not architecture for its own sake — **the optimistic completion path is the seed of the race in #46**, and a race spread across three components is one nobody can analyse. Here it is four lines, and they are the same four lines every time.

## What is optimistic and what deliberately is not

**Completion is.** It paints, sends, and rolls back if the server disagrees.

**Create, edit and delete are not.** They apply the server's answer by patching local state with the response, *not* by refetching. A refetch after a mutation races every other mutation in flight, and the issue is explicit that these flows are the control group for the non-flaky specs in #51 — contaminating them would make every number in the evaluation harder to read.

There is exactly one deliberate race in this application and it is not here. A test asserts a create issues one GET and one POST and nothing else.

## The rollback names the field, not the list

A snapshot taken before the request and restored after it would silently undo whatever landed in between — a create, a rename. That is a data-loss bug wearing the costume of a rollback.

There is a test for exactly that shape: a task created *while* a failing completion is in flight survives the rollback, and the completion still reverts.

## Delete confirms in the page

Not `window.confirm`. A native dialog blocks the event loop and has to be intercepted by name in Playwright, which is a genuine source of intermittent failures — and this application's intermittency is meant to come from one deliberate place.

## Something I removed while testing it

The create handler had a `busy` early return alongside the disabled submit button. It read as a second layer of double-submit protection.

Mutation testing showed it **unreachable**: HTML blocks implicit submission when the default button is disabled, so the flag already covers the click path *and* the Enter path. Removing the early return changed nothing; removing the disabled attribute failed two tests.

A guard that guards nothing is worse than none, because it reads as protection. It is gone, the comment now says which mechanism actually does the work, and both paths are pinned by tests that fail when the flag is removed.

## Testing

49 tests in `app/client`, 1289 overall. `app/client` at 98.4% statements, 98.4% functions.

Write failures surface in a dismissible banner that never blocks the list — a failed write is not a reason to stop showing what was read — and there is a test that the list survives a dismissal.

The selector policy from #43 holds: the new containers (`create-form`, `edit-form`, `delete-confirm`, `write-error`) get test ids; every new button is found by its accessible name, and the existing test that asserts no button carries a test id still passes.