### PR TITLE
test(server): a database per test, and a report the pipeline can read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ yarn-error.log*
 # The Vite bundle. `dist/` next to it holds TypeScript's declarations, and the two
 # tools would delete each other's output if they shared a directory.
 app/client/dist-bundle/
+
+# The unit run's machine-readable report. Playwright's is results.json above; the
+# two are separate files so that `npm test` cannot have one erase the other.
+/results-unit.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,6 +8,7 @@ package-lock.json
 
 # Pipeline outputs — generated, never hand-edited.
 results.json
+results-unit.json
 analysis.json
 report.md
 otel-spans.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,7 @@
   "files.readonlyInclude": {
     "analysis.json": true,
     "results.json": true,
+    "results-unit.json": true,
     "otel-spans.json": true
   }
 }

--- a/README.md
+++ b/README.md
@@ -174,21 +174,21 @@ cat eval/report.md
 
 ### Script reference
 
-| Script                       | Milestone | What it does                                                  |
-| ---------------------------- | --------- | ------------------------------------------------------------- |
-| `npm run help`               | M0        | Annotated listing of every pipeline command and its status    |
-| `npm run dev`                | M4        | Start TaskFlow (API + client) locally                         |
-| `npm run build`              | M4        | Build the TaskFlow client bundle                              |
-| `npm run test:unit`          | M0        | Vitest — API, flakemetry-lib, prompt builders, contracts      |
-| `npm run test:coverage`      | M2        | Vitest with coverage, enforcing the floor in vitest.config.ts |
-| `npm run test:e2e`           | M5 🚧     | Playwright — TaskFlow UI flows including the flaky specs      |
-| `npm test`                   | M5 🚧     | Unit and E2E together; emits results.json                     |
-| `npm run flakemetry:analyze` | M6 🚧     | Test report + history → analysis.json                         |
-| `npm run agents:analyze`     | M7 🚧     | analysis.json → report.md                                     |
-| `npm run analyze`            | M8 🚧     | flakemetry and agents in sequence                             |
-| `npm run eval`               | M2        | Golden-dataset evaluation → eval/report.md                    |
-| `npm run eval:ablation`      | M9 🚧     | Context-ablation study → eval/ablation.md                     |
-| `npm run demo`               | M3        | Full pipeline in replay mode, no credentials                  |
+| Script                       | Milestone | What it does                                                              |
+| ---------------------------- | --------- | ------------------------------------------------------------------------- |
+| `npm run help`               | M0        | Annotated listing of every pipeline command and its status                |
+| `npm run dev`                | M4        | Start TaskFlow (API + client) locally                                     |
+| `npm run build`              | M4        | Build the TaskFlow client bundle                                          |
+| `npm run test:unit`          | M0        | Vitest — API, flakemetry-lib, prompts, contracts; emits results-unit.json |
+| `npm run test:coverage`      | M2        | Vitest with coverage, enforcing the floor in vitest.config.ts             |
+| `npm run test:e2e`           | M5 🚧     | Playwright — TaskFlow UI flows including the flaky specs                  |
+| `npm test`                   | M5 🚧     | Unit and E2E together; emits results.json                                 |
+| `npm run flakemetry:analyze` | M6 🚧     | Test report + history → analysis.json                                     |
+| `npm run agents:analyze`     | M7 🚧     | analysis.json → report.md                                                 |
+| `npm run analyze`            | M8 🚧     | flakemetry and agents in sequence                                         |
+| `npm run eval`               | M2        | Golden-dataset evaluation → eval/report.md                                |
+| `npm run eval:ablation`      | M9 🚧     | Context-ablation study → eval/ablation.md                                 |
+| `npm run demo`               | M3        | Full pipeline in replay mode, no credentials                              |
 
 🚧 marks a script that is not implemented yet; running it says so and names its issue.
 Everything else runs today. `npm run help` prints this table from the terminal.

--- a/app/server/api.test.ts
+++ b/app/server/api.test.ts
@@ -1,14 +1,15 @@
-import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { Server } from 'node:http'
 import { createApp } from './app.js'
-import { existsSync, mkdtempSync } from 'node:fs'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
-import { clear, create, list, open, reorder, type Db } from './db.js'
+import { create, list, open, reorder, type Db } from './db.js'
 import { serve } from './index.js'
 import { seed, SEED, SEED_TIME } from './seed.js'
 
 /**
- * The API over real HTTP, on a real port.
+ * The API over real HTTP, on a real port, against its own database.
  *
  * Not because a request object could not be faked, but because everything that
  * consumes this API — the client, the Playwright specs, the flaky ones
@@ -17,15 +18,53 @@ import { seed, SEED, SEED_TIME } from './seed.js'
  * flaky live in the layer above it: status codes, JSON parsing, what a malformed
  * body does.
  *
+ * **A file per test, not one shared `:memory:` database.** Two reasons, and the
+ * second is the one that mattered:
+ *
+ * 1. Shared state between tests is the mechanism behind #54 — a spec that fails
+ *    because a different spec left something behind. Demonstrating that failure
+ *    deliberately in the E2E suite while tolerating it accidentally in the unit
+ *    suite would be an odd position for this repository to hold. Deleting every
+ *    row between tests is not isolation; it is cleanup that has to be remembered,
+ *    and `id` sequences, WAL state and open handles survive it.
+ * 2. `:memory:` silently ignores `journal_mode = WAL`. It reports `memory` and
+ *    carries on, so every concurrency assertion here used to run against a
+ *    journal mode the application never uses in production. A file gets the
+ *    pragma the server actually sets.
+ *
  * `listen(0)` for the port. Hard-coding one would make this suite fail whenever
  * a dev server was running, which is a flaky test with a very boring cause — in
  * a repository about flaky tests.
  */
 
-const db: Db = open(':memory:')
-const server = createApp({ db, now: () => SEED_TIME }).listen(0)
-const port = (server.address() as { port: number }).port
-const base = `http://127.0.0.1:${String(port)}`
+/** One directory for the whole file, removed once. Per-test dirs are 84 syscalls for nothing. */
+const workspace = mkdtempSync(join(tmpdir(), 'taskflow-api-'))
+let opened = 0
+
+let db: Db
+let server: Server
+let base: string
+
+beforeEach(() => {
+  opened += 1
+  db = open(join(workspace, `run-${String(opened)}`, 'tasks.db'))
+  server = createApp({ db, now: () => SEED_TIME }).listen(0)
+  base = `http://127.0.0.1:${String((server.address() as { port: number }).port)}`
+})
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+  db.close()
+})
+
+/**
+ * The whole tree at once. Closing a WAL database leaves `-wal` and `-shm`
+ * beside it, so removing only the files this suite named would leave two
+ * behind per test in the system temp directory, forever.
+ */
+afterAll(() => {
+  rmSync(workspace, { recursive: true, force: true })
+})
 
 const api = async (
   path: string,
@@ -45,19 +84,48 @@ const patch = (path: string, body: unknown): ReturnType<typeof api> =>
   api(path, { method: 'PATCH', body: JSON.stringify(body) })
 
 interface TaskBody {
-  task: { id: number; title: string; description: string; status: string; position: number }
+  task: {
+    id: number
+    title: string
+    description: string
+    status: string
+    position: number
+    createdAt: string
+    updatedAt: string
+  }
 }
 interface ListBody {
   tasks: TaskBody['task'][]
 }
 
-beforeEach(() => {
-  clear(db)
-})
+/**
+ * Isolation, asserted rather than assumed.
+ *
+ * A fixture that quietly stops isolating is the worst kind of broken: nothing
+ * fails, tests simply start depending on each other, and the failure arrives
+ * months later as an ordering-dependent flake in the one suite that is supposed
+ * to be the control group. So the first test writes a row with a known id and
+ * the second checks it is not there — which only passes if `beforeEach` really
+ * did hand over a different database.
+ */
+describe('each test gets its own database', () => {
+  it('writes a row that the next test must not see', async () => {
+    const created = (await post('/api/tasks', { title: 'left behind' })).body as TaskBody
+    expect(created.task.id).toBe(1)
+  })
 
-afterAll(async () => {
-  await new Promise<void>((resolve) => server.close(() => resolve()))
-  db.close()
+  it('starts from an empty table and an unused id sequence', async () => {
+    expect((await api('/api/tasks')).body).toEqual({ tasks: [] })
+    const created = (await post('/api/tasks', { title: 'fresh' })).body as TaskBody
+    // AUTOINCREMENT keeps a high-water mark, so a reused database would hand
+    // out 2 here even after every row was deleted.
+    expect(created.task.id).toBe(1)
+  })
+
+  /** WAL is the mode the server sets; `:memory:` reports `memory` and ignores it. */
+  it('runs in the journal mode the application actually configures', () => {
+    expect(db.pragma('journal_mode', { simple: true })).toBe('wal')
+  })
 })
 
 describe('reading', () => {
@@ -191,6 +259,26 @@ describe('updating', () => {
   it('404s when completing something that is gone', async () => {
     expect((await patch('/api/tasks/999/complete', {})).status).toBe(404)
   })
+
+  /**
+   * A body that validates and an id that does not.
+   *
+   * The two are checked in that order, so the schema passes and the id is what
+   * fails — the path where a `NaN` reaching the database turns a 404 into a 500,
+   * and a 500 in this application ends up as an unexplained failure in a
+   * Playwright trace that somebody has to triage.
+   */
+  it.each([
+    ['a patch', '/api/tasks/abc', { title: 'ghost' }],
+    ['a completion', '/api/tasks/abc/complete', {}],
+  ])(
+    '404s rather than 500s for %s addressed to an id that is not a number',
+    async (_c, path, b) => {
+      const response = await patch(path, b)
+      expect(response.status).toBe(404)
+      expect(response.body).toMatchObject({ error: { code: 'not_found' } })
+    },
+  )
 })
 
 describe('deleting', () => {
@@ -204,6 +292,45 @@ describe('deleting', () => {
     const id = ((await post('/api/tasks', { title: 'temporary' })).body as TaskBody).task.id
     await api(`/api/tasks/${String(id)}`, { method: 'DELETE' })
     expect((await api(`/api/tasks/${String(id)}`, { method: 'DELETE' })).status).toBe(404)
+  })
+
+  it('404s for an id that is not a number, rather than deleting by NaN', async () => {
+    await post('/api/tasks', { title: 'still here' })
+    expect((await api('/api/tasks/abc', { method: 'DELETE' })).status).toBe(404)
+    expect(((await api('/api/tasks')).body as ListBody).tasks).toHaveLength(1)
+  })
+})
+
+/**
+ * The clock, when nobody injects one.
+ *
+ * Every other test in this file pins `now`, which is what makes the assertions
+ * readable — and which is also how the default came to be the one line no test
+ * exercised. A default nothing runs is a default nobody has checked, and this
+ * one stamps every row the running server writes.
+ */
+describe('the timestamp the server writes when it is not told what time it is', () => {
+  it('records a real, current, ISO-8601 instant', async () => {
+    const own = createApp({ db }).listen(0)
+    const port = (own.address() as { port: number }).port
+
+    try {
+      const before = Date.now()
+      const response = await fetch(`http://127.0.0.1:${String(port)}/api/tasks`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ title: 'what time is it' }),
+      })
+      const { task } = (await response.json()) as TaskBody
+
+      expect(task.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/)
+      const stamped = Date.parse(task.createdAt)
+      expect(stamped).toBeGreaterThanOrEqual(before - 1000)
+      expect(stamped).toBeLessThanOrEqual(Date.now() + 1000)
+      expect(task.updatedAt).toBe(task.createdAt)
+    } finally {
+      await new Promise<void>((resolve) => own.close(() => resolve()))
+    }
   })
 })
 
@@ -366,6 +493,70 @@ describe('starting up', () => {
     const b = serve({ port: 0, database: ':memory:', log: () => undefined })
     expect(a.port).not.toBe(b.port)
     await Promise.all([a.close(), b.close()])
+  })
+
+  it('says where it is listening and which database it opened', async () => {
+    const said: string[] = []
+    const running = serve({ port: 0, database: ':memory:', log: (m) => said.push(m) })
+    await running.close()
+
+    expect(said.join('\n')).toContain(String(running.port))
+    expect(said.join('\n')).toContain(':memory:')
+  })
+
+  /**
+   * The announcement is not decoration. A server quietly injecting latency makes
+   * every test in the suite suspect, and the seed printed here is the only way
+   * back to a reproduction — so it is asserted rather than left to the reader of
+   * `index.ts`.
+   */
+  it('announces the chaos seed when the environment sets one', async () => {
+    const previous = process.env.SENTRA_CHAOS
+    process.env.SENTRA_CHAOS = '37'
+    const said: string[] = []
+
+    try {
+      const running = serve({ port: 0, database: ':memory:', log: (m) => said.push(m) })
+      await running.close()
+    } finally {
+      if (previous === undefined) delete process.env.SENTRA_CHAOS
+      else process.env.SENTRA_CHAOS = previous
+    }
+
+    expect(said.join('\n')).toContain('SENTRA_CHAOS=37')
+  })
+
+  it('says nothing about chaos when the environment has not asked for any', async () => {
+    const said: string[] = []
+    const running = serve({ port: 0, database: ':memory:', log: (m) => said.push(m) })
+    await running.close()
+    expect(said.join('\n')).not.toContain('SENTRA_CHAOS')
+  })
+
+  /**
+   * `SENTRA_DB` and `PORT`, which is how the dev command and CI point the server
+   * somewhere other than the default — and the only reason `serve()` reads the
+   * environment at all.
+   */
+  it('takes the database path and the port from the environment', async () => {
+    const before = { db: process.env.SENTRA_DB, port: process.env.PORT }
+    const path = join(workspace, 'from-the-environment', 'tasks.db')
+    process.env.SENTRA_DB = path
+    process.env.PORT = '0'
+
+    try {
+      const running = serve({ log: () => undefined })
+      await running.close()
+      expect(existsSync(path)).toBe(true)
+    } finally {
+      for (const [key, value] of [
+        ['SENTRA_DB', before.db],
+        ['PORT', before.port],
+      ] as const) {
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
+      }
+    }
   })
 })
 
@@ -538,7 +729,6 @@ describe('reordering under a race', () => {
  */
 describe('the limit of halving a gap', () => {
   it('collapses onto the neighbour after 52 insertions below the same row', () => {
-    clear(db)
     const top = create(db, { title: 'top', position: 1 }, SEED_TIME)
     create(db, { title: 'bottom', position: 2 }, SEED_TIME)
 

--- a/app/server/chaos.test.ts
+++ b/app/server/chaos.test.ts
@@ -222,4 +222,38 @@ describe('the server with chaos on', () => {
   it('still answers correctly with chaos on', async () => {
     expect((await run({ SENTRA_CHAOS: '11' })).status).toBe(200)
   })
+
+  /**
+   * Once, with the real timer.
+   *
+   * Every other test here injects `sleep` and asserts on the number, which keeps
+   * the suite fast and is the right trade — but it means the delay the server
+   * actually performs is the one line nothing runs. A `sleep` that resolved
+   * immediately, or never, would pass all of them and inject no latency at all,
+   * and the flaky specs downstream would quietly stop being flaky.
+   *
+   * Seed 3 on a `GET`, whose profile tops out at 60ms, so this costs
+   * milliseconds. The assertion is that time passed at all, with a floor well
+   * under the delay — a tight bound would be exactly the fixed-timeout mistake
+   * #55 exists to demonstrate.
+   */
+  it('really waits, when nobody hands it a fake clock', async () => {
+    const db: Db = open(':memory:')
+    const chaos = chaosFrom({ SENTRA_CHAOS: '3' })
+    const delay = chaosFrom({ SENTRA_CHAOS: '3' }).delay('GET /api/tasks')
+    expect(delay).toBeGreaterThan(20)
+
+    const server = createApp({ db, chaos }).listen(0)
+    const port = (server.address() as { port: number }).port
+
+    const started = process.hrtime.bigint()
+    const response = await fetch(`http://127.0.0.1:${String(port)}/api/tasks`)
+    const elapsed = Number(process.hrtime.bigint() - started) / 1e6
+
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+    db.close()
+
+    expect(response.status).toBe(200)
+    expect(elapsed).toBeGreaterThan(delay / 2)
+  })
 })

--- a/scripts/script-manifest.json
+++ b/scripts/script-manifest.json
@@ -24,7 +24,7 @@
     },
     {
       "name": "test:unit",
-      "description": "Vitest \u2014 API, flakemetry-lib, prompt builders, contracts",
+      "description": "Vitest \u2014 API, flakemetry-lib, prompt builders, contracts; emits results-unit.json",
       "milestone": "M0",
       "issue": 9,
       "status": "implemented"

--- a/tests/unit/vitest-reporter.test.ts
+++ b/tests/unit/vitest-reporter.test.ts
@@ -1,0 +1,154 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { normaliseVitestReport, TestRunSchema, type TestRun } from '@sentra/contracts'
+import { UNIT_RESULTS } from '../../vitest.config.js'
+
+/**
+ * The unit run really does emit a report the pipeline can read.
+ *
+ * `tests/unit/reporter-contract.test.ts` checks the *format*, against a fixture
+ * captured from a pinned version. This checks the *wiring*, by running the suite
+ * for real and normalising whatever comes out — which is a different claim, and
+ * the one that broke last time. Two bugs in `npm run dev` survived 1378 passing
+ * tests because every test checked the arguments the command would pass and none
+ * of them ran it; a reporter configured in a file nobody executes fails exactly
+ * the same way, and the symptom is an empty artifact in CI rather than an error.
+ *
+ * So the child process is given no `--outputFile`, no `--reporter`. It runs the
+ * committed configuration, and the assertions are about the file that appears.
+ */
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const report = join(root, UNIT_RESULTS)
+
+/**
+ * The API suite, deliberately named rather than discovered.
+ *
+ * #49 exists because unit failures are a distribution the golden dataset is
+ * missing — far more often `deterministic`, far more often `app_code` — and this
+ * file is where those come from. Naming it means renaming it breaks this test,
+ * which is the correct outcome.
+ */
+const SUITE = 'app/server/api.test.ts'
+
+// A child `vitest run` is seconds, not milliseconds, and a cold CI runner is
+// slower than that again. Left at the 5s default this becomes a test that fails
+// under load — which is #55, and writing it by accident in the file that checks
+// the control group would be an embarrassing way to make the point.
+vi.setConfig({ testTimeout: 180_000 })
+
+let emitted: unknown
+let startedAt = 0
+
+beforeAll(() => {
+  // Removed first, so a file left over from an earlier run cannot pass for one
+  // this run produced. The parent suite rewrites it on the way out.
+  rmSync(report, { force: true })
+  startedAt = Date.now()
+
+  execFileSync('npx', ['vitest', 'run', SUITE], {
+    cwd: root,
+    encoding: 'utf8',
+    stdio: 'pipe',
+    // `npx` resolves through the repository's own node_modules; the vitest
+    // binary is a devDependency and is not assumed to be on PATH.
+    env: { ...process.env, CI: '1' },
+  })
+
+  emitted = JSON.parse(readFileSync(report, 'utf8'))
+})
+
+describe('the configured reporter', () => {
+  it('writes the file the configuration names, without being asked on the command line', () => {
+    expect(existsSync(report)).toBe(true)
+    expect(statSync(report).mtimeMs).toBeGreaterThanOrEqual(startedAt - 1000)
+  })
+
+  /**
+   * A pipeline output committed by accident is a diff that changes on every run
+   * and stops being read within a week — and this one carries absolute paths
+   * from whichever machine ran the suite.
+   */
+  it('writes it somewhere git is told to ignore', () => {
+    const ignored = execFileSync('git', ['check-ignore', UNIT_RESULTS], {
+      cwd: root,
+      encoding: 'utf8',
+    })
+    expect(ignored.trim()).toBe(UNIT_RESULTS)
+  })
+
+  /**
+   * Playwright's report is `results.json` and this one is not. `npm test` runs
+   * both; sharing a filename would mean whichever finished second silently
+   * erased the other's failures, and a lost failure is worse than a loud one.
+   */
+  it('does not collide with the end-to-end report', () => {
+    expect(UNIT_RESULTS).not.toBe('results.json')
+  })
+})
+
+describe('the report it wrote', () => {
+  const meta = { runId: 'run-1', commitSha: 'abc1234', branch: 'main', repositoryRoot: root }
+  const run = (): TestRun => normaliseVitestReport(emitted, meta)
+
+  it('normalises without throwing', () => {
+    expect(() => run()).not.toThrow()
+  })
+
+  it('is a schema-valid TestRun', () => {
+    expect(() => TestRunSchema.parse(run())).not.toThrow()
+  })
+
+  /** An empty run would satisfy every other assertion in this block. */
+  it('carries the tests that actually ran', () => {
+    const results = run().results
+    expect(results.length).toBeGreaterThan(20)
+    expect(results.every((result) => result.file === SUITE)).toBe(true)
+  })
+
+  /**
+   * Absolute paths are what Vitest reports. An id derived from
+   * `/home/runner/work/repo/…` in CI and `/Users/x/repo/…` locally would be two
+   * tests with two separate histories, and the flakiness signal would never
+   * accumulate for either.
+   */
+  it('reports repository-relative paths, with the machine stripped out', () => {
+    for (const result of run().results) {
+      expect(result.file).not.toMatch(/^\/|^[A-Za-z]:/)
+      expect(result.testId).not.toContain(root)
+    }
+  })
+
+  it('gives every test a unique id', () => {
+    const ids = run().results.map((result) => result.testId)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('says which runner produced it, because the two normalise differently', () => {
+    expect(run().source).toBe('vitest')
+  })
+
+  /**
+   * The suite this run reports on is the control group for the whole project.
+   * A flaky unit test here would contaminate the `deterministic` fixtures it is
+   * supposed to supply, so the run passing is part of the assertion rather than
+   * a precondition somebody checks by eye.
+   */
+  it('is green, because these are the tests nothing is allowed to be flaky in', () => {
+    expect(run().results.filter((result) => result.status !== 'passed')).toEqual([])
+  })
+
+  /**
+   * A budget, not a measurement. #49 asks for under ten seconds; the suite takes
+   * about a quarter of one, so this fires on a change that makes the feedback
+   * loop forty times worse and on nothing else. Read against the reported
+   * duration rather than the wall clock, so a slow runner's process startup is
+   * not counted as the suite being slow.
+   */
+  it('finishes well inside the budget the milestone set', () => {
+    expect(run().durationMs).toBeLessThan(10_000)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,18 @@
 import { defineConfig } from 'vitest/config'
 
+/**
+ * Where the unit run leaves its machine-readable report.
+ *
+ * Separate from Playwright's `results.json` rather than sharing it: both would
+ * be written by `npm test`, and whichever finished second would silently erase
+ * the other's failures. Two files, one merge, no lost run.
+ *
+ * Exported so a test can assert the file is gitignored rather than trusting
+ * that somebody remembered — a pipeline output committed by accident is a diff
+ * that changes on every run and stops being read within a week.
+ */
+export const UNIT_RESULTS = 'results-unit.json'
+
 export default defineConfig({
   test: {
     include: [
@@ -14,6 +27,27 @@ export default defineConfig({
       'app/client/**/*.test.tsx',
     ],
     exclude: ['**/node_modules/**', '**/dist/**'],
+
+    /**
+     * The unit run is a data source, not only a gate.
+     *
+     * Unit failures classify differently from browser failures — far more often
+     * `deterministic`, far more often `app_code` — and a golden dataset built
+     * only from Playwright output would teach the classifier that every failure
+     * has a locator in it. So the JSON report is emitted on every run and
+     * normalised by `normaliseVitestReport`, the same way Playwright's is.
+     *
+     * **Always on, not behind a flag.** A reporter somebody has to remember to
+     * switch on is one CI forgets, and the evidence is gone by the time anyone
+     * notices — the run that would have been worth capturing is the run that
+     * already finished.
+     *
+     * `default` stays first so a human still gets a human report; `json` is
+     * additional, not instead.
+     */
+    reporters: ['default', 'json'],
+    outputFile: { json: UNIT_RESULTS },
+
     coverage: {
       provider: 'v8',
       reporter: ['text-summary', 'lcov'],


### PR DESCRIPTION
Closes #49

## What this changes

The API suite already covered the handlers, the ordering scheme and the concurrent reorder path.
Two acceptance criteria were not met, and one of them was hiding something.

### A database per test

The suite shared one `:memory:` database and deleted every row between tests. That is cleanup, not
isolation — id sequences, open handles and journal state all survive it — and this milestone is
about to ship a spec (#54) whose entire point is that state left behind by one test breaks another.
Tolerating that accidentally in the control group while demonstrating it deliberately in the E2E
suite would be an odd position to hold.

**The thing it was hiding:** `:memory:` silently ignores `journal_mode = WAL`. It reports `memory`
and carries on. Every concurrency assertion in this file was running against a journal mode the
application never uses in production.

```
memory journal_mode -> [{"journal_mode":"memory"}]
file   journal_mode -> [{"journal_mode":"wal"}]
```

Each test now opens its own file under one temp directory, and a test asserts the mode is `wal` so
that cannot quietly regress.

Isolation is asserted rather than assumed: one test writes a row, the next requires an empty table
and an unused id sequence. Mutating `beforeEach` to reuse the database fails it immediately —

```
✓ writes a row that the next test must not see
× starts from an empty table and an unused id sequence
```

### The JSON reporter

Unit failures are a distribution the golden dataset is missing — far more often `deterministic`,
far more often `app_code` — and this suite is where they come from. `results-unit.json` is written
on every run, **always on rather than behind a flag**, because a reporter somebody has to remember
to switch on is one CI forgets, and the evidence is gone by the time anyone notices. Separate from
Playwright's `results.json` so that `npm test` cannot have one erase the other.

The test for it runs `vitest` as a child process with **no reporter arguments** and normalises
whatever the committed configuration writes. `tests/unit/reporter-contract.test.ts` checks the
*format* against a captured fixture; this checks the *wiring*, which is the claim that broke last
time — two bugs in `npm run dev` survived 1378 passing tests because every test checked the
arguments the command would pass and none of them ran it.

### Coverage of the paths nothing ran

`PATCH /api/tasks/abc` and its completion route, `DELETE` with a non-numeric id, the default clock
when no test injects one, the chaos announcement in `serve()`, and the real `setTimeout` behind the
chaos delay — a `sleep` that resolved immediately would have passed every existing chaos test and
injected no latency at all, and the flaky specs downstream would quietly stop being flaky.

`app.ts` and `chaos.ts` are now fully covered. What remains uncovered in `app/server` is three
defensive fallbacks the type system already excludes and the `if (process.argv[1])` CLI guard.

## Acceptance criteria

| Criterion | Where |
| --- | --- |
| Handler coverage including validation failures and 404 paths | `app/server/api.test.ts` — 66 tests |
| Ordering scheme tested at boundaries | `describe('ordering')`, `describe('the limit of halving a gap')` |
| Concurrent reorder behaviour matching #42 | `describe('reordering under a race')` |
| Each test uses an isolated temp database | `beforeEach` + `describe('each test gets its own database')` |
| Vitest JSON reporter, output normalisable by #15 | `vitest.config.ts`, `tests/unit/vitest-reporter.test.ts` |
| Suite runs in under 10 seconds | 0.44s for `app/server`; asserted against the reported duration |

The budget is checked against the duration the run reports, not the wall clock — a fixed wall-clock
bound in the control group is #55, and writing it by accident here would be an embarrassing way to
make that point.

## How this was verified

- `npm run test:unit` — 1404 tests, 47 files, green
- `npm run test:coverage` — 97.29% statements, 87.70% branches, above the floor
- `npm run lint`, `npm run typecheck`, `npm run format:check` — clean
- `docs:status:check`, `eval:lint`, `prompts:sync:check`, `cassettes:check` — clean
- The isolation fixture was mutated to share a database; the isolation test fails