### PR TITLE
test(e2e): the control group — five flows, written to be beyond reproach

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,33 @@ it executes, which is the only point at which reading it helps.
   filled in and the numbers moved in the direction the PR claims.
 - Reviewer notes state what you are unsure about.
 
+## Writing tests
+
+The end-to-end suite is the control group for the whole project. Every number in `eval/report.md`
+is measured against a dataset built from its runs, so a spec that is a little bit flaky does not
+merely fail sometimes — it teaches the classifier that everything is a little bit flaky, and it
+makes the deliberately flaky specs indistinguishable from the noise around them.
+
+Four rules, enforced by `tests/unit/e2e-standards.test.ts` rather than left to memory:
+
+- **Web-first assertions.** `expect(locator).toHaveCount(3)` retries until the condition holds.
+  `expect(await locator.count()).toBe(3)` samples once and races the application. The two look
+  almost identical in a diff.
+- **Never wait on the clock.** No `waitForTimeout`, no `setTimeout`. A sleep is a guess about how
+  fast a machine is, and CI is not that machine.
+- **Locators, not element handles.** `page.$` and `waitForSelector` return an element taken at one
+  moment; every assertion built on one races the next render.
+- **No dependence on another test.** Each test opens the page itself and starts from the seeded
+  database. `tests/e2e/fixtures.ts` makes that the default; opting out is one visible line and is
+  reserved for the spec that exists to demonstrate a cross-test leak.
+
+The deliberately flaky specs are held to the same four rules. Their flakiness has to come from the
+application, or from a selector choice the header comment explains and defends — never from a sleep
+somebody left in, which would make the ground-truth label a guess about the author's intent.
+
+Fault injection belongs at the network boundary (`page.route`), not in the application. A forced
+500 is deterministic; the request never reaches the server, so there is nothing to race.
+
 ## Working on prompts
 
 The highest-leverage and easiest-to-fool area of the project.

--- a/app/client/styles.css
+++ b/app/client/styles.css
@@ -89,8 +89,24 @@ button:hover {
   gap: 0.5rem;
 }
 
+/*
+ * `flex-wrap`, because a row can grow two more buttons.
+ *
+ * Opening the delete confirmation adds "Confirm delete" and "Cancel" to a row
+ * that already carries five controls. On one line the actions do not shrink —
+ * they are `flex-shrink: 0`, deliberately, so a button never becomes an ellipsis
+ * — so the text took all of the loss and collapsed to a box zero pixels wide.
+ * The title still *painted*, overflowing under the buttons, which is why nobody
+ * noticed it by looking.
+ *
+ * A Playwright spec did notice: an element with an empty bounding box is hidden,
+ * and `expect(title).toBeVisible()` failed while the screenshot showed the words
+ * on screen. Wrapping is the fix, and the basis on which `.task-text` is allowed
+ * to shrink to `12rem` and no further.
+ */
 .task {
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-start;
   gap: 0.85rem;
   padding: 0.75rem 0.9rem;
@@ -114,6 +130,9 @@ button:hover {
 }
 
 .task-text {
+  /* Grow into the space, give it back down to 12rem, and stop. Below that the
+     row wraps instead — see `.task`. */
+  flex: 1 1 12rem;
   min-width: 0;
 }
 

--- a/tests/e2e/board.ts
+++ b/tests/e2e/board.ts
@@ -1,0 +1,66 @@
+import type { Locator, Page } from '@playwright/test'
+import { expect } from './fixtures.js'
+
+/**
+ * The handful of things every spec does, named once.
+ *
+ * Deliberately thin. A full page object would hide the locators, and the specs
+ * in this directory are meant to be read side by side with the flaky ones in
+ * #52–#55 — a reader has to be able to see *which* selector a test chose and
+ * judge it. So this exposes locators and performs actions; it never asserts on
+ * behalf of a spec, except where the assertion is the wait.
+ *
+ * ## The locator policy these helpers follow
+ *
+ * Containers by test id, controls by role and name, text by text. That is the
+ * policy `app/client/App.tsx` documents from the other side, and it is what
+ * makes a renamed button a legitimate test failure rather than an invisible one.
+ */
+
+/** Structural containers, by the ids the application commits to. */
+export const list = (page: Page): Locator => page.getByTestId('task-list')
+export const items = (page: Page): Locator => page.getByTestId('task-item')
+export const emptyState = (page: Page): Locator => page.getByTestId('empty-state')
+export const writeError = (page: Page): Locator => page.getByTestId('write-error')
+
+/** One row, by its exact title. Exact, so `Review the migration plan` cannot match two rows. */
+export const row = (page: Page, title: string): Locator =>
+  items(page).filter({ has: page.getByText(title, { exact: true }) })
+
+/**
+ * One row by the id the application renders on it.
+ *
+ * For the cases where the title is not a usable handle — while a row is being
+ * edited its title is the value of an input, so `row()` above matches nothing.
+ * Locating by a rendered id is the right answer there and the wrong one
+ * elsewhere: a spec that names ids everywhere is a spec that no longer says what
+ * a user would say.
+ */
+export const rowById = (page: Page, id: number): Locator =>
+  page.locator(`[data-task-id="${String(id)}"]`)
+
+/** The titles as rendered, in the order they are rendered. The list's whole contract. */
+export const titles = (page: Page): Locator => page.locator('.task-title')
+
+/**
+ * Open the board and wait for it to have finished loading.
+ *
+ * The wait is a web-first assertion rather than a sleep: it retries until the
+ * loading state is gone, and it fails with "expected hidden, got visible" rather
+ * than with whatever the next line happened to trip over. Every spec starts here,
+ * so getting this wrong once would look like flakiness everywhere.
+ */
+export async function open(page: Page, query = ''): Promise<void> {
+  await page.goto(`/${query}`)
+  await expect(page.getByTestId('loading-state')).toBeHidden()
+}
+
+/** Type a title and submit. The button is disabled until the field has content. */
+export async function add(page: Page, title: string): Promise<void> {
+  await page.getByPlaceholder('What needs doing?').fill(title)
+  await page.getByRole('button', { name: 'Add task' }).click()
+}
+
+/** The buttons a row carries, scoped to that row so a name cannot match another one's. */
+export const action = (page: Page, title: string, name: string): Locator =>
+  row(page, title).getByRole('button', { name, exact: true })

--- a/tests/e2e/complete.spec.ts
+++ b/tests/e2e/complete.spec.ts
@@ -1,0 +1,121 @@
+import { SEED } from '@sentra/taskflow-server'
+import { action, items, open, row, titles } from './board.js'
+import { expect, stored, test } from './fixtures.js'
+
+/**
+ * Completing and reopening a task.
+ *
+ * This is the flow with the optimistic write behind it — `toggle` in
+ * `useTasks.ts` paints first and rolls the field back if the server disagrees —
+ * which makes it the one place in the control group where "the screen says so"
+ * and "the server agrees" are genuinely different claims. Both are asserted, and
+ * separately.
+ *
+ * Optimism is not flakiness. The paint is synchronous and the reconciliation
+ * replaces one field of one row, so there is no interleaving to lose: two
+ * completions in flight touch different rows, and a completion racing its own
+ * response converges on the server's answer. The race this project is about
+ * lives in `move`, not here, and #52 is the spec that catches it.
+ */
+
+const ACTIVE = 'Draft the release notes'
+const DONE = 'Renew the staging certificate'
+
+test.beforeEach(async ({ page }) => {
+  await open(page)
+})
+
+test('marks a task done', async ({ page, db }) => {
+  await action(page, ACTIVE, 'Complete').click()
+
+  await expect(row(page, ACTIVE).getByTestId('task-status')).toHaveText('Done')
+  expect(stored(db).find((task) => task.title === ACTIVE)?.status).toBe('completed')
+})
+
+test('offers to reopen what it just completed', async ({ page }) => {
+  await action(page, ACTIVE, 'Complete').click()
+
+  // The control renames itself, which is the affordance a user reads. Asserting
+  // on the name rather than on a class means a rewording is a visible failure —
+  // deliberately, since that is the fragility `button-lookup-uses-superseded-label`
+  // in the golden dataset is about.
+  await expect(action(page, ACTIVE, 'Reopen')).toBeVisible()
+  await expect(action(page, ACTIVE, 'Complete')).toHaveCount(0)
+})
+
+test('reopens a completed task', async ({ page, db }) => {
+  await action(page, DONE, 'Reopen').click()
+
+  await expect(row(page, DONE).getByTestId('task-status')).toHaveText('To do')
+  await expect(action(page, DONE, 'Complete')).toBeVisible()
+  expect(stored(db).find((task) => task.title === DONE)?.status).toBe('active')
+})
+
+test('keeps the change after a reload', async ({ page }) => {
+  await action(page, ACTIVE, 'Complete').click()
+  await expect(row(page, ACTIVE).getByTestId('task-status')).toHaveText('Done')
+
+  await open(page)
+  await expect(row(page, ACTIVE).getByTestId('task-status')).toHaveText('Done')
+})
+
+/**
+ * The list is ordered by position, and completing a task changes its status, not
+ * its position. A UI that quietly moved completed rows to the bottom would break
+ * every drag-and-drop assertion in the suite for a reason none of them mention.
+ */
+test('leaves the order alone', async ({ page }) => {
+  const before = await titles(page).allTextContents()
+
+  await action(page, ACTIVE, 'Complete').click()
+  await expect(row(page, ACTIVE).getByTestId('task-status')).toHaveText('Done')
+
+  await expect(titles(page)).toHaveText(before)
+})
+
+test('completes one task without touching its neighbours', async ({ page, db }) => {
+  const untouched = stored(db).filter((task) => task.title !== ACTIVE)
+
+  await action(page, ACTIVE, 'Complete').click()
+  await expect(row(page, ACTIVE).getByTestId('task-status')).toHaveText('Done')
+
+  const after = stored(db).filter((task) => task.title !== ACTIVE)
+  expect(after.map((task) => [task.title, task.status])).toEqual(
+    untouched.map((task) => [task.title, task.status]),
+  )
+})
+
+test('completes every task, one after another', async ({ page }) => {
+  for (const task of SEED.filter((row) => row.completed !== true)) {
+    await action(page, task.title, 'Complete').click()
+    await expect(row(page, task.title).getByTestId('task-status')).toHaveText('Done')
+  }
+
+  await expect(page.getByTestId('task-status').filter({ hasText: 'To do' })).toHaveCount(0)
+  await expect(items(page)).toHaveCount(SEED.length)
+})
+
+/**
+ * The rollback path. Forced at the network boundary so it is deterministic:
+ * the request never reaches the server, so there is no timing to get wrong.
+ *
+ * What it demonstrates is the interesting half of an optimistic write — the row
+ * flips, the server refuses, and the row flips back. A UI that painted and then
+ * left the wrong state on screen would be lying to the user, and no reload would
+ * be there to correct it.
+ */
+test('puts the row back when the server refuses', async ({ page, db }) => {
+  await page.route('**/api/tasks/*/complete', (route) =>
+    route.fulfill({
+      status: 500,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: { code: 'internal', message: 'something went wrong' } }),
+    }),
+  )
+
+  await action(page, ACTIVE, 'Complete').click()
+
+  await expect(page.getByTestId('write-error')).toBeVisible()
+  await expect(row(page, ACTIVE).getByTestId('task-status')).toHaveText('To do')
+  expect(stored(db).find((task) => task.title === ACTIVE)?.status).toBe('active')
+})

--- a/tests/e2e/create.spec.ts
+++ b/tests/e2e/create.spec.ts
@@ -1,0 +1,151 @@
+import { SEED } from '@sentra/taskflow-server'
+import { add, emptyState, items, open, titles, writeError } from './board.js'
+import { expect, stored, test } from './fixtures.js'
+
+/**
+ * Creating a task. Part of the control group.
+ *
+ * ## What "control group" means here, and why it is worth the care
+ *
+ * The classifier this repository evaluates is measured against a dataset built
+ * from these runs. If the ordinary specs are a bit flaky, the dataset says
+ * everything is a bit flaky, every number in `eval/report.md` gets harder to
+ * read, and the one deliberately flaky spec stops being distinguishable from the
+ * noise around it. So the standard here is not "passes on my machine" — it is
+ * that a reader comparing this file with the deliberately flaky reorder spec
+ * (#52, not yet written) should be able to say *why* one of them is at fault and
+ * the other is not.
+ *
+ * Concretely, in this file and its four siblings:
+ *
+ * - **Web-first assertions only.** `expect(locator).toHaveCount()` retries until
+ *   the condition holds or the timeout expires. `expect(await locator.count())`
+ *   samples once and races the application.
+ * - **No `waitForTimeout`.** Not one, anywhere. A sleep is a guess about how
+ *   fast a machine is, and CI is not that machine.
+ * - **No dependence on another test.** Every test opens the board itself and
+ *   every test starts from the seeded database, so running one alone and running
+ *   it last produce the same result.
+ * - **The server is asked too.** The UI can paint a change the server never
+ *   accepted — that is exactly what the optimistic path in `useTasks` does — so
+ *   where a test is about a write having landed, it checks the row as well as
+ *   the pixels.
+ */
+
+test.beforeEach(async ({ page }) => {
+  await open(page)
+})
+
+test('adds a task to the end of the list', async ({ page, db }) => {
+  await add(page, 'Write the postmortem')
+
+  await expect(items(page)).toHaveCount(SEED.length + 1)
+  await expect(titles(page).last()).toHaveText('Write the postmortem')
+
+  // The server, not only the screen. A create that painted and never landed
+  // would satisfy every assertion above.
+  expect(stored(db).at(-1)?.title).toBe('Write the postmortem')
+})
+
+test('clears the field, so the next task can just be typed', async ({ page }) => {
+  await add(page, 'First')
+
+  await expect(page.getByPlaceholder('What needs doing?')).toHaveValue('')
+  await expect(items(page)).toHaveCount(SEED.length + 1)
+})
+
+test('keeps the task after a reload, because it was written and not just drawn', async ({
+  page,
+}) => {
+  await add(page, 'Survives a refresh')
+  await expect(items(page)).toHaveCount(SEED.length + 1)
+
+  await open(page)
+  await expect(titles(page).last()).toHaveText('Survives a refresh')
+})
+
+test('will not submit an empty title', async ({ page, db }) => {
+  const submit = page.getByRole('button', { name: 'Add task' })
+  await expect(submit).toBeDisabled()
+
+  // Whitespace is not content. The button stays disabled, which also blocks the
+  // implicit submission a return key would perform.
+  await page.getByPlaceholder('What needs doing?').fill('   ')
+  await expect(submit).toBeDisabled()
+
+  await expect(items(page)).toHaveCount(SEED.length)
+  expect(stored(db)).toHaveLength(SEED.length)
+})
+
+test('enables the button as soon as there is something to add', async ({ page }) => {
+  const submit = page.getByRole('button', { name: 'Add task' })
+
+  await page.getByPlaceholder('What needs doing?').fill('Something')
+  await expect(submit).toBeEnabled()
+})
+
+test('stores the title without the whitespace around it', async ({ page, db }) => {
+  await add(page, '   Padded on both sides   ')
+
+  await expect(titles(page).last()).toHaveText('Padded on both sides')
+  expect(stored(db).at(-1)?.title).toBe('Padded on both sides')
+})
+
+test('adds a second task below the first', async ({ page }) => {
+  await add(page, 'Earlier')
+  await expect(items(page)).toHaveCount(SEED.length + 1)
+
+  await add(page, 'Later')
+  await expect(items(page)).toHaveCount(SEED.length + 2)
+
+  await expect(titles(page).nth(SEED.length)).toHaveText('Earlier')
+  await expect(titles(page).nth(SEED.length + 1)).toHaveText('Later')
+})
+
+/**
+ * A rejected write, forced rather than waited for.
+ *
+ * The failure is injected at the network boundary with `page.route`, which makes
+ * it deterministic: the request never reaches the server, so there is nothing to
+ * race. Injecting it in the *application* would produce something intermittent,
+ * and the one intermittent thing in this suite is meant to be #52.
+ */
+test('says so when the server refuses the write, and keeps the list', async ({ page, db }) => {
+  await page.route('**/api/tasks', async (route) =>
+    route.request().method() === 'POST'
+      ? route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: { code: 'internal', message: 'something went wrong' } }),
+        })
+      : route.fallback(),
+  )
+
+  await add(page, 'Never lands')
+
+  await expect(writeError(page)).toBeVisible()
+  await expect(writeError(page)).toContainText('something went wrong')
+
+  // The list is still there — a failed write must not take the page down with it.
+  await expect(items(page)).toHaveCount(SEED.length)
+  expect(stored(db)).toHaveLength(SEED.length)
+
+  await page.getByRole('button', { name: 'Dismiss' }).click()
+  await expect(writeError(page)).toBeHidden()
+})
+
+/**
+ * The empty state is the create flow's other end: a board with nothing on it has
+ * to say so, or a reader cannot tell it apart from a board that failed to load.
+ */
+test('offers the empty state when there is nothing left to show', async ({ page, db }) => {
+  db.exec('DELETE FROM tasks')
+  await open(page)
+
+  await expect(emptyState(page)).toHaveText('Nothing to do. Add a task to get started.')
+  await expect(items(page)).toHaveCount(0)
+
+  await add(page, 'The only one')
+  await expect(emptyState(page)).toBeHidden()
+  await expect(items(page)).toHaveCount(1)
+})

--- a/tests/e2e/delete.spec.ts
+++ b/tests/e2e/delete.spec.ts
@@ -1,0 +1,115 @@
+import { SEED } from '@sentra/taskflow-server'
+import { action, emptyState, items, open, row, titles } from './board.js'
+import { expect, stored, test } from './fixtures.js'
+
+/**
+ * Deleting a task, which TaskFlow asks about first.
+ *
+ * The confirmation is two buttons in the page rather than `window.confirm`, and
+ * that is a deliberate choice made in `App.tsx` for the sake of this file: a
+ * native dialog blocks the event loop and has to be intercepted by name in
+ * Playwright, which is a genuine and well-known source of intermittent failures.
+ * This application's intermittency is meant to come from exactly one place, so
+ * the dialog is in the DOM where a spec can see it.
+ */
+
+const TASK = 'Draft the release notes'
+
+test.beforeEach(async ({ page }) => {
+  await open(page)
+})
+
+test('asks before deleting anything', async ({ page, db }) => {
+  await action(page, TASK, 'Delete').click()
+
+  await expect(row(page, TASK).getByTestId('delete-confirm')).toBeVisible()
+  await expect(items(page)).toHaveCount(SEED.length)
+  expect(stored(db)).toHaveLength(SEED.length)
+})
+
+test('keeps the task when the confirmation is dismissed', async ({ page, db }) => {
+  await action(page, TASK, 'Delete').click()
+  await action(page, TASK, 'Cancel').click()
+
+  await expect(page.getByTestId('delete-confirm')).toHaveCount(0)
+  await expect(page.getByText(TASK)).toBeVisible()
+  expect(stored(db).map((task) => task.title)).toContain(TASK)
+})
+
+test('removes the task when the deletion is confirmed', async ({ page, db }) => {
+  await action(page, TASK, 'Delete').click()
+  await action(page, TASK, 'Confirm delete').click()
+
+  await expect(page.getByText(TASK)).toHaveCount(0)
+  await expect(items(page)).toHaveCount(SEED.length - 1)
+  expect(stored(db).map((task) => task.title)).not.toContain(TASK)
+})
+
+test('leaves the other rows in the order they were in', async ({ page }) => {
+  const before = await titles(page).allTextContents()
+
+  await action(page, TASK, 'Delete').click()
+  await action(page, TASK, 'Confirm delete').click()
+  await expect(items(page)).toHaveCount(SEED.length - 1)
+
+  await expect(titles(page)).toHaveText(before.filter((title) => title !== TASK))
+})
+
+test('keeps the deletion after a reload', async ({ page }) => {
+  await action(page, TASK, 'Delete').click()
+  await action(page, TASK, 'Confirm delete').click()
+  await expect(items(page)).toHaveCount(SEED.length - 1)
+
+  await open(page)
+  await expect(page.getByText(TASK)).toHaveCount(0)
+})
+
+test('deletes more than one, one confirmation at a time', async ({ page }) => {
+  for (const title of [TASK, 'Triage the flaky board spec']) {
+    await action(page, title, 'Delete').click()
+    await action(page, title, 'Confirm delete').click()
+    await expect(page.getByText(title)).toHaveCount(0)
+  }
+
+  await expect(items(page)).toHaveCount(SEED.length - 2)
+})
+
+test('shows the empty state once the last task is gone', async ({ page, db }) => {
+  db.exec("DELETE FROM tasks WHERE title != 'Draft the release notes'")
+  await open(page)
+  await expect(items(page)).toHaveCount(1)
+
+  await action(page, TASK, 'Delete').click()
+  await action(page, TASK, 'Confirm delete').click()
+
+  await expect(emptyState(page)).toHaveText('Nothing to do. Add a task to get started.')
+  await expect(items(page)).toHaveCount(0)
+})
+
+/**
+ * A delete the server refuses. Forced at the network boundary, so the failure is
+ * the one the test is about rather than one it happened to catch.
+ *
+ * Deleting is not optimistic — the row is removed only once the server has
+ * agreed — so the interesting assertion is that a refusal leaves the list intact
+ * rather than that it is restored.
+ */
+test('keeps the row when the server refuses the delete', async ({ page, db }) => {
+  await page.route('**/api/tasks/*', async (route) =>
+    route.request().method() === 'DELETE'
+      ? route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: { code: 'internal', message: 'something went wrong' } }),
+        })
+      : route.fallback(),
+  )
+
+  await action(page, TASK, 'Delete').click()
+  await action(page, TASK, 'Confirm delete').click()
+
+  await expect(page.getByTestId('write-error')).toBeVisible()
+  await expect(page.getByText(TASK)).toBeVisible()
+  await expect(items(page)).toHaveCount(SEED.length)
+  expect(stored(db).map((task) => task.title)).toContain(TASK)
+})

--- a/tests/e2e/edit.spec.ts
+++ b/tests/e2e/edit.spec.ts
@@ -1,0 +1,143 @@
+import type { Locator, Page } from '@playwright/test'
+import type { Db } from '@sentra/taskflow-server'
+import { items, open, row, rowById } from './board.js'
+import { expect, stored, test } from './fixtures.js'
+
+/**
+ * Editing a task's title and description.
+ *
+ * The flow that changes the thing every other spec locates by. That is worth
+ * saying out loud: a rename moves the selector, and both
+ * `assertion-pins-reworded-empty-state` and `button-lookup-uses-superseded-label`
+ * in the golden dataset are that failure. This file uses the old title before
+ * the rename and the new one after it, on purpose — a spec that kept using the
+ * old name would be asserting on a fixture rather than on the application.
+ *
+ * **While a row is being edited it has no title to find it by.** The title
+ * becomes the value of an input, so a locator built from the text matches
+ * nothing, and the failure reads as "the row disappeared". These tests hold the
+ * row by the id the application renders on it, which is stable across the rename
+ * that is the point of the flow. Everywhere else in the suite, locating by id
+ * would be worse: it stops saying what a user would say.
+ *
+ * The edit form is not optimistic. It sends, waits, and applies the row the
+ * server returns — so every assertion here is about the final state and none of
+ * them needs to know how long the request took.
+ */
+
+const TASK = 'Triage the flaky board spec'
+
+/** The row under test, held by id so that renaming it does not lose it. */
+const target = (page: Page, db: Db): Locator =>
+  rowById(page, stored(db).find((task) => task.title === TASK)?.id ?? 0)
+
+const form = (page: Page, db: Db): Locator => target(page, db).getByTestId('edit-form')
+
+const startEditing = async (page: Page, db: Db): Promise<Locator> => {
+  await target(page, db).getByRole('button', { name: 'Edit', exact: true }).click()
+  await expect(form(page, db)).toBeVisible()
+  return form(page, db)
+}
+
+test.beforeEach(async ({ page }) => {
+  await open(page)
+})
+
+test('opens with the values the task already has', async ({ page, db }) => {
+  const editing = await startEditing(page, db)
+
+  await expect(editing.getByLabel('Title')).toHaveValue(TASK)
+  await expect(editing.getByLabel('Description')).toHaveValue('It has failed four times this week.')
+})
+
+test('saves a new title', async ({ page, db }) => {
+  const editing = await startEditing(page, db)
+
+  await editing.getByLabel('Title').fill('Triage the reorder spec')
+  await editing.getByRole('button', { name: 'Save' }).click()
+
+  await expect(page.getByText('Triage the reorder spec')).toBeVisible()
+  await expect(page.getByText(TASK)).toHaveCount(0)
+  expect(stored(db).map((task) => task.title)).toContain('Triage the reorder spec')
+})
+
+test('saves a new description', async ({ page, db }) => {
+  const editing = await startEditing(page, db)
+
+  await editing.getByLabel('Description').fill('Five times now.')
+  await editing.getByRole('button', { name: 'Save' }).click()
+
+  await expect(row(page, TASK)).toContainText('Five times now.')
+  expect(stored(db).find((task) => task.title === TASK)?.description).toBe('Five times now.')
+})
+
+test('closes the form once the save has landed', async ({ page, db }) => {
+  const editing = await startEditing(page, db)
+  await editing.getByRole('button', { name: 'Save' }).click()
+
+  await expect(page.getByTestId('edit-form')).toHaveCount(0)
+  await expect(row(page, TASK).getByRole('button', { name: 'Edit' })).toBeVisible()
+})
+
+test('leaves the task alone when the edit is cancelled', async ({ page, db }) => {
+  const editing = await startEditing(page, db)
+
+  await editing.getByLabel('Title').fill('Discarded')
+  await editing.getByRole('button', { name: 'Cancel' }).click()
+
+  await expect(page.getByTestId('edit-form')).toHaveCount(0)
+  await expect(page.getByText(TASK)).toBeVisible()
+  await expect(page.getByText('Discarded')).toHaveCount(0)
+  expect(stored(db).map((task) => task.title)).toContain(TASK)
+})
+
+test('will not save an empty title', async ({ page, db }) => {
+  const editing = await startEditing(page, db)
+  const save = editing.getByRole('button', { name: 'Save' })
+
+  await editing.getByLabel('Title').fill('')
+  await expect(save).toBeDisabled()
+
+  // Whitespace is not a title. The form stays open and the row keeps its name.
+  await editing.getByLabel('Title').fill('   ')
+  await expect(save).toBeDisabled()
+  expect(stored(db).map((task) => task.title)).toContain(TASK)
+})
+
+test('keeps the edit after a reload', async ({ page, db }) => {
+  const editing = await startEditing(page, db)
+
+  await editing.getByLabel('Title').fill('Renamed and reloaded')
+  await editing.getByRole('button', { name: 'Save' }).click()
+  await expect(page.getByText('Renamed and reloaded')).toBeVisible()
+
+  await open(page)
+  await expect(page.getByText('Renamed and reloaded')).toBeVisible()
+})
+
+/**
+ * Two rows can be open at once — each keeps its own state — so the assertion is
+ * that they are independent rather than that only one exists. A form that read
+ * another row's values would be a data-loss bug wearing the costume of a
+ * rendering glitch.
+ */
+test('edits one row at a time', async ({ page, db }) => {
+  const first = await startEditing(page, db)
+  await row(page, 'Draft the release notes')
+    .getByRole('button', { name: 'Edit', exact: true })
+    .click()
+
+  await expect(page.getByTestId('edit-form')).toHaveCount(2)
+  await expect(first.getByLabel('Title')).toHaveValue(TASK)
+})
+
+test('does not change how many tasks there are', async ({ page, db }) => {
+  const before = stored(db).length
+
+  const editing = await startEditing(page, db)
+  await editing.getByRole('button', { name: 'Save' }).click()
+  await expect(page.getByTestId('edit-form')).toHaveCount(0)
+
+  await expect(items(page)).toHaveCount(before)
+  expect(stored(db)).toHaveLength(before)
+})

--- a/tests/e2e/filter.spec.ts
+++ b/tests/e2e/filter.spec.ts
@@ -1,0 +1,158 @@
+import { SEED } from '@sentra/taskflow-server'
+import { action, emptyState, items, open, row, titles } from './board.js'
+import { expect, test } from './fixtures.js'
+
+/**
+ * Filtering the list, and the query parameter that records the choice.
+ *
+ * The filter is applied in the client, so switching it issues no request. That
+ * is what makes these assertions safe to write without waiting on anything: the
+ * list changes in the same tick as the click. It is also why this file is the
+ * right neighbour for #53 — under a filter, the same locator can match one row
+ * or two, and a spec written against one view fails under another for reasons
+ * that have nothing to do with timing.
+ *
+ * The seed leaves two tasks completed and three active. Every count here is
+ * derived from `SEED` rather than written as a number, so adding a fixture row
+ * cannot leave this file quietly asserting the wrong thing.
+ */
+
+const COMPLETED = SEED.filter((task) => task.completed === true)
+const ACTIVE = SEED.filter((task) => task.completed !== true)
+
+test('shows everything by default', async ({ page }) => {
+  await open(page)
+
+  await expect(items(page)).toHaveCount(SEED.length)
+  await expect(page.getByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'true')
+})
+
+test('shows only the active tasks', async ({ page }) => {
+  await open(page)
+  await page.getByRole('button', { name: 'Active' }).click()
+
+  await expect(items(page)).toHaveCount(ACTIVE.length)
+  await expect(titles(page)).toHaveText(ACTIVE.map((task) => task.title))
+})
+
+test('shows only the completed tasks', async ({ page }) => {
+  await open(page)
+  await page.getByRole('button', { name: 'Completed' }).click()
+
+  await expect(items(page)).toHaveCount(COMPLETED.length)
+  await expect(titles(page)).toHaveText(COMPLETED.map((task) => task.title))
+})
+
+/**
+ * `aria-pressed`, not a class. It is what a screen reader announces and what a
+ * spec can assert on without knowing anything about the stylesheet — the control
+ * is found the way a user finds it, by role and name.
+ */
+test('says which filter is selected', async ({ page }) => {
+  await open(page)
+  await page.getByRole('button', { name: 'Active' }).click()
+
+  await expect(page.getByRole('button', { name: 'Active', pressed: true })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'All', pressed: false })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Completed', pressed: false })).toBeVisible()
+})
+
+test('records the choice in the address bar', async ({ page }) => {
+  await open(page)
+
+  await page.getByRole('button', { name: 'Active' }).click()
+  await expect(page).toHaveURL(/\?filter=active$/)
+
+  await page.getByRole('button', { name: 'Completed' }).click()
+  await expect(page).toHaveURL(/\?filter=completed$/)
+
+  // `all` is the default, so it leaves no parameter behind. A URL that carries
+  // its defaults is one nobody can read at a glance.
+  await page.getByRole('button', { name: 'All' }).click()
+  await expect(page).toHaveURL((url) => url.search === '')
+})
+
+test('opens straight into the filter a link asked for', async ({ page }) => {
+  await open(page, '?filter=completed')
+
+  await expect(items(page)).toHaveCount(COMPLETED.length)
+  await expect(page.getByRole('button', { name: 'Completed', pressed: true })).toBeVisible()
+})
+
+/**
+ * A typo in a shared link should still show tasks. The alternative — an empty
+ * board, or an error — makes a link that was almost right look like an outage.
+ */
+test('falls back to everything when the parameter makes no sense', async ({ page }) => {
+  await open(page, '?filter=nearly')
+
+  await expect(items(page)).toHaveCount(SEED.length)
+  await expect(page.getByRole('button', { name: 'All', pressed: true })).toBeVisible()
+})
+
+test('keeps the filter across a reload', async ({ page }) => {
+  await open(page)
+  await page.getByRole('button', { name: 'Active' }).click()
+  await expect(items(page)).toHaveCount(ACTIVE.length)
+
+  await page.reload()
+  await expect(page.getByRole('button', { name: 'Active', pressed: true })).toBeVisible()
+  await expect(items(page)).toHaveCount(ACTIVE.length)
+})
+
+test('moves a task between the two filtered views when it is completed', async ({ page }) => {
+  const task = ACTIVE[0]?.title ?? ''
+
+  await open(page)
+  await action(page, task, 'Complete').click()
+  await expect(row(page, task).getByTestId('task-status')).toHaveText('Done')
+
+  await page.getByRole('button', { name: 'Active' }).click()
+  await expect(page.getByText(task)).toHaveCount(0)
+
+  await page.getByRole('button', { name: 'Completed' }).click()
+  await expect(page.getByText(task)).toBeVisible()
+  await expect(items(page)).toHaveCount(COMPLETED.length + 1)
+})
+
+test('adds to the unfiltered list even while a filter is set', async ({ page }) => {
+  await open(page, '?filter=completed')
+  await expect(items(page)).toHaveCount(COMPLETED.length)
+
+  await page.getByPlaceholder('What needs doing?').fill('Created under a filter')
+  await page.getByRole('button', { name: 'Add task' }).click()
+
+  // A new task is active, so it does not belong in this view — and the view is
+  // not silently switched, because a filter the user set is a filter they meant.
+  await expect(items(page)).toHaveCount(COMPLETED.length)
+  await page.getByRole('button', { name: 'All' }).click()
+  await expect(page.getByText('Created under a filter')).toBeVisible()
+})
+
+/**
+ * "Nothing here" and "nothing matches" are different facts, and the application
+ * says so in different words. One message for both would leave a reader unable
+ * to tell an empty database from a filter they forgot they set.
+ */
+test.describe('the empty states', () => {
+  test('says everything is done when nothing is active', async ({ page, db }) => {
+    db.exec("UPDATE tasks SET status = 'completed'")
+    await open(page, '?filter=active')
+
+    await expect(emptyState(page)).toHaveText('No active tasks. Everything here is done.')
+  })
+
+  test('says nothing is completed when nothing is', async ({ page, db }) => {
+    db.exec("UPDATE tasks SET status = 'active'")
+    await open(page, '?filter=completed')
+
+    await expect(emptyState(page)).toHaveText('Nothing completed yet.')
+  })
+
+  test('says the board is empty when it is', async ({ page, db }) => {
+    db.exec('DELETE FROM tasks')
+    await open(page, '?filter=active')
+
+    await expect(emptyState(page)).toHaveText('No active tasks. Everything here is done.')
+  })
+})

--- a/tests/unit/e2e-standards.test.ts
+++ b/tests/unit/e2e-standards.test.ts
@@ -1,0 +1,111 @@
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The standard the end-to-end specs are held to, enforced rather than described.
+ *
+ * These specs are the control group. Every number in `eval/report.md` is measured
+ * against a dataset built from their runs, so a spec that is a little bit flaky
+ * does not merely fail sometimes — it teaches the classifier that everything is a
+ * little bit flaky, and it makes the one deliberately flaky spec indistinguishable
+ * from the noise around it.
+ *
+ * A standard in a CONTRIBUTING file is a standard until somebody is in a hurry.
+ * These are the four habits that produce most intermittent failures in Playwright
+ * suites, and each is checked here against the files git actually tracks.
+ *
+ * The flaky specs of #52–#55 are held to the same rules on purpose. Their
+ * flakiness has to come from the application or from a *deliberate, documented*
+ * selector choice — never from a sleep somebody left in, which would make the
+ * ground-truth label a guess about the author's intent.
+ */
+
+/**
+ * Comments removed before anything is checked.
+ *
+ * These specs explain themselves, and the explanations name the very things the
+ * rules forbid — the header of `create.spec.ts` says "no `waitForTimeout`" in so
+ * many words. A guard that fired on the sentence describing it would push
+ * authors towards writing less about why, which is the opposite of what this
+ * repository wants from a spec.
+ *
+ * Line comments are dropped only when they start the line, so a `//` inside a
+ * URL survives and no assertion loses its subject.
+ */
+const code = (source: string): string =>
+  source
+    .replaceAll(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('//'))
+    .join('\n')
+
+const specs = execSync('git ls-files "tests/e2e/*.spec.ts"', { encoding: 'utf8' })
+  .split('\n')
+  .filter((path) => path !== '')
+  .map((path) => {
+    const raw = readFileSync(path, 'utf8')
+    return { path, raw, source: code(raw) }
+  })
+
+describe('the end-to-end specs', () => {
+  it('exist, so the rules below are checking something', () => {
+    expect(specs.length).toBeGreaterThan(0)
+  })
+
+  /**
+   * A sleep is a guess about how fast a machine is, and CI is not that machine.
+   * It is also the single most common cause of a suite that passes locally and
+   * fails at 20% in CI — which is #55, a spec this repository writes on purpose
+   * and exactly once.
+   */
+  it.each(specs)('$path waits for conditions, never for the clock', ({ source }) => {
+    expect(source).not.toContain('waitForTimeout')
+    expect(source).not.toMatch(/setTimeout\s*\(/)
+  })
+
+  /**
+   * `expect(await locator.count()).toBe(3)` samples once and races the
+   * application. `expect(locator).toHaveCount(3)` retries until the condition
+   * holds or the timeout expires. The two look almost identical in a diff and
+   * behave completely differently under load.
+   *
+   * Reading a value to compare against later is a different thing and is allowed
+   * — `const before = await titles(page).allTextContents()` is a capture, not an
+   * assertion.
+   */
+  it.each(specs)('$path asserts on the page with web-first assertions', ({ source }) => {
+    // Matched across the rest of the line rather than to the closing bracket:
+    // `expect(await items(page).count())` nests parentheses, and a pattern that
+    // stopped at the first `)` walked straight past it — which is how this rule
+    // came to be checked by feeding it the violation rather than by reading it.
+    const sampled =
+      /expect\(\s*await\s[^\n]*(?:page\.|\.count\(|\.textContent\(|\.innerText\(|\.isVisible\(|\.allTextContents\()/
+    expect(source).not.toMatch(sampled)
+  })
+
+  /**
+   * The pre-locator API returns an element handle taken at one moment. Every
+   * assertion built on one is a race against the next render.
+   */
+  it.each(specs)('$path uses locators rather than element handles', ({ source }) => {
+    expect(source).not.toContain('waitForSelector')
+    expect(source).not.toMatch(/page\.\$\$?\(/)
+  })
+
+  /** A `test.only` that reaches main silently shrinks the suite to one test. */
+  it.each(specs)('$path runs all of its tests', ({ source }) => {
+    expect(source).not.toMatch(/\btest\.only\b/)
+    expect(source).not.toMatch(/\bdescribe\.only\b/)
+  })
+
+  /**
+   * Every spec file opens with a comment explaining what it covers and why it is
+   * written the way it is. For #52–#55 that comment is the ground truth a reader
+   * checks the dataset label against, so the habit is worth having everywhere
+   * rather than being remembered in the four files where it carries weight.
+   */
+  it.each(specs)('$path says what it is for', ({ raw }) => {
+    expect(raw.slice(0, 2000)).toContain('/**')
+  })
+})


### PR DESCRIPTION
Closes #51

Specs for **create, edit, delete, complete and filter** — 47 tests across five files, alongside the
seven harness tests already there.

## Why the bar is higher than "passes on my machine"

Every number in `eval/report.md` is measured against a dataset built from these runs. A suite that
is a little bit flaky does not merely fail sometimes: it teaches the classifier that everything is
a little bit flaky, and it makes the one deliberately flaky spec indistinguishable from the noise
around it.

So the test is not "is it green" — it is whether a reader comparing one of these files with #52 can
say **why** one is at fault and the other is not. That means the standard has to be visible in the
file rather than asserted in a PR description.

## Four rules, enforced rather than described

`tests/unit/e2e-standards.test.ts` reads every tracked spec and fails on:

| Rule | What it catches |
| --- | --- |
| Web-first assertions | `expect(await locator.count()).toBe(3)` — samples once, races the app |
| Never wait on the clock | `waitForTimeout`, `setTimeout` |
| Locators, not handles | `page.$`, `waitForSelector` |
| The whole suite runs | `test.only`, `describe.only` |

Comments are stripped before anything is checked. The header of `create.spec.ts` explains the rules
by name, and a guard that fired on the sentence describing it would push authors towards writing
less about why.

**Each guard was checked by feeding it the violation.** The web-first one did not fire the first
time — `[^)]*` stopped at the first bracket and walked straight past
`expect(await items(page).count())`. Found by mutation, not by reading.

The flaky specs of #52–#55 are held to the same four rules, deliberately: their flakiness has to
come from the application or from a selector choice the header defends, never from a sleep somebody
left in, which would make the ground-truth label a guess about the author's intent.

## A real layout bug, found by a spec and fixed in the application

`expect(page.getByText('Draft the release notes')).toBeVisible()` failed while the screenshot showed
the words on screen:

```
box {"x":408.98,"y":341.03,"width":0,"height":96}
```

Opening the delete confirmation adds two buttons to a row that already carries five. The actions are
`flex-shrink: 0` on purpose — a button should never become an ellipsis — so the text took all of the
loss and `.task-title` collapsed to a box **zero pixels wide**. It still painted, overflowing under
the buttons, which is why looking at it never revealed anything. An element with an empty bounding
box is hidden, and Playwright was right.

The row now wraps and `.task-text` stops shrinking at `12rem`.

## Editing needed a different kind of locator

While a row is being edited its title is the value of an input, so a locator built from the text
matches nothing and the failure reads as "the row disappeared". Those tests hold the row by the id
the application renders on it. Everywhere else that would be worse — it stops saying what a user
would say — and the file says so.

## Fault injection at the network boundary, never in the application

A forced 500 through `page.route` is deterministic: the request never reaches the server, so there
is nothing to race. Injecting failure into the application would produce something intermittent,
and the one intermittent thing in this suite is meant to be #52.

## Acceptance criteria

| Criterion | Evidence |
| --- | --- |
| Specs for all five flows | `create` 9, `edit` 9, `delete` 8, `complete` 8, `filter` 13 |
| Web-first assertions; no arbitrary sleeps | enforced by `e2e-standards.test.ts`, each guard mutation-tested |
| No inter-test dependencies | see below |
| Green 20 consecutive runs locally | log below |
| Readable as an example of how to write a stable test | header comments; the standard is also in CONTRIBUTING |

**On `--shuffle`:** Playwright has no such flag — that is Vitest's. What stands in for it: a fresh
database and a fresh page per test, every spec file run alone, and `--repeat-each=3`.

```
--repeat-each=3    162 passed (16.1s)

create       9 passed (2.4s)
edit         9 passed (2.6s)
delete       8 passed (2.6s)
complete     8 passed (2.9s)
filter      13 passed (2.8s)
harness      7 passed (1.7s)
```

## 20 consecutive runs

```
run  1:  54 passed (5.8s)     run 11:  54 passed (5.6s)
run  2:  54 passed (5.8s)     run 12:  54 passed (6.1s)
run  3:  54 passed (5.8s)     run 13:  54 passed (5.8s)
run  4:  54 passed (6.4s)     run 14:  54 passed (5.7s)
run  5:  54 passed (6.4s)     run 15:  54 passed (6.6s)
run  6:  54 passed (6.0s)     run 16:  54 passed (7.0s)
run  7:  54 passed (6.3s)     run 17:  54 passed (6.1s)
run  8:  54 passed (5.6s)     run 18:  54 passed (5.9s)
run  9:  54 passed (5.9s)     run 19:  54 passed (5.9s)
run 10:  54 passed (5.7s)     run 20:  54 passed (6.2s)
```

## How this was verified

- 20 consecutive full runs, 54/54 green each, 5.6–7.0s
- `--repeat-each=3` — 162 passed; every spec file alone — green
- `npm run test:unit` — 1474 tests green
- `lint`, `typecheck`, `format:check`, `docs:status:check`, `eval:lint` — clean
- Each of the four spec guards was mutated into failing, and one of them did not fail until it was fixed

**Deliberately not here:** reordering. A stable single-move spec and the racy one belong together,
in #52, where the contrast between them is the point.