### PR TITLE
fix(app): npm run dev did not work, and 1378 tests did not notice

### DIFF
--- a/app/server/api.test.ts
+++ b/app/server/api.test.ts
@@ -1,6 +1,9 @@
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 import { createApp } from './app.js'
-import { clear, create, open, reorder, type Db } from './db.js'
+import { existsSync, mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { clear, create, list, open, reorder, type Db } from './db.js'
 import { serve } from './index.js'
 import { seed, SEED, SEED_TIME } from './seed.js'
 
@@ -234,6 +237,32 @@ describe('ordering', () => {
 
     const titles = ((await api('/api/tasks')).body as ListBody).tasks.map((t) => t.title)
     expect(titles).toEqual(['earlier', 'later'])
+  })
+})
+
+/**
+ * The failure `npm run dev` hit on a clean clone, and the reason it survived a
+ * full suite: every other test here opens `:memory:`, which needs no directory.
+ * SQLite creates the file and refuses to create the folder above it.
+ */
+describe('opening a database file', () => {
+  it('creates the directory it was pointed at', () => {
+    const path = join(mkdtempSync(join(tmpdir(), 'taskflow-')), 'nested', 'deeper', 'tasks.db')
+    expect(existsSync(dirname(path))).toBe(false)
+
+    const file = open(path)
+    try {
+      expect(existsSync(path)).toBe(true)
+      expect(list(file)).toEqual([])
+    } finally {
+      file.close()
+    }
+  })
+
+  it('needs no directory for an in-memory database', () => {
+    const memory = open(':memory:')
+    expect(list(memory)).toEqual([])
+    memory.close()
   })
 })
 

--- a/app/server/db.ts
+++ b/app/server/db.ts
@@ -1,3 +1,5 @@
+import { mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
 import Database from 'better-sqlite3'
 
 /**
@@ -57,6 +59,13 @@ export type Db = Database.Database
  * argument in tests; the CLI passes a real file.
  */
 export function open(path: string): Db {
+  // SQLite creates the file and refuses to create the directory, so the default
+  // path — `.taskflow/tasks.db`, which is gitignored and therefore absent on
+  // every clean clone — made `npm run dev` fail on the first run and only the
+  // first run. Every test used `:memory:`, so nothing caught it; a test that
+  // opens a path under a directory that does not exist does now.
+  if (path !== ':memory:') mkdirSync(dirname(path), { recursive: true })
+
   const db = new Database(path)
 
   // Without this SQLite runs with foreign keys off and, more importantly here,

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -27,6 +27,9 @@ import { createServer } from 'node:net'
 export const DEFAULT_API_PORT = 3001
 export const DEFAULT_WEB_PORT = 5173
 
+/** Relative to the repository root, which is where npm scripts run. */
+export const VITE_CONFIG = 'app/client/vite.config.ts'
+
 export interface DevDeps {
   env?: NodeJS.ProcessEnv
   /** Injected so the tests can check the plan without starting anything. */
@@ -107,10 +110,21 @@ export async function main(deps: DevDeps = {}): Promise<number> {
       ...env,
       PORT: String(apiPort),
     }),
-    start('web', 'npx', ['vite', '--port', String(webPort), '--strictPort'], {
-      ...env,
-      VITE_API_URL: `http://localhost:${String(apiPort)}`,
-    }),
+    // `--config` is not optional. Vite looks for its config in the *working
+    // directory*, and this runs from the repository root — without it Vite
+    // serves the root with no React plugin and no `/api` proxy, and the only
+    // symptom is a 404 on a page that used to work. The unit tests check the
+    // arguments; only running the command catches this, which is how it was
+    // found.
+    start(
+      'web',
+      'npx',
+      ['vite', '--config', VITE_CONFIG, '--port', String(webPort), '--strictPort'],
+      {
+        ...env,
+        VITE_API_URL: `http://localhost:${String(apiPort)}`,
+      },
+    ),
   ]
 
   return await supervise(children, log)

--- a/tests/unit/dev.test.ts
+++ b/tests/unit/dev.test.ts
@@ -1,4 +1,5 @@
 import type { ChildProcess } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { createServer } from 'node:net'
 import { EventEmitter } from 'node:events'
 import { describe, expect, it, vi } from 'vitest'
@@ -8,6 +9,7 @@ import {
   DEFAULT_WEB_PORT,
   isFree,
   kill,
+  VITE_CONFIG,
   main,
   plan,
   spawnPrefixed,
@@ -106,6 +108,20 @@ describe('starting both halves', () => {
     const { started } = await run({ PORT: '4000', VITE_PORT: '4001' })
     expect(started[0]?.env.PORT).toBe('4000')
     expect(started[1]?.args).toContain('4001')
+  })
+
+  /**
+   * Vite reads its config from the working directory, and this runs from the
+   * repository root. Without `--config` it serves the root with no React plugin
+   * and no `/api` proxy, and the only symptom is a 404 on a page that used to
+   * work — which is exactly how it was found: by running the command, not by
+   * reading the arguments.
+   */
+  it('points the client at its own config', async () => {
+    const { started } = await run({})
+    expect(started[1]?.args).toContain('--config')
+    expect(started[1]?.args).toContain(VITE_CONFIG)
+    expect(existsSync(VITE_CONFIG)).toBe(true)
   })
 
   /**


### PR DESCRIPTION
An audit of M4, done by **running** things rather than reading them. Two bugs in the milestone's flagship command, neither reachable from a unit test as written.

## `npm run dev` failed on a clean clone

SQLite creates the database *file* and refuses to create the directory above it. The default path is `.taskflow/tasks.db` — gitignored, and therefore absent on every clean clone.

So the command failed on the first run and only the first run. **Every server test opens `:memory:`**, which needs no directory, so all 1378 passed.

`open` now creates the directory, and a test opens a path two levels deep under one that does not exist.

## And when it started, it served the wrong thing

Vite reads its config from the **working directory**, and the dev command runs from the repository root. Without `--config` it served the repo root with no React plugin and no `/api` proxy.

The API was fine. The page was a 404. Nothing in the suite disagreed, because the tests assert the *arguments* rather than the result.

## The lesson is the one this repository keeps making

A test that checks the plan is not a test that the thing works. Both fixes carry a test now — but the tests exist because the command was run, not the other way round.

## What I verified live afterwards

- API answers on its port; `/api/tasks` returns the six seeded tasks.
- The client serves the real `index.html`, and `/api` proxies through it to the API.
- `PATCH /api/tasks/reorder` moves a task and returns the resulting order; `PATCH /api/tasks/:id/complete` completes; an unknown field is a 400 naming it; an unknown route is a 404.
- `SENTRA_CHAOS=37` delays the first reorder by **408ms** and the second by **14ms**, against the 399 and 11 the test pins — and the server announces it.
- With chaos unset: no delay, no announcement.
- Ctrl-C and a crashed API both bring the other half down; no orphans left holding a port.

## What the audit found clean

Every other check passes: `lint`, `typecheck`, `format:check`, `docs:status:check`, `eval:lint`, `prompts:sync:check`, `prompts:freeze`, `cassettes:check`, `eval -- --gate`, `npm run demo`, `npm run build`, `npm run help`. The script manifest, the README table and `package.json` agree.

`CHANGELOG.md` is behind again — the documented cadence, regenerated at release, not a defect.

**Two surfaces remain unexercised and I am saying so rather than implying otherwise:** the React app has never been rendered in a real browser (that arrives with Playwright in M5, and jsdom covers the components), and `npm run wiki:publish` pushes to the GitHub wiki, which is an outward-facing action I have not taken.