### PR TITLE
feat(client): filter by status, and the ambiguity it makes possible

### DIFF
--- a/app/client/App.test.tsx
+++ b/app/client/App.test.tsx
@@ -46,6 +46,9 @@ afterEach(() => {
   cleanup()
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
+  // The filter lives in the query string, so a test that set one would otherwise
+  // deep-link the next test into a filtered view.
+  window.history.replaceState(null, '', '/')
 })
 
 describe('loading', () => {
@@ -589,5 +592,136 @@ describe('completing', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Complete' }))
     await waitFor(() => expect(fetchMock.mock.calls.at(-1)?.[0]).toBe('/api/tasks/5/complete'))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Filtering
+// ---------------------------------------------------------------------------
+
+describe('filtering', () => {
+  const mixed = (): Task[] => [
+    task({ id: 1, title: 'still going' }),
+    task({ id: 2, title: 'finished', status: 'completed' }),
+    task({ id: 3, title: 'also finished', status: 'completed' }),
+  ]
+
+  const titles = (): (string | null)[] =>
+    screen
+      .queryAllByTestId('task-item')
+      .map((row) => row.querySelector('.task-title')?.textContent ?? null)
+
+  it('shows everything by default', async () => {
+    fetchMock.mockResolvedValue(respond(mixed()))
+    render(<App />)
+
+    await waitFor(() => expect(screen.getAllByTestId('task-item')).toHaveLength(3))
+    expect(screen.getByRole('button', { name: 'All' }).getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('narrows to active', async () => {
+    fetchMock.mockResolvedValue(respond(mixed()))
+    render(<App />)
+
+    await waitFor(() => expect(screen.getAllByTestId('task-item')).toHaveLength(3))
+    await userEvent.click(screen.getByRole('button', { name: 'Active' }))
+
+    expect(titles()).toEqual(['still going'])
+  })
+
+  it('narrows to completed', async () => {
+    fetchMock.mockResolvedValue(respond(mixed()))
+    render(<App />)
+
+    await waitFor(() => expect(screen.getAllByTestId('task-item')).toHaveLength(3))
+    await userEvent.click(screen.getByRole('button', { name: 'Completed' }))
+
+    expect(titles()).toEqual(['finished', 'also finished'])
+  })
+
+  it('puts the filter in the query string', async () => {
+    fetchMock.mockResolvedValue(respond(mixed()))
+    render(<App />)
+
+    await waitFor(() => expect(screen.getAllByTestId('task-item')).toHaveLength(3))
+    await userEvent.click(screen.getByRole('button', { name: 'Completed' }))
+    expect(window.location.search).toBe('?filter=completed')
+
+    await userEvent.click(screen.getByRole('button', { name: 'All' }))
+    expect(window.location.search).toBe('')
+  })
+
+  /** A shared link has to show what the sharer was looking at. */
+  it('deep-links into a filtered view on load', async () => {
+    window.history.replaceState(null, '', '/?filter=completed')
+    fetchMock.mockResolvedValue(respond(mixed()))
+    render(<App />)
+
+    await waitFor(() => expect(screen.getAllByTestId('task-item')).toHaveLength(2))
+    expect(screen.getByRole('button', { name: 'Completed' }).getAttribute('aria-pressed')).toBe(
+      'true',
+    )
+  })
+
+  it('does not request anything when the filter changes', async () => {
+    fetchMock.mockResolvedValue(respond(mixed()))
+    render(<App />)
+
+    await waitFor(() => expect(screen.getAllByTestId('task-item')).toHaveLength(3))
+    const before = fetchMock.mock.calls.length
+
+    await userEvent.click(screen.getByRole('button', { name: 'Active' }))
+    expect(fetchMock.mock.calls.length).toBe(before)
+  })
+
+  it('survives a mutation', async () => {
+    fetchMock.mockResolvedValueOnce(respond(mixed()))
+    render(<App />)
+
+    await waitFor(() => expect(screen.getAllByTestId('task-item')).toHaveLength(3))
+    await userEvent.click(screen.getByRole('button', { name: 'Active' }))
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ task: task({ id: 4, title: 'brand new' }) }), {
+        status: 201,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+    await userEvent.type(screen.getByLabelText('New task'), 'brand new')
+    await userEvent.click(screen.getByRole('button', { name: 'Add task' }))
+
+    await waitFor(() => expect(titles()).toEqual(['still going', 'brand new']))
+    expect(window.location.search).toBe('?filter=active')
+  })
+
+  it('says which kind of empty it is', async () => {
+    fetchMock.mockResolvedValue(respond([task({ id: 2, status: 'completed' })]))
+    render(<App />)
+
+    await waitFor(() => expect(screen.getAllByTestId('task-item')).toHaveLength(1))
+    await userEvent.click(screen.getByRole('button', { name: 'Active' }))
+
+    expect(screen.getByTestId('empty-state').textContent).toContain('Everything here is done')
+  })
+
+  /**
+   * The point of the feature, and the reason it was chosen. Every row renders the
+   * same status label, so how many elements a text locator matches depends on the
+   * filter — and a Playwright locator resolving to more than one element fails in
+   * strict mode. A spec written under one filter breaks under another for reasons
+   * that have nothing to do with timing, which is exactly the flakiness a
+   * timing-focused classifier misreads.
+   */
+  it('shows text that is unique under one filter and ambiguous under another', async () => {
+    fetchMock.mockResolvedValue(respond(mixed()))
+    render(<App />)
+
+    await waitFor(() => expect(screen.getAllByTestId('task-item')).toHaveLength(3))
+    expect(screen.getAllByText('To do')).toHaveLength(1)
+    expect(screen.getAllByText('Done')).toHaveLength(2)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Active' }))
+    expect(screen.getAllByText('To do')).toHaveLength(1)
+    expect(screen.queryAllByText('Done')).toHaveLength(0)
   })
 })

--- a/app/client/App.tsx
+++ b/app/client/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import type { Task } from './api.js'
+import { FILTERS, useFilter, visible, type Filter } from './useFilter.js'
 import { useTasks, type Tasks } from './useTasks.js'
 
 /**
@@ -39,10 +40,26 @@ import { useTasks, type Tasks } from './useTasks.js'
  *
  * **Text content never gets one.** A title is data; asserting on it is
  * asserting on the fixture, and that is the point.
+ *
+ * ## The list can legitimately show duplicate text, and that is deliberate
+ *
+ * Every row renders the same status label — "To do" or "Done" — so how many
+ * elements a text locator matches depends on the filter. Under `?filter=all` the
+ * seed shows three "To do" and two "Done"; under `?filter=completed` it shows two
+ * "Done" and no "To do" at all. The seed also contains two tasks whose titles
+ * begin "Review the", so a locator built from a partial title matches two rows
+ * under one filter and one under another.
+ *
+ * A Playwright locator that resolves to more than one element fails in strict
+ * mode. So a spec written against one filter, run under another, fails for
+ * reasons that have nothing to do with timing — which is exactly the flakiness a
+ * timing-focused classifier misreads, and exactly what #53 needs to exist.
  */
 
 export function App(): React.JSX.Element {
   const tasks = useTasks()
+  const { filter, setFilter } = useFilter()
+  const shown = visible(tasks.tasks, filter)
 
   return (
     <main className="app">
@@ -54,6 +71,7 @@ export function App(): React.JSX.Element {
       </header>
 
       <CreateForm onCreate={tasks.create} />
+      <FilterBar filter={filter} onChange={setFilter} />
 
       {tasks.writeError !== null && (
         <div className="banner banner-error" data-testid="write-error" role="alert">
@@ -80,14 +98,61 @@ export function App(): React.JSX.Element {
       )}
 
       {tasks.status === 'ready' &&
-        (tasks.tasks.length === 0 ? (
+        (shown.length === 0 ? (
           <p className="state" data-testid="empty-state">
-            Nothing to do. Add a task to get started.
+            {EMPTY[filter]}
           </p>
         ) : (
-          <TaskList tasks={tasks} />
+          <TaskList tasks={tasks} shown={shown} />
         ))}
     </main>
+  )
+}
+
+/**
+ * Different words per filter, because "nothing here" and "nothing matches" are
+ * different facts. A single message would leave a reader unable to tell an empty
+ * database from a filter they forgot they set.
+ */
+const EMPTY: Record<Filter, string> = {
+  all: 'Nothing to do. Add a task to get started.',
+  active: 'No active tasks. Everything here is done.',
+  completed: 'Nothing completed yet.',
+}
+
+const LABEL: Record<Filter, string> = {
+  all: 'All',
+  active: 'Active',
+  completed: 'Completed',
+}
+
+/**
+ * `aria-pressed` rather than a hidden radio group.
+ *
+ * It gives a spec `getByRole('button', { name: 'Active', pressed: true })`, which
+ * says what a user would say, and it keeps the control inside the policy: found
+ * by role and name, with no test id.
+ */
+function FilterBar({
+  filter,
+  onChange,
+}: {
+  filter: Filter
+  onChange: (next: Filter) => void
+}): React.JSX.Element {
+  return (
+    <div className="filter-bar" role="group" aria-label="Filter tasks">
+      {FILTERS.map((option) => (
+        <button
+          key={option}
+          type="button"
+          aria-pressed={filter === option}
+          onClick={() => onChange(option)}
+        >
+          {LABEL[option]}
+        </button>
+      ))}
+    </div>
   )
 }
 
@@ -133,10 +198,10 @@ function CreateForm({ onCreate }: { onCreate: Tasks['create'] }): React.JSX.Elem
   )
 }
 
-function TaskList({ tasks }: { tasks: Tasks }): React.JSX.Element {
+function TaskList({ tasks, shown }: { tasks: Tasks; shown: readonly Task[] }): React.JSX.Element {
   return (
     <ul className="task-list" data-testid="task-list">
-      {tasks.tasks.map((task) => (
+      {shown.map((task) => (
         <TaskRow key={task.id} task={task} tasks={tasks} />
       ))}
     </ul>

--- a/app/client/styles.css
+++ b/app/client/styles.css
@@ -202,3 +202,15 @@ input {
 .edit-form input {
   flex: 1 1 8rem;
 }
+
+.filter-bar {
+  display: flex;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+
+.filter-bar button[aria-pressed='true'] {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: #eff6ff;
+}

--- a/app/client/useFilter.test.ts
+++ b/app/client/useFilter.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import type { Task } from './api.js'
+import { FILTERS, filterQuery, parseFilter, visible } from './useFilter.js'
+
+/**
+ * The pure half of filtering, tested without a DOM.
+ *
+ * The hook itself is exercised through the component, where the query string and
+ * the rendered list can be checked together. These are the parts a deep link
+ * depends on, and a deep link that silently falls back is a shared URL that
+ * shows the wrong thing to whoever opened it.
+ */
+
+const task = (id: number, status: Task['status']): Task => ({
+  id,
+  title: `task ${String(id)}`,
+  description: '',
+  status,
+  position: id,
+  createdAt: '2026-01-15T09:00:00.000Z',
+  updatedAt: '2026-01-15T09:00:00.000Z',
+})
+
+const tasks = [task(1, 'active'), task(2, 'completed'), task(3, 'active')]
+
+describe('reading the filter from a URL', () => {
+  it.each(FILTERS)('recognises %s', (filter) => {
+    expect(parseFilter(`?filter=${filter}`)).toBe(filter)
+  })
+
+  it('defaults to all when there is no parameter', () => {
+    expect(parseFilter('')).toBe('all')
+  })
+
+  /** A typo in a shared link should still show tasks, not an error page. */
+  it.each(['?filter=done', '?filter=', '?other=active', '?filter=ACTIVE'])(
+    'falls back to all for %s',
+    (search) => {
+      expect(parseFilter(search)).toBe('all')
+    },
+  )
+
+  it('ignores the rest of the query string', () => {
+    expect(parseFilter('?utm=x&filter=completed&y=1')).toBe('completed')
+  })
+})
+
+describe('writing the filter to a URL', () => {
+  it('omits the parameter for the default, because the default belongs in the code', () => {
+    expect(filterQuery('all')).toBe('')
+  })
+
+  it.each(['active', 'completed'] as const)('writes %s', (filter) => {
+    expect(filterQuery(filter)).toBe(`?filter=${filter}`)
+  })
+
+  it('round-trips every filter', () => {
+    for (const filter of FILTERS) expect(parseFilter(filterQuery(filter))).toBe(filter)
+  })
+})
+
+describe('applying the filter', () => {
+  it('shows everything under all', () => {
+    expect(visible(tasks, 'all')).toHaveLength(3)
+  })
+
+  it('shows only what is left to do under active', () => {
+    expect(visible(tasks, 'active').map((t) => t.id)).toEqual([1, 3])
+  })
+
+  it('shows only what is finished under completed', () => {
+    expect(visible(tasks, 'completed').map((t) => t.id)).toEqual([2])
+  })
+
+  it('keeps the order it was given rather than sorting again', () => {
+    const reversed = [...tasks].reverse()
+    expect(visible(reversed, 'all').map((t) => t.id)).toEqual([3, 2, 1])
+  })
+
+  it('does not mutate the list it was handed', () => {
+    const original = [...tasks]
+    visible(tasks, 'active')
+    expect(tasks).toEqual(original)
+  })
+})

--- a/app/client/useFilter.ts
+++ b/app/client/useFilter.ts
@@ -1,0 +1,57 @@
+import { useCallback, useState } from 'react'
+import type { Task } from './api.js'
+
+/**
+ * Which tasks the list shows, and the query string that says so.
+ *
+ * No router. One query parameter, read once on mount and written on every
+ * change, is the whole feature — and a routing library would be another
+ * dependency to rule out when a test goes flaky, which is the standing argument
+ * against every dependency in this application.
+ *
+ * `replaceState` rather than `pushState`. A history entry per filter click needs
+ * a `popstate` listener to be worth anything, and without one the back button
+ * appears to do nothing — a worse bug than having no history entry, and a
+ * genuinely confusing one to hit in a Playwright spec that calls `goBack()`.
+ */
+
+export const FILTERS = ['all', 'active', 'completed'] as const
+export type Filter = (typeof FILTERS)[number]
+
+export const PARAM = 'filter'
+
+/** Anything unrecognised is `all`, because a typo in a shared link should still show tasks. */
+export function parseFilter(search: string): Filter {
+  const value = new URLSearchParams(search).get(PARAM)
+  return FILTERS.find((filter) => filter === value) ?? 'all'
+}
+
+/** `?filter=active`, and no parameter at all for `all` — the default belongs in the code. */
+export function filterQuery(filter: Filter): string {
+  return filter === 'all' ? '' : `?${PARAM}=${filter}`
+}
+
+export function useFilter(): { filter: Filter; setFilter: (next: Filter) => void } {
+  const [filter, setLocal] = useState<Filter>(() => parseFilter(window.location.search))
+
+  const setFilter = useCallback((next: Filter) => {
+    setLocal(next)
+    window.history.replaceState(null, '', `${window.location.pathname}${filterQuery(next)}`)
+  }, [])
+
+  return { filter, setFilter }
+}
+
+/**
+ * The filter itself: three states over one field.
+ *
+ * Applied in the client rather than as a server query parameter. It is one line
+ * either way, and doing it here means switching filters never issues a request —
+ * so a spec that changes the filter is not also waiting on a network round trip
+ * it did not ask for.
+ */
+export const visible = (tasks: readonly Task[], filter: Filter): Task[] =>
+  filter === 'all' ? [...tasks] : tasks.filter((task) => task.status === status(filter))
+
+const status = (filter: Exclude<Filter, 'all'>): Task['status'] =>
+  filter === 'completed' ? 'completed' : 'active'

--- a/app/server/api.test.ts
+++ b/app/server/api.test.ts
@@ -255,8 +255,20 @@ describe('the seed', () => {
     expect(seed(db).map((task) => task.createdAt)).toEqual(SEED.map(() => SEED_TIME))
   })
 
-  it('leaves one task completed, so a status filter has something to hide', () => {
-    expect(seed(db).filter((task) => task.status === 'completed')).toHaveLength(1)
+  /**
+   * Two, not one. Every row renders the same status label, so two completed rows
+   * make a text locator match two elements under `?filter=completed` and one
+   * under no filter — the strict-mode ambiguity #53 needs, arriving from the
+   * data rather than from timing.
+   */
+  it('leaves two tasks completed, so a filtered list can show duplicate text', () => {
+    expect(seed(db).filter((task) => task.status === 'completed')).toHaveLength(2)
+  })
+
+  it('gives two tasks titles with a shared prefix, so a partial locator is ambiguous', () => {
+    const reviews = seed(db).filter((task) => task.title.startsWith('Review the'))
+    expect(reviews).toHaveLength(2)
+    expect(reviews.filter((task) => task.status === 'completed')).toHaveLength(1)
   })
 
   it('replaces whatever was there rather than appending', () => {

--- a/app/server/seed.ts
+++ b/app/server/seed.ts
@@ -12,6 +12,19 @@ import { clear, create, update, type Db, type Task } from './db.js'
  *
  * Small on purpose. Five rows is enough for ordering, filtering and drag targets,
  * and few enough to read in a failure message.
+ *
+ * Two details are load-bearing rather than decorative, and both exist so that
+ * #53 has a realistically fragile locator to be flaky about:
+ *
+ * - **Two rows are completed.** Every row renders the same status label, so a
+ *   text locator matches three "To do" and two "Done" under no filter, and two
+ *   "Done" and nothing else under `?filter=completed`. A Playwright locator that
+ *   resolves to more than one element fails in strict mode, so a spec written
+ *   against one filter fails under another for reasons that have nothing to do
+ *   with timing.
+ * - **Two titles begin "Review the".** A locator built from a partial title
+ *   matches two rows under one filter and one under another, which is the same
+ *   failure arriving through the more common mistake.
  */
 
 export const SEED_TIME = '2026-01-15T09:00:00.000Z'
@@ -26,6 +39,7 @@ export const SEED: readonly SeedRow[] = [
   { title: 'Write the incident postmortem', description: 'Due Friday. Include the timeline.' },
   { title: 'Review the migration plan', description: 'Second pass — check the rollback path.' },
   { title: 'Renew the staging certificate', description: '', completed: true },
+  { title: 'Review the release checklist', description: 'Signed off last week.', completed: true },
   { title: 'Draft the release notes', description: 'Wait for the eval numbers first.' },
   { title: 'Triage the flaky board spec', description: 'It has failed four times this week.' },
 ]


### PR DESCRIPTION
Closes #45.

Three states over one field — all / active / completed — reflected in the query string, deep-linkable, and applied in the client so switching filters never issues a request a spec did not ask for.

## The last acceptance criterion is the reason this feature exists

> *The list can legitimately contain duplicate visible text under some filters — documented, as it is used by a flaky spec.*

Every row renders the same status label, so **how many elements a text locator matches depends on which filter is set**. A Playwright locator that resolves to more than one element fails in strict mode. So a spec written under one filter breaks under another for reasons that have nothing to do with timing — which is exactly the flakiness a timing-focused classifier misreads, and exactly what #53 needs to exist.

Making that true needed the seed to change:

- **Two tasks are completed**, not one. Under no filter the list shows one "To do" and two "Done"; under `?filter=active` it shows one "To do" and no "Done" at all.
- **Two titles begin "Review the"**, so the same ambiguity arrives through the more common mistake of locating by a partial title.

Both are asserted in `app/server`, so a later tidy-up that renames one cannot quietly remove a fixture's premise.

## Three smaller decisions

**`replaceState`, not `pushState`.** A history entry per filter click needs a `popstate` listener to be worth anything, and without one the back button appears to do nothing — a worse bug than no history entry, and a confusing one to hit in a spec that calls `goBack()`.

**An unrecognised filter falls back to `all`.** A typo in a shared link should still show tasks.

**The empty state says which kind of empty it is.** "Nothing here" and "nothing matches" are different facts, and one message would leave a reader unable to tell an empty database from a filter they forgot they set.

## Testing

76 tests in `app/client`, 1317 overall. `app/client` at 98.7% statements, 99.2% lines.

Covered: every filter, the query string in both directions, deep-linking on load, that changing the filter issues no request, that the filter survives a mutation, and the ambiguity itself — one "To do" and two "Done" under no filter, one and zero under `active`.

The filter control stays inside the selector policy from #43: found by role and accessible name with `aria-pressed`, and no test id. `getByRole('button', { name: 'Active', pressed: true })` says what a user would say.