### PR TITLE
feat(client): drag-to-reorder, and the race it is meant to have

### DIFF
--- a/app/client/App.test.tsx
+++ b/app/client/App.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { App } from './App.js'
@@ -723,5 +723,219 @@ describe('filtering', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Active' }))
     expect(screen.getAllByText('To do')).toHaveLength(1)
     expect(screen.queryAllByText('Done')).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Reordering
+// ---------------------------------------------------------------------------
+
+describe('reordering', () => {
+  const three = (): Task[] => [
+    task({ id: 1, title: 'first', position: 1 }),
+    task({ id: 2, title: 'second', position: 2 }),
+    task({ id: 3, title: 'third', position: 3 }),
+  ]
+
+  const titles = (): (string | undefined)[] =>
+    screen
+      .getAllByTestId('task-item')
+      .map((row) => row.querySelector('.task-title')?.textContent ?? undefined)
+
+  const rowFor = (title: string): HTMLElement => {
+    const row = screen
+      .getAllByTestId('task-item')
+      .find((element) => element.textContent?.includes(title))
+    if (row === undefined) throw new Error(`no row showing "${title}"`)
+    return row
+  }
+
+  const listed = (tasks: Task[]): Response =>
+    new Response(JSON.stringify({ tasks }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+
+  const ready = async (): Promise<void> => {
+    fetchMock.mockResolvedValueOnce(respond(three()))
+    render(<App />)
+    await waitFor(() => expect(screen.getAllByTestId('task-item')).toHaveLength(3))
+  }
+
+  describe('by keyboard', () => {
+    it('moves a task up one place', async () => {
+      await ready()
+      fetchMock.mockResolvedValueOnce(
+        listed([
+          task({ id: 1, title: 'first' }),
+          task({ id: 3, title: 'third' }),
+          task({ id: 2, title: 'second' }),
+        ]),
+      )
+
+      await userEvent.click(within(rowFor('third')).getByRole('button', { name: 'Move up' }))
+      await waitFor(() => expect(titles()).toEqual(['first', 'third', 'second']))
+    })
+
+    it('moves a task down one place', async () => {
+      await ready()
+      fetchMock.mockResolvedValueOnce(
+        listed([
+          task({ id: 2, title: 'second' }),
+          task({ id: 1, title: 'first' }),
+          task({ id: 3, title: 'third' }),
+        ]),
+      )
+
+      await userEvent.click(within(rowFor('first')).getByRole('button', { name: 'Move down' }))
+      await waitFor(() => expect(titles()).toEqual(['second', 'first', 'third']))
+    })
+
+    /** A control reachable only by drag is unusable without a pointer. */
+    it('offers no move at the ends of the list', async () => {
+      await ready()
+      expect(within(rowFor('first')).getByRole('button', { name: 'Move up' })).toHaveProperty(
+        'disabled',
+        true,
+      )
+      expect(within(rowFor('third')).getByRole('button', { name: 'Move down' })).toHaveProperty(
+        'disabled',
+        true,
+      )
+    })
+  })
+
+  describe('by drag', () => {
+    it('reorders on drop', async () => {
+      await ready()
+      fetchMock.mockResolvedValueOnce(
+        listed([
+          task({ id: 3, title: 'third' }),
+          task({ id: 1, title: 'first' }),
+          task({ id: 2, title: 'second' }),
+        ]),
+      )
+
+      fireEvent.dragStart(rowFor('third'))
+      fireEvent.dragOver(rowFor('first'))
+      fireEvent.drop(rowFor('first'))
+
+      await waitFor(() => expect(titles()).toEqual(['third', 'first', 'second']))
+    })
+
+    it('ignores a drop on the row being dragged', async () => {
+      await ready()
+      fireEvent.dragStart(rowFor('first'))
+      fireEvent.drop(rowFor('first'))
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores a drop with nothing being dragged', async () => {
+      await ready()
+      fireEvent.drop(rowFor('second'))
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  /** The optimistic half. Without it a drag would wait on a round trip to show anything. */
+  it('paints the new order before the server answers', async () => {
+    await ready()
+    fetchMock.mockReturnValueOnce(new Promise(() => undefined))
+
+    await userEvent.click(within(rowFor('third')).getByRole('button', { name: 'Move up' }))
+    expect(titles()).toEqual(['first', 'third', 'second'])
+  })
+
+  /** Dropping onto a row above lands before it; the server is asked for the same thing. */
+  it('asks the server for the index it painted', async () => {
+    await ready()
+    fetchMock.mockReturnValueOnce(new Promise(() => undefined))
+
+    fireEvent.dragStart(rowFor('third'))
+    fireEvent.drop(rowFor('first'))
+
+    expect(titles()).toEqual(['third', 'first', 'second'])
+    const call = fetchMock.mock.calls.at(-1) as unknown as [string, RequestInit]
+    const body = call[1].body
+    expect(call[0]).toBe('/api/tasks/reorder')
+    expect(typeof body === 'string' ? JSON.parse(body) : null).toEqual({ id: 3, index: 0 })
+  })
+
+  it('re-reads the list when the reorder fails', async () => {
+    await ready()
+    fetchMock.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+    fetchMock.mockResolvedValueOnce(respond(three()))
+
+    await userEvent.click(within(rowFor('third')).getByRole('button', { name: 'Move up' }))
+
+    await waitFor(() => expect(screen.getByTestId('write-error')).toBeDefined())
+    await waitFor(() => expect(titles()).toEqual(['first', 'second', 'third']))
+  })
+})
+
+/**
+ * The bug this application exists to have, asserted rather than hidden.
+ *
+ * It is `app_code` + `intermittent` — the hard quadrant — and the whole project
+ * is built to classify it from a trace. A test that pins it is the only thing
+ * standing between "a deliberate fixture" and "somebody tidied it away on a
+ * Friday", so this one fails if the race is fixed, and says so.
+ *
+ * See the comment on `move` in useTasks.ts for the interleaving.
+ */
+describe('the deliberate reconciliation race', () => {
+  const order = (...titles: string[]): Response =>
+    new Response(
+      JSON.stringify({
+        tasks: titles.map((title, index) => task({ id: index + 10, title, position: index + 1 })),
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    )
+
+  it('applies whichever response arrives last, not whichever was sent last', async () => {
+    fetchMock.mockResolvedValueOnce(
+      respond([
+        task({ id: 1, title: 'first', position: 1 }),
+        task({ id: 2, title: 'second', position: 2 }),
+        task({ id: 3, title: 'third', position: 3 }),
+      ]),
+    )
+    render(<App />)
+    await waitFor(() => expect(screen.getAllByTestId('task-item')).toHaveLength(3))
+
+    const titles = (): (string | undefined)[] =>
+      screen
+        .getAllByTestId('task-item')
+        .map((element) => element.querySelector('.task-title')?.textContent ?? undefined)
+    const move = async (title: string, direction: 'Move up' | 'Move down'): Promise<void> => {
+      const row = screen
+        .getAllByTestId('task-item')
+        .find((element) => element.textContent?.includes(title))
+      if (row === undefined) throw new Error(`no row showing "${title}"`)
+      await userEvent.click(within(row).getByRole('button', { name: direction }))
+    }
+
+    // R1 goes out and is held open.
+    let answerFirst: (response: Response) => void = () => undefined
+    fetchMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        answerFirst = resolve
+      }),
+    )
+    await move('third', 'Move up')
+
+    // R2 goes out second and answers first, with the server's order after both.
+    fetchMock.mockResolvedValueOnce(order('after', 'both', 'moves'))
+    await move('second', 'Move up')
+    await waitFor(() => expect(titles()).toEqual(['after', 'both', 'moves']))
+
+    // R1 answers late, carrying the server's order after only the first move.
+    answerFirst(order('after', 'the', 'first'))
+
+    // The newer request's result is overwritten by the older one's response.
+    // The user's second drag is visibly undone; the server still has it, which
+    // is what makes this so hard to catch by hand.
+    await waitFor(() => expect(titles()).toEqual(['after', 'the', 'first']))
   })
 })

--- a/app/client/App.tsx
+++ b/app/client/App.tsx
@@ -198,22 +198,105 @@ function CreateForm({ onCreate }: { onCreate: Tasks['create'] }): React.JSX.Elem
   )
 }
 
+/**
+ * Native HTML drag events, no library.
+ *
+ * Fewer moving parts, and the Playwright interaction is explicit rather than
+ * mediated by a library's event synthesis. The dragged id lives in component
+ * state rather than in `dataTransfer`: the payload is only needed for drags
+ * between windows, and reading it back is unreliable in both jsdom and
+ * Playwright's synthesised events.
+ *
+ * The drop index is the position in the **filtered** list mapped back to the
+ * full one. Dropping onto row three of a filtered view means "after the two rows
+ * above it", not "at index 3 of everything" — the latter would move a task
+ * somewhere the user cannot see, which is a bug that only appears when a filter
+ * is set and is therefore very hard to notice.
+ */
 function TaskList({ tasks, shown }: { tasks: Tasks; shown: readonly Task[] }): React.JSX.Element {
+  const [dragging, setDragging] = useState<number | null>(null)
+
+  const drop = (target: Task): void => {
+    if (dragging === null || dragging === target.id) return
+    void tasks.move(dragging, indexOf(tasks.tasks, target))
+    setDragging(null)
+  }
+
   return (
     <ul className="task-list" data-testid="task-list">
-      {shown.map((task) => (
-        <TaskRow key={task.id} task={task} tasks={tasks} />
+      {shown.map((task, position) => (
+        <TaskRow
+          key={task.id}
+          task={task}
+          tasks={tasks}
+          neighbours={{ above: shown[position - 1], below: shown[position + 1] }}
+          onDragStart={() => setDragging(task.id)}
+          onDrop={() => drop(task)}
+        />
       ))}
     </ul>
   )
 }
 
-function TaskRow({ task, tasks }: { task: Task; tasks: Tasks }): React.JSX.Element {
+/**
+ * Where a drop onto `target` lands, as an index in the unfiltered list.
+ *
+ * `move` reads its index against the list with the dragged task removed, which
+ * gives drag-up and drag-down the asymmetry a person expects for free: dragging
+ * *down* onto a row lands after it, because removing the dragged task shifts the
+ * target up one; dragging *up* lands before it, because it does not.
+ */
+const indexOf = (all: readonly Task[], target: Task): number =>
+  Math.max(
+    0,
+    all.findIndex((task) => task.id === target.id),
+  )
+
+function TaskRow({
+  task,
+  tasks,
+  neighbours,
+  onDragStart,
+  onDrop,
+}: {
+  task: Task
+  tasks: Tasks
+  neighbours: { above?: Task | undefined; below?: Task | undefined }
+  onDragStart: () => void
+  onDrop: () => void
+}): React.JSX.Element {
   const [editing, setEditing] = useState(false)
   const [confirming, setConfirming] = useState(false)
 
+  /**
+   * Swap with a neighbour, by index in the full list.
+   *
+   * The keyboard path exists because it must — a control reachable only by drag
+   * is unusable without a pointer — and because HTML drag-and-drop is
+   * notoriously hard to drive from Playwright. The specs in #51 and #53 use
+   * these buttons; the drag is what a person uses.
+   */
+  const swapWith = (other: Task | undefined): void => {
+    if (other === undefined) return
+    void tasks.move(
+      task.id,
+      tasks.tasks.findIndex((row) => row.id === other.id),
+    )
+  }
+
   return (
-    <li className={`task task-${task.status}`} data-testid="task-item" data-task-id={task.id}>
+    <li
+      className={`task task-${task.status}`}
+      data-testid="task-item"
+      data-task-id={task.id}
+      draggable
+      onDragStart={onDragStart}
+      onDragOver={(event) => event.preventDefault()}
+      onDrop={(event) => {
+        event.preventDefault()
+        onDrop()
+      }}
+    >
       <span className="task-status" data-testid="task-status">
         {task.status === 'completed' ? 'Done' : 'To do'}
       </span>
@@ -235,6 +318,21 @@ function TaskRow({ task, tasks }: { task: Task; tasks: Tasks }): React.JSX.Eleme
       )}
 
       <div className="task-actions">
+        <button
+          type="button"
+          disabled={neighbours.above === undefined}
+          onClick={() => swapWith(neighbours.above)}
+        >
+          Move up
+        </button>
+        <button
+          type="button"
+          disabled={neighbours.below === undefined}
+          onClick={() => swapWith(neighbours.below)}
+        >
+          Move down
+        </button>
+
         <button type="button" onClick={() => void tasks.toggle(task)}>
           {task.status === 'completed' ? 'Reopen' : 'Complete'}
         </button>

--- a/app/client/useTasks.ts
+++ b/app/client/useTasks.ts
@@ -47,6 +47,7 @@ export interface Tasks extends TasksState {
   edit: (id: number, patch: { title?: string; description?: string }) => Promise<void>
   remove: (id: number) => Promise<void>
   toggle: (task: Task) => Promise<void>
+  move: (id: number, index: number) => Promise<void>
   dismissWriteError: () => void
 }
 
@@ -156,9 +157,82 @@ export function useTasks(): Tasks {
     }
   }, [])
 
+  /**
+   * Optimistic reorder — and the deliberate bug this application exists to have.
+   *
+   * ## What it does
+   *
+   * Move the row locally, send the index, then replace the list with whatever
+   * the server returns. The optimistic half is why a drag feels immediate; the
+   * reconciliation is what makes the client agree with the server about an order
+   * the server computes.
+   *
+   * ## The race, and the exact interleaving that triggers it
+   *
+   * Responses are applied in the order they **arrive**, and nothing checks that
+   * an arriving response is the newest one. So:
+   *
+   * 1. Drag A. The list paints order `A'`, request R1 goes out.
+   * 2. Drag B, before R1 has answered. The list paints order `B'`, request R2
+   *    goes out.
+   * 3. The server applies R1 then R2 and is now in the order the user intended.
+   * 4. **R1's response arrives after R2's.** The last `setState` wins, so the
+   *    list is replaced with the server's order *as of R1* — the second drag is
+   *    visibly undone, and a refresh brings it back, because the server had it
+   *    all along.
+   *
+   * ## Why it is still here
+   *
+   * On purpose, and this comment is the documentation the issue asks for. It is
+   * `app_code` + `intermittent` — the hard quadrant — and it is the failure the
+   * whole project is built to classify. A correctly written test catches it some
+   * of the time and passes the rest, which is precisely the shape a rerun-until-
+   * green culture ships to users.
+   *
+   * It is not reproducible on a normal machine: the two responses come back in
+   * microseconds and in order. `SENTRA_CHAOS=<seed>` (#47) delays the first more
+   * than the second and makes the interleaving happen every time, which is what
+   * separates emergent flakiness from a scripted sleep.
+   *
+   * **Do not fix this without deleting the fixtures that depend on it.** The
+   * one-line fix is a request sequence number, ignoring any response older than
+   * the newest sent.
+   */
+  const move = useCallback(
+    async (id: number, index: number): Promise<void> => {
+      setState((current) => ({
+        ...current,
+        writeError: null,
+        tasks: reposition(current.tasks, id, index),
+      }))
+
+      try {
+        const tasks = await api.reorderTask(id, index)
+        setState((current) => ({ ...current, tasks }))
+      } catch (failure) {
+        // A failed reorder does re-read, because unlike the other writes there is
+        // no single field to put back: the optimistic move already renumbered the
+        // list, and guessing at the previous order would invent one.
+        setState((current) => ({ ...current, writeError: message(failure) }))
+        await reload()
+      }
+    },
+    [reload],
+  )
+
   const dismissWriteError = useCallback(() => {
     setState((current) => ({ ...current, writeError: null }))
   }, [])
 
-  return { ...state, reload, create, edit, remove, toggle, dismissWriteError }
+  return { ...state, reload, create, edit, remove, toggle, move, dismissWriteError }
+}
+
+/** Local preview of the move the server is about to make. Same rule: index in the result. */
+export function reposition(tasks: readonly Task[], id: number, index: number): Task[] {
+  const moved = tasks.find((task) => task.id === id)
+  if (moved === undefined) return [...tasks]
+
+  const others = tasks.filter((task) => task.id !== id)
+  const at = Math.min(Math.max(Math.trunc(index), 0), others.length)
+  return [...others.slice(0, at), moved, ...others.slice(at)]
 }

--- a/docs/limitations-and-guardrails.md
+++ b/docs/limitations-and-guardrails.md
@@ -20,6 +20,19 @@ about honest reporting.
 | Agents never push, tag, or open PRs                  | **planned** — #63 | A read-only `simple-git` facade exposing `diff`, `log`, `show`. Today the dependency is not installed and no agent reads git at all, so the guarantee holds by absence rather than by design — which is not the same thing and will stop being true in M7.                   |
 | Fix suggestions are never applied                    | **planned** — #65 | `patch` will be a string rendered inside a fenced code block, with no code path to an apply step, and a test asserting it. Today there is no fix-suggestion agent, so there is nothing to apply and nothing enforcing that there never will be.                              |
 
+## The bug that is left in on purpose
+
+TaskFlow's optimistic reorder applies responses in the order they **arrive** and never checks that
+an arriving response is the newest one. Two drags in quick succession, with the first response
+landing last, leave the list showing the server's order as of the _first_ drag — the second is
+visibly undone, and a refresh brings it back because the server had it all along.
+
+It is `app_code` + `intermittent`, the hard quadrant, and it is the failure this whole project is
+built to classify. Documented in `app/client/useTasks.ts` with the exact interleaving, pinned by a
+test that fails if somebody fixes it, and reproducible on demand under `SENTRA_CHAOS` (#47) rather
+than by a sleep in a spec. The point is that the classifier has to work it out from a trace, not
+that the bug is a secret.
+
 ## What the system genuinely cannot do
 
 - **It cannot reproduce a failure.** It reads a trace after the fact. It cannot rerun a test in


### PR DESCRIPTION
Closes #46. The centrepiece of the application.

Native HTML drag events, no library — fewer moving parts, and the Playwright interaction is explicit rather than mediated by a library's event synthesis. The dragged id lives in component state rather than `dataTransfer`, whose payload is only needed for drags between windows and is unreliable to read back in both jsdom and synthesised events.

## Keyboard reordering is not a courtesy

A control reachable only by drag is unusable without a pointer. It is also the practical path for the specs: HTML drag-and-drop is notoriously hard to drive from Playwright, so #51 and #53 will use **Move up** and **Move down**, and the drag is what a person uses.

## The race, left in and written down

Responses are applied in the order they **arrive**, and nothing checks that an arriving response is the newest one:

1. Drag A paints, R1 goes out.
2. Drag B paints, R2 goes out.
3. The server applies R1 then R2 and now holds the order the user intended.
4. **R1's response arrives after R2's.** The list is replaced with the server's order *as of R1* — the second drag is visibly undone, and a refresh brings it back, because the server had it all along.

That is `app_code` + `intermittent` — the hard quadrant — and it is the failure this whole project is built to classify. The interleaving is documented on `move` in `useTasks.ts`, and now in `docs/limitations-and-guardrails.md` under a heading that says it is deliberate.

**A test pins it and fails if it is fixed.** I checked by writing the one-line fix — a request sequence number that ignores stale responses — and watching the test go red, then reverting. Without that test the fixture is one Friday tidy-up away from disappearing, and the comment says so in as many words.

It is not reproducible on a normal machine; both responses come back in microseconds and in order. `SENTRA_CHAOS` (#47, next) is what makes the interleaving happen on demand, which is the difference between emergent flakiness and a sleep in a spec.

## Two details that fell out rather than being coded twice

Dropping onto a row **above** lands before it; onto a row **below**, after it. That asymmetry is what a person expects, and it comes free from the server's index-after-removal rule — the client does not implement its own version.

A failed reorder **re-reads the list**. Unlike the other writes there is no single field to put back: the optimistic move already renumbered everything, and guessing at the previous order would invent one.

## Testing

86 tests in `app/client`, 1327 overall. Covered: both keyboard directions, the disabled ends, drop, drop-on-self, drop-with-nothing-dragged, the optimistic paint, the index actually sent to the server, the failure re-read — and the race itself.