### PR TITLE
test(e2e): a selector that names two things, and only sometimes

### DIFF
--- a/docs/eval-methodology.md
+++ b/docs/eval-methodology.md
@@ -58,30 +58,32 @@ the project demonstrates something rarer than a working classifier: a willingnes
 
 ### What it scores today
 
-Against the 33 committed fixtures, with 95% Wilson intervals:
+Against the 35 committed fixtures, with 95% Wilson intervals:
 
 | Metric                | Baseline              | Macro-F1 |
 | --------------------- | --------------------- | -------- |
-| **Joint** (both axes) | **36.4% [22.2–53.4]** | —        |
-| `owner`               | 54.5% [38.0–70.2]     | 0.36     |
-| `determinism`         | 78.8% [62.2–89.3]     | 0.77     |
+| **Joint** (both axes) | **34.3% [20.8–50.8]** | —        |
+| `owner`               | 54.3% [38.2–69.5]     | 0.40     |
+| `determinism`         | 77.1% [61.0–87.9]     | 0.76     |
 
 Three things in that table are worth reading carefully, because they are the reason the metrics are
 shaped this way.
 
-**Joint accuracy is 18pp below the `owner` axis and 42pp below `determinism`.** Reporting either
-axis alone would describe a classifier that half works; 36.4% is how often it produces an answer a
+**Joint accuracy is 20pp below the `owner` axis and 43pp below `determinism`.** Reporting either
+axis alone would describe a classifier that half works; 34.3% is how often it produces an answer a
 developer could act on without checking.
 
-**`test_code` has an F1 of exactly 0.** The baseline never once identifies a test-code failure —
-support 8, four predictions, none correct. Accuracy hides this completely; macro-F1 is what makes
-it visible, which is the argument for reporting both.
+**`test_code` has an F1 of 0.13.** The baseline identifies one test-code failure out of nine —
+support 9, six predictions, one correct — and that one is the captured fixture with no commit under
+test, where there is no product diff for the ownership rule to fire on. It was exactly 0 until that
+fixture arrived. Accuracy hides this completely; macro-F1 is what makes it visible, which is the
+argument for reporting both.
 
-**A classifier that answers `app_code` unconditionally beats it on `owner` accuracy**, 63.6%
-against 54.5%, because 21 of 33 fixtures are `app_code`. That is not a defect in the baseline — it
+**A classifier that answers `app_code` unconditionally beats it on `owner` accuracy**, 62.9%
+against 54.3%, because 22 of 35 fixtures are `app_code`. That is not a defect in the baseline — it
 is the adversarial dataset doing its job. The constant classifier's macro-F1 is 0.26 against the
-baseline's 0.36, so the baseline is genuinely better; accuracy alone simply cannot say so. And the
-two intervals overlap heavily, so at n=33 neither result is evidence of a difference at all. That
+baseline's 0.40, so the baseline is genuinely better; accuracy alone simply cannot say so. And the
+two intervals overlap heavily, so at n=35 neither result is evidence of a difference at all. That
 is the honest reading, and it is also the argument for growing the dataset to 60.
 
 Every number above is pinned in `eval/metrics.test.ts`. A change to the rules or to the dataset
@@ -118,16 +120,20 @@ measured against it. Scoring the baseline per bucket is that measurement:
 | Bucket                      |   n | Joint  | `owner` | `determinism` |
 | --------------------------- | --: | ------ | ------- | ------------- |
 | `straightforward`           |   8 | 100.0% | 100.0%  | 100.0%        |
-| `hard-quadrant`             |  10 | 30.0%  | 60.0%   | 70.0%         |
-| `stale-test`                |   7 | 0.0%   | 0.0%    | 100.0%        |
+| `hard-quadrant`             |  11 | 27.3%  | 54.5%   | 72.7%         |
+| `stale-test`                |   8 | 0.0%   | 12.5%   | 87.5%         |
 | `misleading-history`        |   4 | 0.0%   | 75.0%   | 0.0%          |
 | `environment-as-regression` |   4 | 25.0%  | 25.0%   | 100.0%        |
 
 Each adversarial bucket defeats the baseline **on the axis it was built to attack, and only that
 axis**:
 
-- `stale-test` targets diff-only reasoning about ownership. Owner drops to 0%; determinism stays
-  at 100%.
+- `stale-test` targets diff-only reasoning about ownership. Owner drops to 12.5%; determinism
+  stays at 87.5%. Both numbers used to be absolute — 0% and 100% — and the one fixture that moved
+  them is worth naming: the captured fixture from #53 has no commit under test, so there is no
+  product diff for the ownership rule to fire on, the baseline falls through to its locator rule
+  and gets the owner right. It loses the point back on the other axis. The bucket's story is
+  unchanged; the exception is what shows the story was about the diff all along.
 - `misleading-history` targets flakiness-score-only reasoning about stability. Determinism drops
   to 0%; owner stays at a respectable 75%.
 - `environment-as-regression` targets diff-only reasoning again, from the other direction, and
@@ -333,20 +339,20 @@ So the per-bucket balance is **best-effort and measured**, not guaranteed:
 | Bucket                      | Total | Dev | Held out |
 | --------------------------- | ----: | --: | -------: |
 | `environment-as-regression` |     4 |   3 |        1 |
-| `hard-quadrant`             |    10 |   6 |        4 |
+| `hard-quadrant`             |    11 |   7 |        4 |
 | `misleading-history`        |     4 |   3 |        1 |
-| `stale-test`                |     7 |   5 |        2 |
+| `stale-test`                |     8 |   5 |        3 |
 | `straightforward`           |     8 |   5 |        3 |
-| **Total**                   |    33 |  22 |   **11** |
+| **Total**                   |    35 |  23 |   **12** |
 
-11 of 33 is 33%, not 20%. That is ordinary binomial variance at this size — the expected count is
-6.6 with a standard deviation of 2.3 — and it narrows as the dataset grows towards 60. A bucket of
+12 of 35 is 34%, not 20%. That is ordinary binomial variance at this size — the expected count is
+7 with a standard deviation of 2.4 — and it narrows as the dataset grows towards 60. A bucket of
 four has a 41% chance of receiving no held-out fixture at all; none is currently empty, but the
 report states which are rather than letting a reader assume the split guarantees coverage.
 
 One methodological note, since this is a document about not fooling yourself. Two reasonable
 constructions exist for turning a hash into a uniform value — dividing by 2³², and the slightly
-biased `hash % 100` — and on these 33 fixtures they produce **different splits**, 11 held out
+biased `hash % 100` — and on these 35 fixtures they produce **different splits**, 12 held out
 against 6. Choosing between them after seeing that would be picking a test set by how convenient it
 looks. The unbiased one is used; the result is reported, not selected.
 

--- a/eval/baseline.test.ts
+++ b/eval/baseline.test.ts
@@ -181,6 +181,7 @@ describe('scored against the committed dataset', () => {
   const scored = loadAllPayloads().map(({ name, payload: p }) => ({
     name,
     labels: loadLabels(name),
+    payload: p,
     predicted: classifyWithBaseline(p),
   }))
 
@@ -198,13 +199,26 @@ describe('scored against the committed dataset', () => {
     for (const s of easy) expect(s.predicted.owner, s.name).toBe(s.labels.owner)
   })
 
-  it('gets every stale-test fixture wrong, exactly as documented', () => {
-    // Not a defect. Each of those fixtures has a product diff, so the second
-    // rule fires and calls it app_code. Patching around it would mean tuning
-    // the control against the dataset it exists to control for.
+  it('gets every stale-test fixture with a product diff wrong, exactly as documented', () => {
+    // Not a defect. Those fixtures have a product diff, so the second rule fires
+    // and calls them app_code. Patching around it would mean tuning the control
+    // against the dataset it exists to control for.
+    //
+    // The qualifier is new and it is a real change, not a weakening. #53 added a
+    // captured fixture to this bucket that has **no** diff — it was reproduced
+    // locally, so there is no commit under test — and with no diff to reason
+    // from the baseline falls through to its locator rule and gets the owner
+    // right. It is still wrong about the fixture, on the other axis.
     const stale = scored.filter((s) => s.labels.bucket === 'stale-test')
-    expect(stale.length).toBeGreaterThan(0)
-    for (const s of stale) expect(s.predicted.owner, s.name).toBe('app_code')
+    const withDiff = stale.filter((s) => (s.payload.diff ?? '') !== '')
+
+    expect(withDiff.length).toBeGreaterThan(0)
+    for (const s of withDiff) expect(s.predicted.owner, s.name).toBe('app_code')
+
+    for (const s of stale.filter((s) => (s.payload.diff ?? '') === '')) {
+      expect(s.predicted.owner, s.name).toBe('test_code')
+      expect(s.predicted.determinism, s.name).not.toBe(s.labels.determinism)
+    }
   })
 
   it('gets a majority of the hard quadrant wrong, which is why the dataset can discriminate', () => {
@@ -259,12 +273,12 @@ describe('scored against the committed dataset', () => {
 
   it('records the current owner-axis accuracy so a change to the rules is visible', () => {
     // 8 of 15 by construction: every straightforward fixture, no stale-test one.
-    expect(accuracy((s) => s.predicted.owner === s.labels.owner)).toBeCloseTo(18 / 34, 5)
+    expect(accuracy((s) => s.predicted.owner === s.labels.owner)).toBeCloseTo(19 / 35, 5)
   })
 
   it('records the current determinism-axis accuracy', () => {
     expect(accuracy((s) => s.predicted.determinism === s.labels.determinism)).toBeCloseTo(
-      26 / 34,
+      27 / 35,
       5,
     )
   })

--- a/eval/confusion.test.ts
+++ b/eval/confusion.test.ts
@@ -258,7 +258,7 @@ describe('the baseline against the committed dataset', () => {
     // Rows app_code / test_code / environment, columns the same.
     expect(confusionMatrix(judgements, 'owner').counts).toEqual([
       [17, 5, 0],
-      [8, 0, 0],
+      [8, 1, 0],
       [3, 0, 1],
     ])
   })
@@ -266,16 +266,21 @@ describe('the baseline against the committed dataset', () => {
   it('pins the determinism confusion matrix', () => {
     expect(confusionMatrix(judgements, 'determinism').counts).toEqual([
       [17, 4],
-      [4, 9],
+      [4, 10],
     ])
   })
 
-  it('shows the whole `test_code` row collapsing into `app_code`', () => {
-    // Eight fixtures, every one called app_code. This is the single most
-    // informative cell in the report and accuracy alone never shows it.
+  it('shows almost the whole `test_code` row collapsing into `app_code`', () => {
+    // Eight of nine called app_code. This is the single most informative cell in
+    // the report and accuracy alone never shows it.
+    //
+    // The one that escapes is the captured fixture from #53, which has no diff
+    // for the second rule to fire on. It is the exception that shows what the
+    // cell is really measuring: not that the baseline cannot recognise a test
+    // fault, but that a product diff overrides everything else it knows.
     const matrix = confusionMatrix(judgements, 'owner')
     const row = matrix.counts[matrix.labels.indexOf('test_code')]
-    expect(row).toEqual([8, 0, 0])
+    expect(row).toEqual([8, 1, 0])
   })
 
   it('scores 3 of 11 on the hard quadrant', () => {
@@ -286,9 +291,16 @@ describe('the baseline against the committed dataset', () => {
     expect(hard?.accuracy.point).toBeCloseTo(3 / 11, 10)
   })
 
-  it('has an empty quadrant, so the n/a path is exercised by real data', () => {
+  /**
+   * `test_code` + `intermittent` was the empty one until #53 captured a spec
+   * whose locator is ambiguous only under some list states. Every quadrant now
+   * has support, which is what the dataset is supposed to look like — and it
+   * means the n/a rendering path is no longer exercised by real data, so the
+   * test below covers it with fabricated data instead.
+   */
+  it('has support in every quadrant', () => {
     const empty = quadrantBreakdown(judgements).filter((r) => r.support === 0)
-    expect(empty.map((r) => `${r.owner}+${r.determinism}`)).toEqual(['test_code+intermittent'])
+    expect(empty.map((r) => `${r.owner}+${r.determinism}`)).toEqual([])
   })
 
   const byBucket = scoreBy(judgements, (j) => {
@@ -319,9 +331,13 @@ describe('the baseline against the committed dataset', () => {
     expect(bucket('straightforward')?.joint.point).toBe(1)
   })
 
-  it('is defeated by stale-test on owner alone, the axis that bucket attacks', () => {
-    expect(bucket('stale-test')?.owner.accuracy.point).toBe(0)
-    expect(bucket('stale-test')?.determinism.accuracy.point).toBe(1)
+  it('is defeated by stale-test on owner, the axis that bucket attacks', () => {
+    // 1 of 8, not 0 of 7: #53's captured fixture joined this bucket without a
+    // diff for the second rule to fire on, so the baseline reaches its locator
+    // rule and gets that one owner right. It loses it back on determinism, which
+    // is why this bucket no longer scores 100% there either.
+    expect(bucket('stale-test')?.owner.accuracy.point).toBeCloseTo(1 / 8, 10)
+    expect(bucket('stale-test')?.determinism.accuracy.point).toBeCloseTo(7 / 8, 10)
   })
 
   it('is defeated by misleading-history on determinism alone', () => {

--- a/eval/golden-dataset/README.md
+++ b/eval/golden-dataset/README.md
@@ -41,9 +41,14 @@ of the machine that ran the suite. That path reaches a prompt, then a public pul
 and it makes a fixture specific to whoever captured it. `normalisePlaywrightReport` strips it when
 given a `repositoryRoot`, and `npm run test:e2e` gives it one.
 
-**Test sources are captured without their comments.** A comment in a spec is the author's argument
-about the failure, and the author knew the answer. Keeping them would hand a classifier the label
-in prose that no word list can catch.
+**Test sources are captured without their comments, and the lines around an assertion carry none.**
+A comment in a spec is the author's argument about the failure, and the author knew the answer.
+Keeping them in `testSource` would hand a classifier the label in prose that no word list can catch
+— and the same applies to `error.snippet`, which quotes the few lines around the failure. That one
+cannot be stripped: in production the agent really does see whatever comments are there, and a
+fixture cleaned of them would be easier than the input the pipeline gets. So the fix is at the
+source. A deliberately flaky spec explains itself in its file header, which nothing captures, and
+keeps the lines beside its assertions plain.
 
 **A spec is named after the behaviour it covers, never after the defect it demonstrates.** The file
 path is part of what a classifier sees. A spec called `reorder-race.spec.ts` gives the answer away,

--- a/eval/golden-dataset/list-order-reverts-after-two-quick-moves.run.json
+++ b/eval/golden-dataset/list-order-reverts-after-two-quick-moves.run.json
@@ -9,22 +9,22 @@
       "status": "failed",
       "attempts": 1,
       "flakyWithinRun": false,
-      "durationMs": 10580,
+      "durationMs": 10648,
       "annotations": [],
       "error": {
         "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveText\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m failed\n\nLocator:  locator('.task-title').nth(2)\nExpected: \u001b[32m\"Draft the release notes\"\u001b[39m\nReceived: \u001b[31m\"Renew the staging certificate\"\u001b[39m\nTimeout:  10000ms\n\nCall log:\n\u001b[2m  - Expect \"toHaveText\" with timeout 10000ms\u001b[22m\n\u001b[2m  - waiting for locator('.task-title').nth(2)\u001b[22m\n\u001b[2m    24 × locator resolved to <p class=\"task-title\">Renew the staging certificate</p>\u001b[22m\n\u001b[2m       - unexpected value \"Renew the staging certificate\"\u001b[22m\n",
-        "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveText\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m failed\n\nLocator:  locator('.task-title').nth(2)\nExpected: \u001b[32m\"Draft the release notes\"\u001b[39m\nReceived: \u001b[31m\"Renew the staging certificate\"\u001b[39m\nTimeout:  10000ms\n\nCall log:\n\u001b[2m  - Expect \"toHaveText\" with timeout 10000ms\u001b[22m\n\u001b[2m  - waiting for locator('.task-title').nth(2)\u001b[22m\n\u001b[2m    24 × locator resolved to <p class=\"task-title\">Renew the staging certificate</p>\u001b[22m\n\u001b[2m       - unexpected value \"Renew the staging certificate\"\u001b[22m\n\n    at tests/e2e/reorder-quick-succession.spec.ts:124:37",
-        "snippet": "  122 |   // And the list should agree with it. When this fails the row is at index 3 —\n  123 |   // the order as of the first move, restored by its own late response.\n> 124 |   await expect(titles(page).nth(2)).toHaveText(TASK)\n      |                                     ^\n  125 | })\n  126 |\n  127 | /**"
+        "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoHaveText\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m failed\n\nLocator:  locator('.task-title').nth(2)\nExpected: \u001b[32m\"Draft the release notes\"\u001b[39m\nReceived: \u001b[31m\"Renew the staging certificate\"\u001b[39m\nTimeout:  10000ms\n\nCall log:\n\u001b[2m  - Expect \"toHaveText\" with timeout 10000ms\u001b[22m\n\u001b[2m  - waiting for locator('.task-title').nth(2)\u001b[22m\n\u001b[2m    24 × locator resolved to <p class=\"task-title\">Renew the staging certificate</p>\u001b[22m\n\u001b[2m       - unexpected value \"Renew the staging certificate\"\u001b[22m\n\n    at tests/e2e/reorder-quick-succession.spec.ts:135:37",
+        "snippet": "  133 |   await expect.poll(() => stored(db)[2]?.title).toBe(TASK)\n  134 |\n> 135 |   await expect(titles(page).nth(2)).toHaveText(TASK)\n      |                                     ^\n  136 | })\n  137 |\n  138 | /**"
       }
     },
     "signal": {
       "testId": "tests/e2e/reorder-quick-succession.spec.ts›keeps both moves when a task is moved twice in quick succession",
-      "flakinessScore": 0.68,
-      "consecutiveFailures": 2,
+      "flakinessScore": 0.63,
+      "consecutiveFailures": 1,
       "totalRuns": 20,
-      "firstSeenAt": "2026-08-17T12:20:39.396Z",
-      "lastPassedAt": "2026-08-17T12:24:22.364Z",
-      "statusHistory": "PFFPFPPPPFPFPPFPFPFF",
+      "firstSeenAt": "2026-08-17T12:47:45.754Z",
+      "lastPassedAt": "2026-08-17T12:50:58.848Z",
+      "statusHistory": "FPPPPFPFPFFPFPFFFPPF",
       "isNew": false
     }
   },

--- a/eval/golden-dataset/name-lookup-matches-two-rows-after-an-add.labels.json
+++ b/eval/golden-dataset/name-lookup-matches-two-rows-after-an-add.labels.json
@@ -1,0 +1,10 @@
+{
+  "name": "name-lookup-matches-two-rows-after-an-add",
+  "owner": "test_code",
+  "determinism": "intermittent",
+  "justification": "The tempting alternative is app_code, because the failure is intermittent and the product is what changed between a passing run and a failing one — the added row arrives sooner on some runs than on others. It is still the test that is wrong. The locator is a substring match, the board already holds another task whose title starts the same way, and once the new row is on screen the locator names two elements instead of one; the runner says so outright and lists both. Rule 2 fires: the test assumes a partial title identifies one row, which the data does not guarantee, so it is not a valid detector and cannot be evidence about the product. Waiting does not fix it and makes it certain — adding the correct toHaveCount wait before the assertion took it from roughly half of runs to eight failures out of eight. Intermittent because the history alternates: 5 failures in 19 runs, with passes inside the last five.",
+  "ruleApplied": "rule-2-unsafe-test-assumption",
+  "provenance": "captured",
+  "bucket": "stale-test",
+  "lowConfidenceGroundTruth": false
+}

--- a/eval/golden-dataset/name-lookup-matches-two-rows-after-an-add.run.json
+++ b/eval/golden-dataset/name-lookup-matches-two-rows-after-an-add.run.json
@@ -1,0 +1,33 @@
+{
+  "name": "name-lookup-matches-two-rows-after-an-add",
+  "scenario": "A lookup by partial name resolves to more than one row once a task with a similar title is added.",
+  "subject": {
+    "result": {
+      "testId": "tests/e2e/find-by-name.spec.ts›finds a newly added task in the active list",
+      "title": "finds a newly added task in the active list",
+      "file": "tests/e2e/find-by-name.spec.ts",
+      "status": "failed",
+      "attempts": 1,
+      "flakyWithinRun": false,
+      "durationMs": 367,
+      "annotations": [],
+      "error": {
+        "message": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m(\u001b[22m\u001b[2m)\u001b[22m failed\n\nLocator: getByText('Review the')\nExpected: visible\nError: strict mode violation: getByText('Review the') resolved to 2 elements:\n    1) <p class=\"task-title\">Review the migration plan</p> aka getByText('Review the migration plan')\n    2) <p class=\"task-title\">Review the incident timeline</p> aka getByText('Review the incident timeline')\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 10000ms\u001b[22m\n\u001b[2m  - waiting for getByText('Review the')\u001b[22m\n",
+        "stack": "Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m(\u001b[22m\u001b[2m)\u001b[22m failed\n\nLocator: getByText('Review the')\nExpected: visible\nError: strict mode violation: getByText('Review the') resolved to 2 elements:\n    1) <p class=\"task-title\">Review the migration plan</p> aka getByText('Review the migration plan')\n    2) <p class=\"task-title\">Review the incident timeline</p> aka getByText('Review the incident timeline')\n\nCall log:\n\u001b[2m  - Expect \"toBeVisible\" with timeout 10000ms\u001b[22m\n\u001b[2m  - waiting for getByText('Review the')\u001b[22m\n\n    at tests/e2e/find-by-name.spec.ts:102:40",
+        "snippet": "  100 |   await expect(page.getByText('Write the incident postmortem')).toBeVisible()\n  101 |\n> 102 |   await expect(page.getByText(PREFIX)).toBeVisible()\n      |                                        ^\n  103 | })\n  104 |\n  105 | /**"
+      }
+    },
+    "signal": {
+      "testId": "tests/e2e/find-by-name.spec.ts›finds a newly added task in the active list",
+      "flakinessScore": 0.39,
+      "consecutiveFailures": 2,
+      "totalRuns": 19,
+      "firstSeenAt": "2026-08-17T12:47:45.754Z",
+      "lastPassedAt": "2026-08-17T12:50:33.222Z",
+      "statusHistory": "PPPFPPFPFPPPPPPPPFF",
+      "isNew": false
+    }
+  },
+  "historyAvailable": true,
+  "testSource": "const PREFIX = 'Review the'\nconst NEW_TASK = 'Review the incident timeline'\n\ntest.beforeEach(async ({ page }) => {\n  await open(page, '?filter=active')\n})\n\ntest('finds a newly added task in the active list', async ({ page }) => {\n  await expect(page.getByText(PREFIX)).toBeVisible()\n\n  await add(page, NEW_TASK)\n\n  await page.getByRole('button', { name: 'Completed' }).click()\n  await expect(page.getByText(NEW_TASK)).toHaveCount(0)\n  await expect(page.getByText('Review the release checklist')).toBeVisible()\n\n  await page.getByRole('button', { name: 'Active' }).click()\n  await expect(page.getByRole('button', { name: 'Active', pressed: true })).toBeVisible()\n  await expect(page.getByText('Write the incident postmortem')).toBeVisible()\n\n  await expect(page.getByText(PREFIX)).toBeVisible()\n})\n"
+}

--- a/eval/hygiene.test.ts
+++ b/eval/hygiene.test.ts
@@ -163,6 +163,6 @@ describe('the committed dataset', () => {
     // When this flips, the drift check starts failing the build — which is the
     // point at which the remaining buckets have to be filled in.
     expect(report.compositionEnforced).toBe(false)
-    expect(report.fixtures).toBe(34)
+    expect(report.fixtures).toBe(35)
   })
 })

--- a/eval/metrics.json
+++ b/eval/metrics.json
@@ -3,7 +3,7 @@
   "classifier": "baseline",
   "promptVersion": null,
   "slice": "dev",
-  "datasetRevision": "5ce9721387a4b800",
+  "datasetRevision": "f35876ebfe37b8b4",
   "n": 23,
   "joint": {
     "point": 0.34782608695652173,
@@ -17,10 +17,10 @@
     "macroF1": 0.375
   },
   "determinism": {
-    "point": 0.782608695652174,
-    "lower": 0.5809651698373599,
-    "upper": 0.9033602197341379,
-    "macroF1": 0.7667342799188641
+    "point": 0.8260869565217391,
+    "lower": 0.6286235235977385,
+    "upper": 0.9302134643693744,
+    "macroF1": 0.8174603174603174
   },
   "hardQuadrant": {
     "point": 0.2857142857142857,

--- a/eval/metrics.test.ts
+++ b/eval/metrics.test.ts
@@ -355,35 +355,37 @@ describe('the baseline scored against the committed dataset', () => {
    * moved and whether the movement was intended.
    */
   it('records joint accuracy, the headline metric', () => {
-    expect(metrics.n).toBe(34)
+    expect(metrics.n).toBe(35)
     expect(metrics.joint.successes).toBe(12)
-    expect(metrics.joint.point).toBeCloseTo(0.3529, 4)
+    expect(metrics.joint.point).toBeCloseTo(0.3429, 4)
   })
 
   it('shows joint accuracy well below either axis', () => {
-    // 52.9% and 76.5% look like a classifier that half works. 35.3% is how often
+    // 54.3% and 77.1% look like a classifier that half works. 34.3% is how often
     // it produces an answer a developer could act on, and it is the only one of
     // the three that says so.
-    expect(metrics.owner.accuracy.successes).toBe(18)
-    expect(metrics.determinism.accuracy.successes).toBe(26)
+    expect(metrics.owner.accuracy.successes).toBe(19)
+    expect(metrics.determinism.accuracy.successes).toBe(27)
     expect(metrics.joint.point).toBeLessThan(metrics.owner.accuracy.point - 0.15)
   })
 
   it('reports an interval wide enough to forbid reading small movements', () => {
-    // ±15.3pp at n=34. Any comparison of two runs that differ by less than a
+    // ±15.0pp at n=35. Any comparison of two runs that differ by less than a
     // third of the dataset is noise, and the interval is what says so out loud.
-    expect(marginOfError(metrics.joint)).toBeGreaterThan(15)
-    expect(metrics.joint.interval.lower).toBeCloseTo(0.2149, 3)
-    expect(metrics.joint.interval.upper).toBeCloseTo(0.5209, 3)
+    expect(marginOfError(metrics.joint)).toBeGreaterThan(14)
+    expect(metrics.joint.interval.lower).toBeCloseTo(0.2083, 3)
+    expect(metrics.joint.interval.upper).toBeCloseTo(0.5085, 3)
   })
 
-  it('never finds a single test_code fixture, which accuracy alone hides', () => {
-    // The 7 stale-test fixtures all carry a real product diff, so the baseline
-    // calls them app_code — documented in docs/eval-methodology.md and left
-    // deliberately unfixed. The consequence is a class with F1 exactly 0.
+  it('finds one test_code fixture in nine, which accuracy alone hides', () => {
+    // The stale-test fixtures that carry a real product diff are all called
+    // app_code — documented in docs/eval-methodology.md and left deliberately
+    // unfixed. The only one it gets right is #53's captured fixture, which has
+    // no diff for that rule to fire on. A class with recall 1 in 8 is what the
+    // headline accuracy hides.
     const testCode = metrics.owner.classes.find((c) => c.label === 'test_code')
-    expect(testCode).toMatchObject({ support: 8, predictedCount: 5, truePositives: 0 })
-    expect(testCode?.f1).toBe(0)
+    expect(testCode).toMatchObject({ support: 9, predictedCount: 6, truePositives: 1 })
+    expect(testCode?.f1).toBeCloseTo(2 / 15, 5)
   })
 
   it('is beaten on owner accuracy by answering "app_code" every time', () => {

--- a/eval/report.md
+++ b/eval/report.md
@@ -10,7 +10,7 @@
 | model                  | none — a heuristic, no model call    |
 | prompt version         | none                                 |
 | dataset                | 23 fixtures in `eval/golden-dataset` |
-| dataset revision       | `5ce9721387a4b800`                   |
+| dataset revision       | `f35876ebfe37b8b4`                   |
 | slice                  | `dev`                                |
 | samples per fixture    | 1                                    |
 | scored in the headline | 23 (0 excluded)                      |
@@ -29,9 +29,9 @@ and a label edit both move it, because both move the numbers.
 | ---------------------- | ----------------: | ----: | ----: |
 | **joint accuracy**     | 34.8% [18.8–55.1] |     — |     — |
 | `owner` accuracy       | 47.8% [29.2–67.0] |     — |     — |
-| `determinism` accuracy | 78.3% [58.1–90.3] |     — |     — |
+| `determinism` accuracy | 82.6% [62.9–93.0] |     — |     — |
 | `owner` macro-F1       |             0.375 |     — |     — |
-| `determinism` macro-F1 |             0.767 |     — |     — |
+| `determinism` macro-F1 |             0.817 |     — |     — |
 
 All figures over **n = 23**, with 95% Wilson intervals.
 
@@ -49,14 +49,14 @@ The baseline is a pure function: repeating it produces identical runs, and a sel
 
 ## Calibration
 
-**Confidence is weakly informative.** Confidence ranks predictions at AUROC 0.66 with an expected calibration error of 0.235. It orders predictions better than chance but the stated number is not the observed rate — treat it as a sortable hint, not a probability. No root-cause threshold could be derived: the only thresholds reaching 70.0% do so over fewer than 5 predictions (best: 100.0% over 1), which is noise with a decimal point. At 23 predictions from a stratified dataset this is a direction, not a measurement.
+**Confidence is weakly informative.** Confidence ranks predictions at AUROC 0.71 with an expected calibration error of 0.228. It orders predictions better than chance but the stated number is not the observed rate — treat it as a sortable hint, not a probability. No root-cause threshold could be derived: the only thresholds reaching 70.0% do so over fewer than 5 predictions (best: 100.0% over 1), which is noise with a decimal point. At 23 predictions from a stratified dataset this is a direction, not a measurement.
 
 |                              |                                                                                                                                                 |
 | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | predictions scored           | 23                                                                                                                                              |
-| distinct confidence values   | 5                                                                                                                                               |
-| discrimination (AUROC)       | 0.658 — 0.50 is a coin toss                                                                                                                     |
-| expected calibration error   | 0.235                                                                                                                                           |
+| distinct confidence values   | 4                                                                                                                                               |
+| discrimination (AUROC)       | 0.708 — 0.50 is a coin toss                                                                                                                     |
+| expected calibration error   | 0.228                                                                                                                                           |
 | worst single bin             | 0.350                                                                                                                                           |
 | derived root-cause threshold | not derived — the only thresholds reaching 70.0% do so over fewer than 5 predictions (best: 100.0% over 1), which is noise with a decimal point |
 
@@ -69,8 +69,8 @@ two columns equal in every row. Empty bins are omitted; where the classifier nev
 | confidence | predictions | stated | observed |    gap |
 | ---------- | ----------: | -----: | -------: | -----: |
 | 0.3–0.4    |           1 |  0.350 |    0.000 | -0.350 |
-| 0.5–0.6    |           9 |  0.500 |    0.222 | -0.278 |
-| 0.6–0.7    |          12 |  0.604 |    0.417 | -0.187 |
+| 0.5–0.6    |          10 |  0.500 |    0.200 | -0.300 |
+| 0.6–0.7    |          11 |  0.600 |    0.455 | -0.145 |
 | 0.7–0.8    |           1 |  0.700 |    1.000 | +0.300 |
 
 ### Deriving the threshold
@@ -84,8 +84,7 @@ everything it can be right about, and a higher bar buys accuracy by answering le
 | --------: | ----------------------: | -------: | --- |
 |      0.35 |                      23 |    34.8% |     |
 |      0.50 |                      22 |    36.4% |     |
-|      0.60 |                      13 |    46.2% |     |
-|      0.65 |                       2 |    50.0% |     |
+|      0.60 |                      12 |    50.0% |     |
 |      0.70 |                       1 |   100.0% |     |
 
 ## Per quadrant
@@ -123,8 +122,8 @@ Rows are ground truth, columns are what the classifier said; the bold diagonal i
 | actual ↓ / predicted → | `deterministic` | `intermittent` | **total** |
 | ---------------------- | --------------: | -------------: | --------: |
 | `deterministic`        |          **12** |              3 |        15 |
-| `intermittent`         |               2 |          **6** |         8 |
-| **total**              |              14 |              9 |    **23** |
+| `intermittent`         |               1 |          **7** |         8 |
+| **total**              |              13 |             10 |    **23** |
 
 ## Per class
 
@@ -133,8 +132,8 @@ Rows are ground truth, columns are what the classifier said; the bold diagonal i
 | `owner`       | `app_code`      |      14 |        18 |      10 |   55.6% [33.7–75.4] | 71.4% [45.4–88.3] | 0.625 |
 | `owner`       | `test_code`     |       6 |         4 |       0 |     0.0% [0.0–49.0] |   0.0% [0.0–39.0] | 0.000 |
 | `owner`       | `environment`   |       3 |         1 |       1 | 100.0% [20.7–100.0] |  33.3% [6.1–79.2] | 0.500 |
-| `determinism` | `deterministic` |      15 |        14 |      12 |   85.7% [60.1–96.0] | 80.0% [54.8–93.0] | 0.828 |
-| `determinism` | `intermittent`  |       8 |         9 |       6 |   66.7% [35.4–87.9] | 75.0% [40.9–92.9] | 0.706 |
+| `determinism` | `deterministic` |      15 |        13 |      12 |   92.3% [66.7–98.6] | 80.0% [54.8–93.0] | 0.857 |
+| `determinism` | `intermittent`  |       8 |        10 |       7 |   70.0% [39.7–89.2] | 87.5% [52.9–97.8] | 0.778 |
 
 `support` is how many fixtures genuinely are that class; `predicted` is how often the
 classifier reached for it. A class with support and no correct predictions has an F1 of 0 and
@@ -145,17 +144,17 @@ it.
 
 ### By provenance
 
-| provenance  |   n |             joint |             owner |       determinism |
-| ----------- | --: | ----------------: | ----------------: | ----------------: |
-| `captured`  |   1 |   0.0% [0.0–79.3] |   0.0% [0.0–79.3] |   0.0% [0.0–79.3] |
-| `synthetic` |  22 | 36.4% [19.7–57.0] | 50.0% [30.7–69.3] | 81.8% [61.5–92.7] |
+| provenance  |   n |             joint |             owner |         determinism |
+| ----------- | --: | ----------------: | ----------------: | ------------------: |
+| `captured`  |   1 |   0.0% [0.0–79.3] |   0.0% [0.0–79.3] | 100.0% [20.7–100.0] |
+| `synthetic` |  22 | 36.4% [19.7–57.0] | 50.0% [30.7–69.3] |   81.8% [61.5–92.7] |
 
 ### By difficulty bucket
 
 | bucket                      |   n |               joint |               owner |         determinism |
 | --------------------------- | --: | ------------------: | ------------------: | ------------------: |
 | `environment-as-regression` |   3 |    33.3% [6.1–79.2] |    33.3% [6.1–79.2] | 100.0% [43.9–100.0] |
-| `hard-quadrant`             |   7 |    28.6% [8.2–64.1] |   42.9% [15.8–75.0] |   71.4% [35.9–91.8] |
+| `hard-quadrant`             |   7 |    28.6% [8.2–64.1] |   42.9% [15.8–75.0] |   85.7% [48.7–97.4] |
 | `misleading-history`        |   3 |     0.0% [0.0–56.1] |   66.7% [20.8–93.9] |     0.0% [0.0–56.1] |
 | `stale-test`                |   5 |     0.0% [0.0–43.4] |     0.0% [0.0–43.4] | 100.0% [56.6–100.0] |
 | `straightforward`           |   5 | 100.0% [56.6–100.0] | 100.0% [56.6–100.0] | 100.0% [56.6–100.0] |
@@ -173,9 +172,9 @@ This report scores the `dev` slice.
 | `environment-as-regression` |      4 |      3 |        1 |
 | `hard-quadrant`             |     11 |      7 |        4 |
 | `misleading-history`        |      4 |      3 |        1 |
-| `stale-test`                |      7 |      5 |        2 |
+| `stale-test`                |      8 |      5 |        3 |
 | `straightforward`           |      8 |      5 |        3 |
-| **total**                   | **34** | **23** |   **11** |
+| **total**                   | **35** | **23** |   **12** |
 
 A fixture's slice is a pure function of its name — the first 32 bits of its SHA-256, held out
 below 20%. Nothing about the rest of the dataset enters into it, so adding, removing or
@@ -183,7 +182,7 @@ renaming any other fixture cannot move it. That property is worth more than an e
 a fixture silently changing slice would invalidate every held-out number ever published, and
 would do it without any visible failure.
 
-The realised split is 11 of 34 — 32%, against a 20% target. That gap is
+The realised split is 12 of 35 — 34%, against a 20% target. That gap is
 ordinary binomial variance at this size, not a defect in the rule, and it narrows as the
 dataset grows towards the 60 fixtures the methodology targets.
 
@@ -207,7 +206,7 @@ dataset grows towards the 60 fixtures the methodology targets.
 | `editing-title-clears-board-position`             | `straightforward`           | app_code / deterministic    | app_code / deterministic    | ✓   |  0.60 |
 | `expectation-assumes-flat-response-body`          | `stale-test`                | test_code / deterministic   | app_code / deterministic    | ½   |  0.60 |
 | `export-now-includes-archived-rows`               | `misleading-history`        | app_code / deterministic    | app_code / intermittent     | ½   |  0.50 |
-| `list-order-reverts-after-two-quick-moves`        | `hard-quadrant`             | app_code / intermittent     | test_code / deterministic   | ✗   |  0.65 |
+| `list-order-reverts-after-two-quick-moves`        | `hard-quadrant`             | app_code / intermittent     | test_code / intermittent    | ½   |  0.50 |
 | `locator-still-uses-retired-test-id`              | `stale-test`                | test_code / deterministic   | app_code / deterministic    | ½   |  0.60 |
 | `package-registry-certificate-expired-on-agent`   | `environment-as-regression` | environment / deterministic | app_code / deterministic    | ½   |  0.60 |
 | `port-still-held-by-the-previous-job`             | `environment-as-regression` | environment / deterministic | environment / deterministic | ✓   |  0.70 |

--- a/eval/run-eval.test.ts
+++ b/eval/run-eval.test.ts
@@ -145,8 +145,8 @@ describe('slice wiring', () => {
     // A reader of the dev report has to be able to answer "what did this number
     // not see" without opening the other file.
     const total = (e: Evaluation): number => e.composition.reduce((n, row) => n + row.total, 0)
-    expect(total(await evaluate({ ...DEFAULTS, slice: 'dev' }))).toBe(34)
-    expect(total(await evaluate({ ...DEFAULTS, slice: 'holdout' }))).toBe(34)
+    expect(total(await evaluate({ ...DEFAULTS, slice: 'dev' }))).toBe(35)
+    expect(total(await evaluate({ ...DEFAULTS, slice: 'holdout' }))).toBe(35)
   })
 })
 

--- a/eval/slices.test.ts
+++ b/eval/slices.test.ts
@@ -56,7 +56,7 @@ describe('the split rule', () => {
   })
 
   it('lands near the target share over many names', () => {
-    // Not a claim about the 34 committed fixtures, which are far too few for
+    // Not a claim about the 35 committed fixtures, which are far too few for
     // this to hold — a claim about the rule itself being unbiased.
     const held = Array.from({ length: 20_000 }, (_, i) => sliceOf(`f${String(i)}`)).filter(
       (s) => s === 'holdout',
@@ -75,7 +75,7 @@ describe('adding a fixture never moves an existing one', () => {
    * permanent: a fixture that changes slice invalidates every held-out number
    * published before the change, with nothing going red.
    */
-  it('leaves all 34 committed fixtures where they were after 500 more arrive', () => {
+  it('leaves all 35 committed fixtures where they were after 500 more arrive', () => {
     const before = new Map(listFixtures().map((name) => [name, sliceOf(name)]))
 
     const grown = [...listFixtures(), ...Array.from({ length: 500 }, (_, i) => `new-${String(i)}`)]
@@ -163,11 +163,11 @@ describe('the committed dataset split', () => {
   )
   const held = composition.reduce((n, row) => n + row.holdout, 0)
 
-  it('holds out 11 of 34', () => {
-    // Pinned. 32% against a 20% target is ordinary binomial variance at n=34
-    // (sd ≈ 2.3 on an expected 6.6), not a defect in the rule. If this number
+  it('holds out 12 of 35', () => {
+    // Pinned. 34% against a 20% target is ordinary binomial variance at n=35
+    // (sd ≈ 2.4 on an expected 7), not a defect in the rule. If this number
     // moves without a fixture being added, the rule changed.
-    expect(held).toBe(11)
+    expect(held).toBe(12)
   })
 
   it('currently holds out at least one fixture from every bucket', () => {

--- a/tests/e2e/find-by-name.spec.ts
+++ b/tests/e2e/find-by-name.spec.ts
@@ -1,0 +1,136 @@
+import { SEED } from '@sentra/taskflow-server'
+import { add, open } from './board.js'
+import { expect, test } from './fixtures.js'
+
+/**
+ * # The other flaky one. `test_code` + `intermittent`.
+ *
+ * The counterweight to `reorder-quick-succession.spec.ts`. Same symptom — a spec
+ * that fails some of the time — and the opposite owner, which is the pair that
+ * makes the two-axis taxonomy earn its keep: a flat "flaky" label puts these in
+ * one bucket while they need completely different responses. One is a bug to
+ * fix in the product. This one is a bug to fix in the test, and the product is
+ * behaving perfectly.
+ *
+ * ## The mechanism
+ *
+ * `getByText('Review the')` is a substring match. The seeded board already
+ * contains "Review the migration plan" and "Review the release checklist", so
+ * the locator is ambiguous under `?filter=all` and unambiguous under
+ * `?filter=active`, where only one of them is showing.
+ *
+ * This spec opens the active list — one match, fine — and adds a task whose
+ * title happens to begin the same way. Once that row arrives there are two
+ * matches, Playwright's strict mode refuses to guess which one was meant, and
+ * the assertion fails with **"resolved to 2 elements"**.
+ *
+ * Creating is not optimistic: `useTasks.create` waits for the server and then
+ * appends what it returns. So whether the second row is on screen when the
+ * assertion first resolves depends on how quickly that write answers — and
+ * against the chaotic instance, that varies.
+ *
+ * ## Why this is not a timing failure, even though the timing varies
+ *
+ * Because waiting does not help. A timing failure is one where the application
+ * is on its way to the state the spec expects and the spec looked too early;
+ * waiting longer fixes it. Here the opposite is true: the longer the spec waits,
+ * the more certainly there are two matching rows.
+ *
+ * Measured. As written, this test fails on about half of its runs. Adding the
+ * correct synchronisation in front of the assertion —
+ *
+ * ```ts
+ * await expect(page.getByTestId('task-item')).toHaveCount(ACTIVE + 1)
+ * ```
+ *
+ * — took it to **eight failures out of eight**. The wait that would fix a timing
+ * bug makes this one certain, which is as clear a demonstration as the
+ * distinction admits.
+ *
+ * The evidence a classifier sees says so too. A timing failure reports a value
+ * that never arrived; this one reports
+ *
+ * ```
+ * strict mode violation: getByText('Review the') resolved to 2 elements
+ * ```
+ *
+ * and names both of them. Nothing in that message is about time.
+ *
+ * ## The correct fix, which is deliberately not applied
+ *
+ * ```ts
+ * await expect(page.getByText('Review the incident timeline', { exact: true })).toBeVisible()
+ * ```
+ *
+ * Or scope the search to the row: `row(page, title)`. Either makes the locator
+ * name one thing, which is what a locator is for. Applying it here would delete
+ * the fixture this file exists to produce — see the dataset entry it feeds.
+ *
+ * ## What it must not become
+ *
+ * A test that waits for two rows and then asserts on an ambiguous locator would
+ * fail every run, which is a *stale test* — `test_code` + `deterministic`, a
+ * different quadrant with a different response. The intermittency is the point,
+ * and it comes from the row sometimes not having arrived yet.
+ */
+
+test.use({ chaos: true })
+
+/** The substring the seeded board already contains twice, in two different states. */
+const PREFIX = 'Review the'
+const NEW_TASK = 'Review the incident timeline'
+
+const ACTIVE = SEED.filter((task) => task.completed !== true).length
+
+test.beforeEach(async ({ page }) => {
+  await open(page, '?filter=active')
+})
+
+test('finds a newly added task in the active list', async ({ page }) => {
+  await expect(page.getByText(PREFIX)).toBeVisible()
+
+  await add(page, NEW_TASK)
+
+  await page.getByRole('button', { name: 'Completed' }).click()
+  await expect(page.getByText(NEW_TASK)).toHaveCount(0)
+  await expect(page.getByText('Review the release checklist')).toBeVisible()
+
+  await page.getByRole('button', { name: 'Active' }).click()
+  await expect(page.getByRole('button', { name: 'Active', pressed: true })).toBeVisible()
+  await expect(page.getByText('Write the incident postmortem')).toBeVisible()
+
+  await expect(page.getByText(PREFIX)).toBeVisible()
+})
+
+/**
+ * The same locator against a list that never changes, to show it is not the
+ * locator style that is wrong.
+ *
+ * Under `?filter=completed` exactly one seeded row begins "Review the", so the
+ * substring match names one element and this passes on every run. The selector
+ * is not broken in general; it is broken against a list state the application
+ * legitimately reaches, which is the thing that makes this class of failure hard
+ * to spot in review.
+ */
+test('finds the completed one without ambiguity, because only one is showing', async ({ page }) => {
+  await open(page, '?filter=completed')
+
+  await expect(page.getByText(PREFIX)).toBeVisible()
+  await expect(page.getByText(PREFIX)).toHaveText('Review the release checklist')
+})
+
+/**
+ * And the count the ambiguity comes from, stated as data rather than inferred
+ * from a failure. Two rows begin with the prefix; the filter decides how many of
+ * them are on screen.
+ */
+test('shows how many rows the prefix matches in each list', async ({ page }) => {
+  await expect(page.getByText(PREFIX)).toHaveCount(1)
+  await expect(page.getByTestId('task-item')).toHaveCount(ACTIVE)
+
+  await page.getByRole('button', { name: 'All' }).click()
+  await expect(page.getByText(PREFIX)).toHaveCount(2)
+
+  await page.getByRole('button', { name: 'Completed' }).click()
+  await expect(page.getByText(PREFIX)).toHaveCount(1)
+})

--- a/tests/e2e/reorder-quick-succession.spec.ts
+++ b/tests/e2e/reorder-quick-succession.spec.ts
@@ -58,6 +58,23 @@ import { expect, stored, test } from './fixtures.js'
  * into this file. A spec with a sleep in it is a spec that says what it expects
  * to happen. This one says nothing about timing, and the race happens anyway.
  *
+ * ## What each test does, since the bodies carry no commentary
+ *
+ * The lines around an assertion end up in the captured fixture's `snippet`, and
+ * a comment there is the author's argument about a failure the author already
+ * understood. So the bodies are plain and the explanation is here.
+ *
+ * Both tests move a row, wait for the list to show the move, move again, then
+ * wait for **both** writes to have answered before asserting. `expect.poll` on
+ * the stored rows shows the server kept both moves in the order they were sent;
+ * the assertion after it is the same claim about the screen. When it fails, the
+ * row is one place off — the order as of the first move, restored by that move's
+ * own late response.
+ *
+ * The second test moves two rows far enough apart that neither move changes
+ * where the other lands, so the expected order is the same whichever request the
+ * server happens to see first.
+ *
  * ## Why this file is not called `reorder-race.spec.ts`
  *
  * It was, until the fixture it produces was run through the dataset's own
@@ -112,15 +129,9 @@ test('keeps both moves when a task is moved twice in quick succession', async ({
   await moveUp(page, TASK)
   await expect(titles(page).nth(2)).toHaveText(TASK)
 
-  // Both writes have answered. Nothing is in flight, so whatever the list shows
-  // now is what it will keep showing — this assertion is not racing anything.
   await expect.poll(answered).toBe(2)
-
-  // The server kept both moves, in the order they were sent.
   await expect.poll(() => stored(db)[2]?.title).toBe(TASK)
 
-  // And the list should agree with it. When this fails the row is at index 3 —
-  // the order as of the first move, restored by its own late response.
   await expect(titles(page).nth(2)).toHaveText(TASK)
 })
 
@@ -133,8 +144,6 @@ test('keeps both moves when a task is moved twice in quick succession', async ({
 test('keeps both moves when two different tasks are moved', async ({ page, db }) => {
   const answered = reorderResponses(page)
 
-  // Two rows far enough apart that neither move changes where the other lands,
-  // so the expected order is the same whichever request the server sees first.
   await moveUp(page, TASK)
   await expect(titles(page).nth(3)).toHaveText(TASK)
 
@@ -144,8 +153,6 @@ test('keeps both moves when two different tasks are moved', async ({ page, db })
   await expect.poll(answered).toBe(2)
   await expect.poll(() => stored(db)[0]?.title).toBe(OTHER)
 
-  // When this fails the list has gone back to the order after the first move,
-  // with the second one undone — and the line above says the server disagrees.
   await expect(titles(page).first()).toHaveText(OTHER)
   await expect(titles(page).nth(3)).toHaveText(TASK)
 })


### PR DESCRIPTION
Closes #53

The counterweight to #52. Same symptom — a spec that fails some of the time — and the opposite
owner. This is the pair that makes the two-axis taxonomy earn its keep: a flat "flaky" label puts
these in one bucket while they need completely different responses. One is a bug to fix in the
product. This one is a bug to fix in the test, and the product is behaving perfectly.

## The mechanism

`getByText('Review the')` is a substring match, and the seeded board already holds two tasks whose
titles begin that way — one active, one completed. So the locator names **one** element under
`?filter=active` and **two** under `?filter=all`.

The spec opens the active list, adds a task whose title happens to start the same way, does the
ordinary checks a person does after adding something — it is not in the completed list, the board
still looks right — and then looks for it by name. Once the new row has arrived there are two
matches and strict mode refuses to guess:

```
Error: strict mode violation: getByText('Review the') resolved to 2 elements:
    1) <p class="task-title">Review the migration plan</p>
    2) <p class="task-title">Review the incident timeline</p>
```

Creating is not optimistic — `useTasks.create` waits for the server — so whether that second row is
on screen when the assertion first resolves depends on how quickly the write answers. Against the
chaotic instance, that varies.

## Waiting does not fix it; it makes it certain

This is the distinction between this failure and a timing one, and it is **measured** rather than
asserted. As written the test fails on about half its runs. Adding the correct synchronisation in
front of the assertion —

```ts
await expect(page.getByTestId('task-item')).toHaveCount(ACTIVE + 1)
```

— took it to **eight failures out of eight**. The wait that would fix a timing bug makes this one
certain.

The evidence a classifier sees agrees. A timing failure reports a value that never arrived; this one
reports two elements where one was expected, and names both. Nothing in that message is about time.

The correct fix is an exact or row-scoped locator. It is written in the header and deliberately not
applied.

## A leak in #52's fixture, found here and fixed

Playwright quotes the lines around a failure into `error.snippet`, and those lines were carrying my
own comments explaining the mechanism straight into the classifier's input:

```
  122 |   // And the list should agree with it. When this fails the row is at index 3 —
  123 |   // the order as of the first move, restored by its own late response.
> 124 |   await expect(titles(page).nth(2)).toHaveText(TASK)
```

That is the label, in prose, in the payload. It cannot be stripped at capture time: in production
the agent really does see whatever comments are there, and a fixture cleaned of them would be
*easier* than the input the pipeline actually gets. So the fix is at the source — both flaky specs
now explain themselves in their file headers, which nothing captures, and keep the lines beside
their assertions plain. #52's fixture is re-captured from 20 fresh runs.

The rule is written into the dataset README so the next captured fixture does not repeat it.

## The two captured fixtures now defeat the baseline on different axes

```
list-order-reverts-after-two-quick-moves
  truth   : app_code / intermittent
  baseline: test_code / intermittent      ← owner wrong

name-lookup-matches-two-rows-after-an-add
  truth   : test_code / intermittent
  baseline: test_code / deterministic     ← determinism wrong
```

Each is wrong for its own reason, which is what an adversarial dataset is for.

## Two claims the dataset made about itself went red

Restated rather than patched, because both changes are real:

- **`test_code` + `intermittent` is no longer an empty quadrant.** It was the one gap in the matrix,
  and this fixture fills it. The n/a rendering path it used to exercise is now covered by fabricated
  data instead.
- **`stale-test` no longer scores 0% on owner.** Every fixture in that bucket carried a product diff,
  so the baseline called them all `app_code`. This one has no commit under test, so there is no diff
  for the ownership rule to fire on, the baseline reaches its locator rule and gets the owner right —
  losing the point back on determinism. The exception is what shows the bucket's story was about the
  diff all along.

`docs/eval-methodology.md`'s tables had also drifted silently when #52 added a fixture. They are
regenerated here: 35 fixtures, joint 34.3% [20.8–50.8], `test_code` F1 0.13 rather than exactly 0.

## Acceptance criteria

| Criterion | Where |
| --- | --- |
| Selector matches multiple elements under some legitimate list states | `find-by-name.spec.ts`, and a third test states the counts per filter as data |
| The failure is not timing-related — adding a wait does not fix it | measured: 8 failures out of 8 with the wait added |
| Header comment explains the mechanism | the file header |
| Produces a `captured` fixture labelled `test_code` + `intermittent` | `name-lookup-matches-two-rows-after-an-add` |
| The correct fix documented and deliberately not applied | the header's "The correct fix" section |

## How this was verified

- 20 runs of both flaky specs together: this one failed 5 of 19, the reorder one 10 of 20
- With the correct wait added, 8 of 8 — the measurement the second criterion asks for
- `npm run test:unit` — 1501 green; `npm run test:e2e` — 67 tests, the two deliberate ones red
- `npm run eval -- --gate` — pass
- `lint`, `typecheck`, `format:check`, `eval:lint`, `prompts:sync:check`, `cassettes:check`, `docs:status:check` — clean

**On the bucket.** `stale-test` is the closest fit among the six — it is the selector-fault family —
but it is not exact: the buckets were written before a fixture like this existed, and this one is
intermittent where the others are deterministic. Worth revisiting when the dataset approaches 60,
where composition starts being enforced.