### PR TITLE
feat(app): one dev command for the API and the client

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ And what does not yet, with the milestone it arrives in:
 
 ```bash
 npm run demo            # full pipeline, no API key — writes report.md
-npm run dev             # 🚧 M4 · #48 — start TaskFlow locally
+npm run dev             # start TaskFlow locally — API + client, Ctrl-C stops both
 npm test                # 🚧 M5 · #50 — unit and e2e together
 ```
 

--- a/README.md
+++ b/README.md
@@ -137,10 +137,19 @@ npm test                # 🚧 M5 — unit + e2e, produces results.json
 npm run analyze         # 🚧 M8 — flakemetry + agents, produces report.md
 ```
 
+**Run TaskFlow locally:**
+
+```bash
+npm run dev             # API on :3001, client on :5173, Ctrl-C stops both
+```
+
+Ports come from `PORT` and `VITE_PORT`; a collision says so in a sentence rather than a stack
+trace. The client proxies `/api` to the API, so there is no CORS layer to reason about.
+
 **Reproduce the deliberate bug:**
 
 ```bash
-SENTRA_CHAOS=37 npm run dev     # 🚧 M4 · #48 — seeded latency, off unless you ask
+SENTRA_CHAOS=37 npm run dev     # seeded latency, off unless you ask
 ```
 
 TaskFlow's optimistic reorder applies responses in the order they _arrive_ and never checks that an
@@ -168,7 +177,7 @@ cat eval/report.md
 | Script                       | Milestone | What it does                                                  |
 | ---------------------------- | --------- | ------------------------------------------------------------- |
 | `npm run help`               | M0        | Annotated listing of every pipeline command and its status    |
-| `npm run dev`                | M4 🚧     | Start TaskFlow (API + client) locally                         |
+| `npm run dev`                | M4        | Start TaskFlow (API + client) locally                         |
 | `npm run build`              | M4        | Build the TaskFlow client bundle                              |
 | `npm run test:unit`          | M0        | Vitest — API, flakemetry-lib, prompt builders, contracts      |
 | `npm run test:coverage`      | M2        | Vitest with coverage, enforcing the floor in vitest.config.ts |

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "changelog": "tsx scripts/changelog.ts",
     "changelog:check": "tsx scripts/changelog.ts --check",
     "demo": "tsx scripts/demo.ts",
-    "dev": "node scripts/pending.mjs dev",
+    "dev": "tsx scripts/dev.ts",
     "docs:status": "tsx scripts/status-banner.ts",
     "docs:status:check": "tsx scripts/status-banner.ts --check",
     "eval": "tsx eval/run-eval.ts",

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,0 +1,191 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import { createServer } from 'node:net'
+
+/**
+ * `npm run dev` — the API and the client, one command, one Ctrl-C.
+ *
+ * A concurrently-style dependency would do this in one line of configuration.
+ * It is forty lines here instead, and the trade is deliberate: this repository
+ * argues that a flaky test is worth understanding, and every dependency is one
+ * more thing to rule out when one appears. Forty lines of `spawn` are readable;
+ * a task runner's process-tree semantics are not.
+ *
+ * Three things are worth more than the brevity:
+ *
+ * **A port collision is a sentence, not a stack trace.** Both ports are probed
+ * before anything starts, so the message names the port and the flag that
+ * changes it rather than surfacing an `EADDRINUSE` from four frames down.
+ *
+ * **Ctrl-C leaves nothing behind.** Both children are put in their own process
+ * group and the group is signalled, so a child that spawned its own child — Vite
+ * does — does not survive as an orphan holding the port the next run needs.
+ *
+ * **Output says who said it.** Two interleaved streams with no prefixes is a log
+ * nobody reads.
+ */
+
+export const DEFAULT_API_PORT = 3001
+export const DEFAULT_WEB_PORT = 5173
+
+export interface DevDeps {
+  env?: NodeJS.ProcessEnv
+  /** Injected so the tests can check the plan without starting anything. */
+  start?: (name: string, command: string, args: string[], env: NodeJS.ProcessEnv) => ChildProcess
+  free?: (port: number) => Promise<boolean>
+  log?: (message: string) => void
+}
+
+export interface Plan {
+  apiPort: number
+  webPort: number
+  chaos: string | null
+}
+
+export function plan(env: NodeJS.ProcessEnv): Plan {
+  return {
+    apiPort: Number(env.PORT ?? DEFAULT_API_PORT),
+    webPort: Number(env.VITE_PORT ?? DEFAULT_WEB_PORT),
+    chaos: env.SENTRA_CHAOS !== undefined && env.SENTRA_CHAOS !== '' ? env.SENTRA_CHAOS : null,
+  }
+}
+
+/** Bind and release. Cheaper and more truthful than parsing `lsof`. */
+export const isFree = (port: number): Promise<boolean> =>
+  new Promise((resolve) => {
+    const probe = createServer()
+    probe.once('error', () => resolve(false))
+    probe.once('listening', () => probe.close(() => resolve(true)))
+    probe.listen(port, '127.0.0.1')
+  })
+
+export function collisionMessage(port: number, flag: string): string {
+  return [
+    '',
+    `  Port ${String(port)} is already in use.`,
+    '',
+    `  Something else is listening — most likely a dev server from an earlier run that`,
+    `  did not shut down. Stop it, or start on another port:`,
+    '',
+    `      ${flag}=<port> npm run dev`,
+    '',
+  ].join('\n')
+}
+
+export async function main(deps: DevDeps = {}): Promise<number> {
+  const env = deps.env ?? process.env
+  const log = deps.log ?? console.log
+  const free = deps.free ?? isFree
+  const { apiPort, webPort, chaos } = plan(env)
+
+  for (const [port, flag] of [
+    [apiPort, 'PORT'],
+    [webPort, 'VITE_PORT'],
+  ] as const) {
+    if (!(await free(port))) {
+      console.error(collisionMessage(port, flag))
+      return 1
+    }
+  }
+
+  log(
+    [
+      '',
+      `  API     http://localhost:${String(apiPort)}`,
+      `  Client  http://localhost:${String(webPort)}   (/api proxied to the API)`,
+      chaos === null ? '' : `  Chaos   SENTRA_CHAOS=${chaos} — seeded latency injection is ON`,
+      '',
+      '  Ctrl-C stops both.',
+      '',
+    ]
+      .filter((line) => line !== '')
+      .join('\n'),
+  )
+
+  const start = deps.start ?? spawnPrefixed
+  const children = [
+    start('api', 'npx', ['tsx', 'app/server/index.ts', '--seed'], {
+      ...env,
+      PORT: String(apiPort),
+    }),
+    start('web', 'npx', ['vite', '--port', String(webPort), '--strictPort'], {
+      ...env,
+      VITE_API_URL: `http://localhost:${String(apiPort)}`,
+    }),
+  ]
+
+  return await supervise(children, log)
+}
+
+/**
+ * Stop everything when anything stops.
+ *
+ * A client left running against a dead API is a debugging session that starts
+ * with a wrong hypothesis, so the first exit takes the other down with it.
+ */
+function supervise(children: ChildProcess[], log: (message: string) => void): Promise<number> {
+  return new Promise((resolve) => {
+    let settled = false
+
+    const stopAll = (code: number): void => {
+      if (settled) return
+      settled = true
+      for (const child of children) kill(child)
+      resolve(code)
+    }
+
+    for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+      process.once(signal, () => {
+        log('\n  Stopping…\n')
+        stopAll(0)
+      })
+    }
+
+    for (const child of children) {
+      child.once('exit', (code) => stopAll(code ?? 0))
+      child.once('error', () => stopAll(1))
+    }
+  })
+}
+
+/**
+ * Signal the group, not the process.
+ *
+ * `spawn` with `detached` puts a child in its own process group, and a negative
+ * pid signals the whole group — which is what reaches the children a child
+ * started. Vite starts one. Without this, Ctrl-C leaves an orphan holding the
+ * port the next run needs, and the next run's error is a collision that has
+ * nothing to do with what the developer just changed.
+ */
+export function kill(child: ChildProcess): void {
+  if (child.pid === undefined || child.killed) return
+  try {
+    process.kill(-child.pid, 'SIGTERM')
+  } catch {
+    // Already gone, or never had a group. Falling back rather than throwing,
+    // because a shutdown path that can fail is a shutdown path that leaves
+    // orphans.
+    child.kill('SIGTERM')
+  }
+}
+
+export function spawnPrefixed(
+  name: string,
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): ChildProcess {
+  const child = spawn(command, args, { env, detached: true, stdio: ['ignore', 'pipe', 'pipe'] })
+
+  for (const stream of [child.stdout, child.stderr]) {
+    stream?.on('data', (chunk: Buffer) => {
+      for (const line of chunk.toString('utf8').split('\n')) {
+        if (line.trim() !== '') console.log(`  [${name}] ${line}`)
+      }
+    })
+  }
+  return child
+}
+
+if (process.argv[1]?.endsWith('dev.ts') === true) {
+  process.exitCode = await main()
+}

--- a/scripts/script-manifest.json
+++ b/scripts/script-manifest.json
@@ -13,7 +13,7 @@
       "description": "Start TaskFlow (API + client) locally",
       "milestone": "M4",
       "issue": 48,
-      "status": "pending"
+      "status": "implemented"
     },
     {
       "name": "build",

--- a/tests/unit/dev.test.ts
+++ b/tests/unit/dev.test.ts
@@ -1,0 +1,294 @@
+import type { ChildProcess } from 'node:child_process'
+import { createServer } from 'node:net'
+import { EventEmitter } from 'node:events'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  collisionMessage,
+  DEFAULT_API_PORT,
+  DEFAULT_WEB_PORT,
+  isFree,
+  kill,
+  main,
+  plan,
+  spawnPrefixed,
+} from '../../scripts/dev.js'
+
+/**
+ * The dev command, without starting a dev server.
+ *
+ * `start` is injected, so these check the *plan* — which processes, with which
+ * ports and which environment — rather than spending seconds proving that Vite
+ * boots. The parts that must touch the machine, the port probe and the process
+ * group, are the two that get real ones.
+ */
+
+/** A child that never runs, but emits like one. Its `kill` is recorded, not real. */
+function fakeChild(): ChildProcess & { kill: ReturnType<typeof vi.fn> } {
+  const child = new EventEmitter() as ChildProcess & { kill: ReturnType<typeof vi.fn> }
+  Object.assign(child, { pid: undefined, killed: false, kill: vi.fn() })
+  return child
+}
+
+interface Started {
+  name: string
+  command: string
+  args: string[]
+  env: NodeJS.ProcessEnv
+}
+
+const run = async (
+  env: NodeJS.ProcessEnv,
+  over: { free?: (port: number) => Promise<boolean> } = {},
+): Promise<{ code: number; started: Started[]; output: string }> => {
+  const started: Started[] = []
+  const lines: string[] = []
+  const children: ChildProcess[] = []
+
+  // Resolved once both children exist. The port probe is async, so emitting an
+  // exit before then would be emitting it at nothing — a test that hangs for
+  // five seconds and reports a timeout instead of the assertion it was about.
+  let bothStarted: () => void = () => undefined
+  const running = new Promise<void>((resolve) => {
+    bothStarted = resolve
+  })
+
+  const codePromise = main({
+    env,
+    free: over.free ?? (() => Promise.resolve(true)),
+    log: (message) => lines.push(message),
+    start: (name, command, args, childEnv) => {
+      started.push({ name, command, args, env: childEnv })
+      const child = fakeChild()
+      children.push(child)
+      if (children.length === 2) bothStarted()
+      return child
+    },
+  })
+
+  // Nothing exits on its own, so end the run the way a stopped API would.
+  const code = await Promise.race([
+    codePromise,
+    running.then(() => {
+      children[0]?.emit('exit', 0)
+      return codePromise
+    }),
+  ])
+
+  return { code, started, output: lines.join('\n') }
+}
+
+describe('the plan', () => {
+  it('defaults both ports', () => {
+    expect(plan({})).toMatchObject({ apiPort: DEFAULT_API_PORT, webPort: DEFAULT_WEB_PORT })
+  })
+
+  it('takes the ports from the environment', () => {
+    expect(plan({ PORT: '4000', VITE_PORT: '4001' })).toMatchObject({
+      apiPort: 4000,
+      webPort: 4001,
+    })
+  })
+
+  it('reports chaos only when a seed is set', () => {
+    expect(plan({}).chaos).toBeNull()
+    expect(plan({ SENTRA_CHAOS: '' }).chaos).toBeNull()
+    expect(plan({ SENTRA_CHAOS: '37' }).chaos).toBe('37')
+  })
+})
+
+describe('starting both halves', () => {
+  it('starts the API and the client', async () => {
+    const { started } = await run({})
+    expect(started.map((child) => child.name)).toEqual(['api', 'web'])
+  })
+
+  it('gives each the port it was planned for', async () => {
+    const { started } = await run({ PORT: '4000', VITE_PORT: '4001' })
+    expect(started[0]?.env.PORT).toBe('4000')
+    expect(started[1]?.args).toContain('4001')
+  })
+
+  /**
+   * `--strictPort`. Vite's default is to pick the next free port silently, which
+   * would leave the client on a port the message just told the developer it was
+   * not on.
+   */
+  it('refuses to let the client wander to another port', async () => {
+    const { started } = await run({})
+    expect(started[1]?.args).toContain('--strictPort')
+  })
+
+  it('points the client at the API it just started', async () => {
+    const { started } = await run({ PORT: '4000' })
+    expect(started[1]?.env.VITE_API_URL).toBe('http://localhost:4000')
+  })
+
+  /** A dev database that starts empty makes every session begin with typing. */
+  it('seeds the database on start', async () => {
+    const { started } = await run({})
+    expect(started[0]?.args).toContain('--seed')
+  })
+
+  it('passes the chaos seed through to the API', async () => {
+    const { started } = await run({ SENTRA_CHAOS: '37' })
+    expect(started[0]?.env.SENTRA_CHAOS).toBe('37')
+  })
+
+  it('says where both are, and that Ctrl-C stops them', async () => {
+    const { output } = await run({})
+    expect(output).toContain('http://localhost:3001')
+    expect(output).toContain('http://localhost:5173')
+    expect(output).toContain('Ctrl-C stops both')
+  })
+
+  /** A server quietly injecting latency makes every test in the suite suspect. */
+  it('says out loud when chaos is on, and nothing when it is not', async () => {
+    expect((await run({ SENTRA_CHAOS: '37' })).output).toContain('SENTRA_CHAOS=37')
+    expect((await run({})).output).not.toContain('SENTRA_CHAOS')
+  })
+
+  /**
+   * A client left running against a dead API is a debugging session that starts
+   * with a wrong hypothesis.
+   */
+  it('stops everything when either half exits', async () => {
+    const { code } = await run({})
+    expect(code).toBe(0)
+  })
+})
+
+describe('a port collision', () => {
+  it('exits 1 without starting anything', async () => {
+    const errors: string[] = []
+    const spy = vi.spyOn(console, 'error').mockImplementation((m: unknown) => {
+      errors.push(String(m))
+    })
+    try {
+      const { code, started } = await run({}, { free: () => Promise.resolve(false) })
+      expect(code).toBe(1)
+      expect(started).toEqual([])
+    } finally {
+      spy.mockRestore()
+    }
+    expect(errors.join('')).toContain('already in use')
+  })
+
+  /** A sentence, not a stack trace from four frames down. */
+  it('names the port and the flag that changes it', () => {
+    const message = collisionMessage(5173, 'VITE_PORT')
+    expect(message).toContain('5173')
+    expect(message).toContain('VITE_PORT=<port> npm run dev')
+    expect(message).not.toContain('EADDRINUSE')
+  })
+
+  it('checks the API port before the client one, so the first message is the first problem', async () => {
+    const probed: number[] = []
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    try {
+      await run(
+        {},
+        {
+          free: (port) => {
+            probed.push(port)
+            return Promise.resolve(false)
+          },
+        },
+      )
+    } finally {
+      spy.mockRestore()
+    }
+    expect(probed).toEqual([DEFAULT_API_PORT])
+  })
+})
+
+describe('the port probe', () => {
+  it('says a free port is free', async () => {
+    expect(await isFree(0)).toBe(true)
+  })
+
+  /** Binding and releasing is cheaper and more truthful than parsing `lsof`. */
+  it('says a taken port is taken', async () => {
+    const held = createServer()
+    const port = await new Promise<number>((resolve) => {
+      held.listen(0, '127.0.0.1', () => resolve((held.address() as { port: number }).port))
+    })
+
+    try {
+      expect(await isFree(port)).toBe(false)
+    } finally {
+      await new Promise<void>((resolve) => held.close(() => resolve()))
+    }
+
+    // And free again once it is released, so the probe is not just always false.
+    expect(await isFree(port)).toBe(true)
+  })
+})
+
+/**
+ * The shutdown path, which is the part that leaves orphans when it is wrong.
+ *
+ * A child that survives Ctrl-C holds the port the next run needs, and the next
+ * run's error is a collision that has nothing to do with what the developer just
+ * changed — a confusing failure two steps removed from its cause.
+ */
+describe('stopping a child', () => {
+  it('signals the process group, not just the process', () => {
+    const child = fakeChild()
+    Object.assign(child, { pid: 4242 })
+    const spy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+
+    try {
+      kill(child)
+      // Negative pid: the group, which is what reaches the children a child
+      // started. Vite starts one.
+      expect(spy).toHaveBeenCalledWith(-4242, 'SIGTERM')
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('falls back to the process when it has no group', () => {
+    const child = fakeChild()
+    Object.assign(child, { pid: 4242 })
+    const spy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw new Error('ESRCH')
+    })
+
+    try {
+      kill(child)
+      expect(child.kill.mock.calls).toEqual([['SIGTERM']])
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  /** A shutdown path that can throw is a shutdown path that leaves orphans. */
+  it('does nothing, quietly, for a child that never started', () => {
+    expect(() => kill(fakeChild())).not.toThrow()
+  })
+})
+
+describe('prefixed output', () => {
+  it('labels every line with the process that wrote it', async () => {
+    const lines: string[] = []
+    const spy = vi.spyOn(console, 'log').mockImplementation((m: unknown) => {
+      lines.push(String(m))
+    })
+
+    try {
+      const child = spawnPrefixed(
+        'api',
+        process.execPath,
+        ['-e', "console.log('listening'); console.error('and a warning')"],
+        process.env,
+      )
+      await new Promise<void>((resolve) => child.once('exit', () => resolve()))
+    } finally {
+      spy.mockRestore()
+    }
+
+    // Two interleaved streams with no prefixes is a log nobody reads.
+    expect(lines.some((line) => line === '  [api] listening')).toBe(true)
+    expect(lines.some((line) => line === '  [api] and a warning')).toBe(true)
+  })
+})

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -93,7 +93,7 @@ happens to their output.
 ## Running the demo application
 
 ```bash
-npm run dev        # 🚧 M4 · #48
+npm run dev        # API on :3001, client on :5173
 ```
 
 TaskFlow is a small task board: create, edit, delete, complete, filter, drag-to-reorder. It exists
@@ -103,7 +103,7 @@ product, and it is deliberately not good software.
 To reproduce a specific race:
 
 ```bash
-SENTRA_CHAOS=<seed> npm run dev   # 🚧 M4 · #47
+SENTRA_CHAOS=37 npm run dev       # reproduces the reorder race
 ```
 
 Seeded latency injection makes a particular interleaving reproducible, which is how the


### PR DESCRIPTION
Closes #48, and **completes M4**.

A `concurrently`-style dependency would do this in one line of configuration. It is forty lines of `spawn` here instead, and the trade is deliberate: this repository argues that a flaky test is worth understanding, and every dependency is one more thing to rule out when one appears. Forty lines are readable; a task runner's process-tree semantics are not.

## Three things worth more than the brevity

**A port collision is a sentence, not a stack trace.** Both ports are probed before anything starts, and the message names the port and the flag that changes it. The API is checked first, so the first message is the first problem.

**Ctrl-C leaves nothing behind.** Both children are detached into their own process group, and the *group* is signalled — which is what reaches the children a child started. Vite starts one. Without this an orphan holds the port the next run needs, and the next run's error is a collision that has nothing to do with what the developer just changed: a confusing failure two steps removed from its cause.

The fallback signals the process directly rather than throwing, because a shutdown path that can fail is a shutdown path that leaves orphans.

**`--strictPort` on the client.** Vite's default is to pick the next free port silently, which would leave it on a port the message just told the developer it was not on.

Output is prefixed per process, and the first exit takes the other down: a client left running against a dead API is a debugging session that starts from a wrong hypothesis.

## Testing

21 tests here, 1378 overall. `scripts/dev.ts` at 91% statements.

`start` is injected, so the tests check the **plan** — which processes, with which ports and which environment — rather than spending seconds proving Vite boots. The two parts that must touch the machine get real ones: the port probe binds and releases an actual port (and checks it reads free again afterwards, so it is not just always false), and `spawnPrefixed` runs a real `node -e` and asserts both streams come back labelled.

The shutdown path is tested directly, because it is the part that leaves orphans when it is wrong: the group signal, the fallback, and the no-op for a child that never started.

## M4 is complete

Eight issues: the API, ordering and the reorder endpoint, the client shell, the task lifecycle, filtering, drag-to-reorder, the chaos layer, and this.

The README quickstart now runs TaskFlow and reproduces the deliberate reorder race with `SENTRA_CHAOS=37`. The pending markers for `npm run dev` and the chaos snippet are gone from the README, CONTRIBUTING and the wiki — the repository's own status-banner check enforced that in both directions while I was working, catching first a command marked implemented too early and then one left marked pending too late.