### PR TITLE
docs(release): mark M4 and M5 done, and say where M5 fell short

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <!-- status:start -->
 
 > **Project status: M3 — Triage agent & replay mode.**
-> 3 of 11 milestones complete.
+> 5 of 11 milestones complete.
 > Current exit criterion: the triage agent beats the baseline on joint accuracy by a margin that survives its confidence interval — or the finding that it does not is documented in the README. Either way, `npm run demo` runs the classifier end to end with no API key.
 >
 > Progress is tracked as [milestones](https://github.com/AKogut/ai-flaky-test-triage/milestones), not dates.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -62,10 +62,13 @@ The system under test: React + TypeScript client, Express + SQLite API, task CRU
 drag-to-reorder, optimistic updates. Deliberately small. Includes a seedable nondeterminism layer
 so flakiness can be _emergent_ rather than scripted.
 
-**Status:** planned
+**Status:** done
 
 **Exit criterion:** `npm run dev` serves a working task board, and `SENTRA_CHAOS=<seed>` reproduces
-a specific interleaving of the optimistic-update race.
+a specific interleaving of the optimistic-update race. Both hold. The reproduction needed a fix the
+milestone did not anticipate: the chaos layer delayed the handler rather than the response, which
+reordered the writes and made the server and the client agree on an order neither had been asked
+for — a race, but not the documented one. See #52.
 
 ## M5 — Test suite & emergent flakiness
 
@@ -73,10 +76,19 @@ Vitest for the API and libraries, Playwright for UI flows, and a set of genuinel
 flakiness comes from real races rather than a `Math.random()` in the test. Captured runs feed the
 golden dataset.
 
-**Status:** planned
+**Status:** done
 
 **Exit criterion:** ≥10 `captured` fixtures from real CI runs are in the dataset, and eval metrics
 are reported broken down by provenance.
+
+**Outcome: the second half holds and the first does not, and the milestone closed anyway.** There
+are six captured fixtures, five of them from genuine CI runs. The constraint is not tooling —
+`npm run capture` takes a directory of downloaded reports — it is that the suite contains six specs
+that can fail and CI had run it nine times. Reaching ten meant capturing the same test's failure on
+several commits, which would have narrowed every interval in `eval/report.md` without adding a
+single new piece of information. That is the specific dishonesty the methodology exists to prevent,
+so the count was left short and #171 tracks it. A criterion quietly restated to match what was
+delivered would have been worse than a criterion visibly unmet.
 
 ## M6 — flakemetry-lib integration
 

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -3,7 +3,7 @@
 <!-- status:start -->
 
 > **Project status: M3 — Triage agent & replay mode.**
-> 3 of 11 milestones complete.
+> 5 of 11 milestones complete.
 > Current exit criterion: the triage agent beats the baseline on joint accuracy by a margin that survives its confidence interval — or the finding that it does not is documented in the README. Either way, `npm run demo` runs the classifier end to end with no API key.
 >
 > Progress is tracked as [milestones](https://github.com/AKogut/ai-flaky-test-triage/milestones), not dates.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -5,7 +5,7 @@
 <!-- status:start -->
 
 > **Project status: M3 — Triage agent & replay mode.**
-> 3 of 11 milestones complete.
+> 5 of 11 milestones complete.
 > Current exit criterion: the triage agent beats the baseline on joint accuracy by a margin that survives its confidence interval — or the finding that it does not is documented in the README. Either way, `npm run demo` runs the classifier end to end with no API key.
 >
 > Progress is tracked as [milestones](https://github.com/AKogut/ai-flaky-test-triage/milestones), not dates.


### PR DESCRIPTION
The roadmap still called both milestones planned. This corrects that, and records one thing that
would otherwise disappear.

## M4

The exit criterion holds — `npm run dev` serves the board and `SENTRA_CHAOS=<seed>` reproduces the
documented interleaving of the optimistic-update race.

It only holds after #52, which found that the chaos layer delayed the *handler* rather than the
*response*. That reordered the writes, so the server and the client agreed on an order neither had
been asked for: a race, but not the one `useTasks.move` documents and not the one the golden dataset
contains. The roadmap now says so, because "criterion met" reads differently when the thing that met
it had to be fixed first.

## M5

**The first half of the criterion does not hold and the milestone closed anyway.** It asked for ≥10
captured fixtures from real CI runs. There are six, five of them from CI.

The constraint is not tooling — `npm run capture` takes a directory of downloaded CI reports and
works. It is that the suite contains six specs that can fail and CI had run it nine times when #56
landed. Reaching ten meant capturing the same test's failure on several commits, which would have
narrowed every interval in `eval/report.md` without adding a single new piece of information: the
specific dishonesty the methodology exists to prevent.

That is recorded **under** the criterion rather than folded into it. A criterion quietly restated to
match what was delivered is worse than one visibly unmet, and this repository has spent five PRs
arguing that measured beats asserted. #171 tracks the rest.

The second half — metrics broken down by provenance — holds, and the report now states the
synthetic-versus-captured gap in words along with why it cannot yet be read as a finding.

## The banner

Regenerated from the roadmap: 5 of 11 milestones complete. The active milestone is still M3, which
is accurate — #38 needs an `ANTHROPIC_API_KEY` this environment does not have, so the first honest
numbers for the agent have not been produced.

## How this was verified

- `npm run docs:status` regenerated the banner; `docs:status:check` is clean
- `npm run test:unit` — 1569 green
- `lint`, `typecheck`, `format:check`, `eval:lint` — clean