### PR TITLE
feat(server): seeded latency injection, off unless asked for

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,14 @@ SENTRA_CONCURRENCY=4
 # gating on it rather than to pick a number that looks reasonable.
 SENTRA_ROOT_CAUSE_THRESHOLD=0.7
 
+# Seeded latency injection in the TaskFlow API. Unset means off, and a test
+# asserts that. The same seed always produces the same interleaving, so a race
+# caught once can be got back — which is what separates emergent flakiness from
+# a sleep in a spec.
+#
+# SENTRA_CHAOS=37 reproduces the deliberate reorder race in app/client/useTasks.ts.
+SENTRA_CHAOS=
+
 # TaskFlow, the system under test.
 #
 # SENTRA_DB is the SQLite file the API opens. It defaults to .taskflow/tasks.db

--- a/README.md
+++ b/README.md
@@ -137,6 +137,25 @@ npm test                # 🚧 M5 — unit + e2e, produces results.json
 npm run analyze         # 🚧 M8 — flakemetry + agents, produces report.md
 ```
 
+**Reproduce the deliberate bug:**
+
+```bash
+SENTRA_CHAOS=37 npm run dev     # 🚧 M4 · #48 — seeded latency, off unless you ask
+```
+
+TaskFlow's optimistic reorder applies responses in the order they _arrive_ and never checks that an
+arriving response is the newest one. Drag two tasks less than about 350ms apart and the second drag
+is visibly undone — then refresh, and it comes back, because the server had it all along.
+
+That is `app_code` + `intermittent`, the hard quadrant, and it is the failure this project exists to
+classify. It is left in on purpose and
+[documented](docs/limitations-and-guardrails.md#the-bug-that-is-left-in-on-purpose) rather than
+hidden: the point is that the _classifier_ has to work it out from a trace.
+
+`SENTRA_CHAOS=<seed>` delays API responses on a seeded schedule — the same seed always produces the
+same interleaving, so a failure can be got back. Seed 37 delays the first reorder by 399ms and the
+second by 11ms. Off by default, and a test asserts it.
+
 **Check the classifier's accuracy yourself:**
 
 ```bash

--- a/app/server/app.ts
+++ b/app/server/app.ts
@@ -1,5 +1,6 @@
 import express, { type Express, type NextFunction, type Request, type Response } from 'express'
 import { z } from 'zod'
+import { OFF, type Chaos } from './chaos.js'
 import { create, find, list, remove, reorder, update, type Db, type Task } from './db.js'
 
 /**
@@ -22,6 +23,10 @@ export interface AppDeps {
   db: Db
   /** Injected so a test can pin timestamps rather than assert around them. */
   now?: () => string
+  /** Seeded latency injection. Off unless the environment asks for it — see chaos.ts. */
+  chaos?: Chaos
+  /** Injected so a chaos test does not spend real seconds proving a delay happened. */
+  sleep?: (ms: number) => Promise<void>
 }
 
 const TitleSchema = z.string().trim().min(1).max(200)
@@ -77,8 +82,30 @@ export function createApp(deps: AppDeps): Express {
   const { db } = deps
   const now = deps.now ?? (() => new Date().toISOString())
 
+  const chaos = deps.chaos ?? OFF
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)))
+
   const app = express()
   app.use(express.json({ limit: '64kb' }))
+
+  /**
+   * The delay goes here — before the handler, after parsing — so it changes when
+   * a response *arrives* relative to other in-flight requests without changing
+   * what any handler does. That is the whole point: the interleaving moves, the
+   * application does not.
+   *
+   * `route` is the pattern rather than the path, so `/api/tasks/7/complete` and
+   * `/api/tasks/9/complete` share a profile instead of being two unknown routes
+   * that fall through to no delay at all.
+   */
+  if (chaos.enabled) {
+    app.use((request, _response, next) => {
+      const ms = chaos.delay(`${request.method} ${pattern(request.path)}`)
+      void sleep(ms).then(() => {
+        next()
+      })
+    })
+  }
 
   app.get('/api/health', (_request, response) => {
     response.json({ status: 'ok' })
@@ -168,6 +195,20 @@ export function createApp(deps: AppDeps): Express {
   })
 
   return app
+}
+
+/**
+ * The route a path belongs to, as a pattern.
+ *
+ * Derived here rather than read from Express, because middleware runs before
+ * routing and `request.route` is not populated yet. Six patterns is few enough
+ * to spell out, and a wrong guess costs a delay of zero rather than an error.
+ */
+export function pattern(path: string): string {
+  if (path === '/api/tasks/reorder') return '/api/tasks/reorder'
+  if (/^\/api\/tasks\/\d+\/complete$/.test(path)) return '/api/tasks/:id/complete'
+  if (/^\/api\/tasks\/\d+$/.test(path)) return '/api/tasks/:id'
+  return path
 }
 
 const identifier = (request: Request): number | null => {

--- a/app/server/chaos.test.ts
+++ b/app/server/chaos.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest'
+import { createApp, pattern } from './app.js'
+import { chaosFrom, generator, OFF, PROFILE, seedFrom } from './chaos.js'
+import { open, type Db } from './db.js'
+
+/**
+ * The chaos layer, and the property that makes it worth having.
+ *
+ * A random sleep would be easier and useless: a failure nobody can reproduce is
+ * a failure nobody can debug, and the golden dataset needs specific interleavings
+ * captured deterministically. So the interesting assertions here are about
+ * *sameness* — the same seed producing the same sequence — and about the layer
+ * being off unless it is asked for, because a server quietly injecting latency
+ * makes every test in the suite suspect.
+ */
+
+describe('the seed', () => {
+  it.each([
+    ['unset', {}],
+    ['empty', { SENTRA_CHAOS: '' }],
+    ['whitespace', { SENTRA_CHAOS: '  ' }],
+    ['not a number', { SENTRA_CHAOS: 'yes' }],
+    ['fractional', { SENTRA_CHAOS: '1.5' }],
+    ['negative', { SENTRA_CHAOS: '-1' }],
+  ])('is off when %s', (_case, env) => {
+    expect(seedFrom(env)).toBeNull()
+    expect(chaosFrom(env).enabled).toBe(false)
+  })
+
+  /**
+   * A debugging switch should not refuse to start over a typo — but zero is a
+   * valid seed and must not be read as "false", which is the bug this pins.
+   */
+  it('treats zero as a seed rather than as off', () => {
+    expect(seedFrom({ SENTRA_CHAOS: '0' })).toBe(0)
+    expect(chaosFrom({ SENTRA_CHAOS: '0' }).enabled).toBe(true)
+  })
+
+  it('reads a whole number', () => {
+    expect(chaosFrom({ SENTRA_CHAOS: '4242' })).toMatchObject({ enabled: true, seed: 4242 })
+  })
+})
+
+describe('when it is off', () => {
+  it('delays nothing at all', () => {
+    const chaos = chaosFrom({})
+    expect(chaos.delay('PATCH /api/tasks/reorder')).toBe(0)
+    expect(chaos.delay('GET /api/tasks')).toBe(0)
+  })
+
+  it('is the same object shape as when it is on, so nothing branches on presence', () => {
+    expect(Object.keys(OFF).sort()).toEqual(Object.keys(chaosFrom({ SENTRA_CHAOS: '1' })).sort())
+  })
+})
+
+describe('when it is on', () => {
+  const sequence = (seed: string, routes: string[]): number[] => {
+    const chaos = chaosFrom({ SENTRA_CHAOS: seed })
+    return routes.map((route) => chaos.delay(route))
+  }
+
+  const REQUESTS = [
+    'PATCH /api/tasks/reorder',
+    'PATCH /api/tasks/reorder',
+    'GET /api/tasks',
+    'POST /api/tasks',
+  ]
+
+  /** The whole point. A failure that cannot be reproduced cannot be debugged. */
+  it('produces the same sequence for the same seed, every time', () => {
+    expect(sequence('7', REQUESTS)).toEqual(sequence('7', REQUESTS))
+    expect(sequence('7', REQUESTS)).toEqual(sequence('7', REQUESTS))
+  })
+
+  it('produces a different sequence for a different seed', () => {
+    expect(sequence('7', REQUESTS)).not.toEqual(sequence('8', REQUESTS))
+  })
+
+  /**
+   * One generator across all routes, advancing once per request. Per-route
+   * generators would make a delay depend on how many requests of that kind came
+   * before it, so two runs differing by a single extra GET would diverge.
+   */
+  it('advances one shared sequence, so an extra request shifts what follows', () => {
+    const withExtra = sequence('7', ['GET /api/tasks', ...REQUESTS])
+    expect(withExtra.slice(1)).not.toEqual(sequence('7', REQUESTS))
+  })
+
+  it('stays inside the documented range for each endpoint', () => {
+    const chaos = chaosFrom({ SENTRA_CHAOS: '99' })
+    for (const [route, { min, max }] of Object.entries(PROFILE)) {
+      for (let i = 0; i < 50; i++) {
+        const delay = chaos.delay(route)
+        expect(delay).toBeGreaterThanOrEqual(min)
+        expect(delay).toBeLessThanOrEqual(max)
+      }
+    }
+  })
+
+  /** Reordering needs the widest range: the race is two reorders whose delays differ. */
+  it('gives reordering more room than anything else', () => {
+    const reorder = PROFILE['PATCH /api/tasks/reorder']?.max ?? 0
+    for (const [route, { max }] of Object.entries(PROFILE)) {
+      if (route !== 'PATCH /api/tasks/reorder') expect(reorder).toBeGreaterThan(max)
+    }
+  })
+
+  /** A dev command waits on health to know the server is up. */
+  it('never delays a route it has no profile for', () => {
+    expect(chaosFrom({ SENTRA_CHAOS: '5' }).delay('GET /api/health')).toBe(0)
+  })
+})
+
+/**
+ * The seed the README tells people to use, pinned so the README cannot rot.
+ *
+ * A documented reproduction that quietly stops reproducing is worse than none:
+ * somebody follows it, sees the bug not happen, and concludes it was fixed.
+ */
+describe('the seed that reproduces the reorder race', () => {
+  const RACE_SEED = '37'
+
+  it('delays the first reorder far longer than the second', () => {
+    const chaos = chaosFrom({ SENTRA_CHAOS: RACE_SEED })
+
+    // The sequence a session actually makes: load the list, then two drags.
+    chaos.delay('GET /api/tasks')
+    const first = chaos.delay('PATCH /api/tasks/reorder')
+    const second = chaos.delay('PATCH /api/tasks/reorder')
+
+    expect(first).toBe(399)
+    expect(second).toBe(11)
+
+    // The window is what matters: the second response can arrive first as long
+    // as the two drags are less than this far apart.
+    expect(first - second).toBeGreaterThan(350)
+  })
+})
+
+describe('the generator', () => {
+  it('is reproducible from its seed', () => {
+    const a = generator(123)
+    const b = generator(123)
+    expect([a(), a(), a()]).toEqual([b(), b(), b()])
+  })
+
+  it('stays inside [0, 1)', () => {
+    const random = generator(1)
+    for (let i = 0; i < 1000; i++) {
+      const value = random()
+      expect(value).toBeGreaterThanOrEqual(0)
+      expect(value).toBeLessThan(1)
+    }
+  })
+
+  it('does not get stuck on one value', () => {
+    const random = generator(2)
+    expect(new Set(Array.from({ length: 20 }, () => random())).size).toBeGreaterThan(15)
+  })
+})
+
+describe('the route pattern', () => {
+  it.each([
+    ['/api/tasks', '/api/tasks'],
+    ['/api/tasks/reorder', '/api/tasks/reorder'],
+    ['/api/tasks/7', '/api/tasks/:id'],
+    ['/api/tasks/7/complete', '/api/tasks/:id/complete'],
+    ['/api/health', '/api/health'],
+  ])('reads %s as %s', (path, expected) => {
+    expect(pattern(path)).toBe(expected)
+  })
+
+  /**
+   * `reorder` is not a number, so it must not be read as an id — which is the
+   * same trap the route registration order guards against, arriving here through
+   * a different door.
+   */
+  it('does not mistake reorder for an id', () => {
+    expect(pattern('/api/tasks/reorder')).not.toBe('/api/tasks/:id')
+  })
+})
+
+// ---------------------------------------------------------------------------
+
+describe('the server with chaos on', () => {
+  const run = async (
+    env: Record<string, string>,
+  ): Promise<{ delays: number[]; status: number }> => {
+    const db: Db = open(':memory:')
+    const delays: number[] = []
+    const app = createApp({
+      db,
+      chaos: chaosFrom(env),
+      // Recorded rather than waited on: this asserts that a delay was applied,
+      // not that a test can spend real seconds proving it.
+      sleep: (ms) => {
+        delays.push(ms)
+        return Promise.resolve()
+      },
+    })
+
+    const server = app.listen(0)
+    const port = (server.address() as { port: number }).port
+    const response = await fetch(`http://127.0.0.1:${String(port)}/api/tasks`)
+
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+    db.close()
+    return { delays, status: response.status }
+  }
+
+  it('delays a request when a seed is set', async () => {
+    const { delays, status } = await run({ SENTRA_CHAOS: '11' })
+    expect(status).toBe(200)
+    expect(delays).toHaveLength(1)
+  })
+
+  /** Left on, every run becomes noise and the suite stops meaning anything. */
+  it('delays nothing when no seed is set', async () => {
+    expect((await run({})).delays).toEqual([])
+  })
+
+  it('still answers correctly with chaos on', async () => {
+    expect((await run({ SENTRA_CHAOS: '11' })).status).toBe(200)
+  })
+})

--- a/app/server/chaos.ts
+++ b/app/server/chaos.ts
@@ -1,0 +1,130 @@
+/**
+ * Seeded, reproducible latency injection. Off unless asked for.
+ *
+ * This is the difference between flakiness that is *scripted* and flakiness that
+ * is *emergent*. A test with a random sleep in it is not a flaky test — it is a
+ * test that fails on purpose, and it poses a classification problem that is
+ * trivially easy and not worth solving. Delaying the *server* changes the
+ * interleaving of requests the client already makes, and the failure that comes
+ * out is the application's own.
+ *
+ * **Seeded, not random.** Two reasons, and both are about being able to use the
+ * result: a failure has to be reproducible to be debugged, and the golden
+ * dataset needs specific interleavings captured deterministically (#56). A
+ * random delay gives a failure nobody can get back.
+ *
+ * **Server-side only.** Nothing is injected into test code. A spec that sleeps is
+ * a spec that says what it expects to happen; the point here is that the spec
+ * says nothing and the race happens anyway.
+ *
+ * **Off by default, and asserted to be.** Left on, every run becomes noise and
+ * the suite stops meaning anything.
+ *
+ * ## The seed that reproduces the reorder race
+ *
+ * `SENTRA_CHAOS=37`. On the request sequence a session actually makes — load the
+ * list, then two drags — it delays the first reorder by 399ms and the second by
+ * 11ms. Any two drags less than about 350ms apart therefore have their responses
+ * arrive in the wrong order, which is the interleaving documented on `move` in
+ * `app/client/useTasks.ts`. A test pins those numbers, because a documented
+ * reproduction that quietly stops reproducing is worse than none: somebody
+ * follows it, sees nothing happen, and concludes the bug was fixed.
+ */
+
+/** Per-endpoint delay ranges, in milliseconds. */
+export interface Profile {
+  min: number
+  max: number
+}
+
+/**
+ * What each endpoint can be delayed by.
+ *
+ * Reordering gets the widest range because it is the one the race needs: two
+ * reorders whose delays differ by more than the gap between the clicks is
+ * exactly the interleaving in `useTasks.move`. Reads are delayed a little so a
+ * spec cannot rely on the list being instant, and health is never delayed at all
+ * — it is what a dev command waits on to know the server is up, and delaying it
+ * would slow every start for no signal.
+ */
+export const PROFILE: Readonly<Record<string, Profile>> = {
+  'PATCH /api/tasks/reorder': { min: 0, max: 400 },
+  'PATCH /api/tasks/:id/complete': { min: 0, max: 250 },
+  'PATCH /api/tasks/:id': { min: 0, max: 150 },
+  'POST /api/tasks': { min: 0, max: 150 },
+  'DELETE /api/tasks/:id': { min: 0, max: 150 },
+  'GET /api/tasks': { min: 0, max: 60 },
+}
+
+export const DEFAULT_PROFILE: Profile = { min: 0, max: 0 }
+
+/**
+ * A 32-bit mulberry generator.
+ *
+ * Small, well-known, and — the part that matters here — entirely reproducible
+ * from its seed. `Math.random` cannot be seeded, and a dependency for eight
+ * lines would be one more thing to rule out when a test goes flaky.
+ */
+export function generator(seed: number): () => number {
+  let state = seed >>> 0
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0
+    let t = state
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+export interface ChaosEnv {
+  SENTRA_CHAOS?: string | undefined
+}
+
+/**
+ * The seed, or null for off.
+ *
+ * Any value that is not a whole number is off rather than an error. This is a
+ * debugging switch, and refusing to start because somebody typed `SENTRA_CHAOS=`
+ * would be a worse failure than ignoring it — but `SENTRA_CHAOS=0` is a valid
+ * seed and must not be read as "false".
+ */
+export function seedFrom(env: ChaosEnv): number | null {
+  const raw = env.SENTRA_CHAOS
+  if (raw === undefined || raw.trim() === '') return null
+
+  const parsed = Number(raw)
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : null
+}
+
+export interface Chaos {
+  enabled: boolean
+  seed: number | null
+  /** Milliseconds to delay this request. Always 0 when disabled. */
+  delay: (route: string) => number
+}
+
+export const OFF: Chaos = { enabled: false, seed: null, delay: () => 0 }
+
+/**
+ * A chaos source for one process.
+ *
+ * The generator is shared across routes and advances once per delayed request,
+ * so the *sequence* of delays is what the seed fixes — which is the thing a
+ * reproduction needs. Per-route generators would make a delay depend on how many
+ * requests of that kind came before it, and two runs that differ by one extra
+ * `GET` would diverge.
+ */
+export function chaosFrom(env: ChaosEnv): Chaos {
+  const seed = seedFrom(env)
+  if (seed === null) return OFF
+
+  const random = generator(seed)
+  return {
+    enabled: true,
+    seed,
+    delay: (route) => {
+      const { min, max } = PROFILE[route] ?? DEFAULT_PROFILE
+      return Math.round(min + random() * (max - min))
+    },
+  }
+}

--- a/app/server/index.ts
+++ b/app/server/index.ts
@@ -1,4 +1,5 @@
 import { createApp } from './app.js'
+import { chaosFrom } from './chaos.js'
 import { open } from './db.js'
 import { seed } from './seed.js'
 
@@ -13,6 +14,7 @@ import { seed } from './seed.js'
  * without a port or a temporary directory.
  */
 
+export * from './chaos.js'
 export * from './db.js'
 export * from './app.js'
 export * from './seed.js'
@@ -37,9 +39,15 @@ export function serve(options: ServeOptions = {}): { close: () => Promise<void>;
   const db = open(path)
   if (options.reseed === true) seed(db)
 
-  const server = createApp({ db }).listen(port)
+  const chaos = chaosFrom(process.env)
+  const server = createApp({ db, chaos }).listen(port)
   const bound = address(server, port)
   log(`  TaskFlow API on http://localhost:${String(bound)} (${path})`)
+  if (chaos.enabled) {
+    // Said out loud, every time. A server quietly injecting latency is a server
+    // that makes every test in the suite suspect.
+    log(`  SENTRA_CHAOS=${String(chaos.seed)} — seeded latency injection is ON`)
+  }
 
   return {
     port: bound,


### PR DESCRIPTION
Closes #47.

This is the difference between flakiness that is **scripted** and flakiness that is **emergent**. A test with a random sleep in it is not a flaky test — it is a test that fails on purpose, and it poses a classification problem that is trivially easy and not worth solving.

Delaying the *server* changes the interleaving of requests the client already makes, and the failure that comes out is the application's own.

## Seeded, not random

Both uses need it: a failure has to be reproducible to be debugged, and the golden dataset needs specific interleavings captured deterministically (#56).

**One generator shared across routes**, advancing once per request, so the seed fixes the whole *sequence*. Per-route generators would make a delay depend on how many requests of that kind came before it, and two runs differing by a single `GET` would diverge — which is a reproduction that does not reproduce.

The delay sits **before the handler and after parsing**, so it changes when a response arrives relative to other requests in flight without changing what any handler does. The interleaving moves; the application does not.

## The documented seed

`SENTRA_CHAOS=37` delays the first reorder by **399ms** and the second by **11ms**, so any two drags less than about 350ms apart come back out of order — the interleaving documented on `move` in `useTasks.ts`, from #46.

Those numbers are **pinned by a test**. A documented reproduction that quietly stops reproducing is worse than none: somebody follows it, sees nothing happen, and concludes the bug was fixed.

The README now carries the reproduction, the range table lives in `chaos.ts`, and reordering deliberately gets the widest range because it is the one the race needs.

## Off by default, and asserted

- Unset, empty, whitespace, non-numeric and negative all mean off.
- **Zero is a seed**, not a falsy value — that is the bug the test pins.
- Anything else unparseable is off rather than an error: a debugging switch should not refuse to start over a typo.
- The server **says out loud** when it is on. A server quietly injecting latency makes every test in the suite suspect.
- `/api/health` is never delayed — a dev command waits on it to know the server is up.

## Server-side only

Nothing is injected into test code, per the acceptance criteria. A spec that sleeps is a spec saying what it expects to happen; the point here is that the spec says nothing and the race happens anyway.

## Testing

82 tests in `app/server`, 1357 overall. The chaos suite covers reproducibility across seeds, the shared-sequence property, the documented ranges, the route-pattern mapping (`/api/tasks/reorder` must not be read as an id), and the middleware itself — with `sleep` injected, so asserting that a delay was applied costs no wall-clock.

The repository's own status-banner check caught the README snippet using `npm run dev` before #48 lands; it carries the pending marker until the next PR removes it.