### PR TITLE
docs(docs): correct what the wiki says about the flaky specs, before publishing it

### DIFF
--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -44,11 +44,28 @@ than either axis alone.
 ## Why do the tests deliberately fail sometimes?
 
 The flaky specs are input, not oversight. They exist so the pipeline has realistic failures to
-classify, and each one's header comment explains the mechanism and why the label is what it is.
+classify, and each one's header comment explains the mechanism and why the label is what it is —
+a reader can check the ground truth rather than take it on trust.
 
-The distinction that matters: their flakiness is **emergent** — it comes from a real race in the app,
-reproducible under a documented seed — not scripted with a random sleep in the test. Scripted
-flakiness makes the classification problem trivial and worthless.
+There are five, and only **one** of them is the application's fault:
+
+| Spec                               | Owner       | Why it fails                                                            |
+| ---------------------------------- | ----------- | ----------------------------------------------------------------------- |
+| `reorder-quick-succession.spec.ts` | `app_code`  | The client applies whichever reorder response arrives last              |
+| `find-by-name.spec.ts`             | `test_code` | A partial-title locator matches two rows in some list states            |
+| `visible-tasks.spec.ts`            | `test_code` | Another spec leaves a row behind — cause and symptom in different files |
+| `board-updates.spec.ts`            | `test_code` | An assertion given a fixed 120ms deadline instead of a condition        |
+| `complete.spec.ts` (fixed)         | `test_code` | Read a stored value straight after an optimistic paint                  |
+
+That spread is the point. A flat "flaky" label would put all five in one bucket while they need
+completely different responses, and the pair at the top — same symptom, opposite owner — is what
+makes the two-axis taxonomy earn its keep.
+
+The distinction that matters for all of them: their flakiness is **emergent**, not scripted. It
+comes from seeded latency in the server or from how the runner happens to schedule files, never
+from a sleep or a random number inside a test. A guard test holds every spec in the suite to that,
+including the deliberate ones. Scripted flakiness makes the classification problem trivial and
+worthless.
 
 ## Why aren't retries enabled in CI?
 

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -49,8 +49,11 @@ decorative.
 **`environment`** — value on the `owner` axis. Neither the product nor the test; the run itself was
 broken.
 
-**Emergent flakiness** — flakiness arising from a real race in the application, as opposed to
-flakiness scripted into a test. Only the former produces a classification problem worth solving.
+**Emergent flakiness** — flakiness that arises from how a system behaves rather than from a sleep
+or a random number written into a test. The source may be the application (a race in its
+optimistic updates), the network (a response that takes longer than usual), or the runner (which
+file a worker happened to pick up next). What it is never is scripted: a test that fails on purpose
+poses a classification problem that is trivial and worthless.
 
 **EWMA** — exponentially weighted moving average, used for the flakiness score so that recent runs
 count more than old ones.


### PR DESCRIPTION
The wiki has never been published. Reading it as a stranger would, before pushing it outward, turned
up two claims that M5 made false.

## The FAQ said all five deliberate specs are the application's fault

> their flakiness is **emergent** — it comes from a real race in the app

One of the five does. The other four are `test_code`, and that spread is the whole point of the
milestone — so the answer now lists them:

| Spec | Owner | Why it fails |
| --- | --- | --- |
| `reorder-quick-succession.spec.ts` | `app_code` | The client applies whichever reorder response arrives last |
| `find-by-name.spec.ts` | `test_code` | A partial-title locator matches two rows in some list states |
| `visible-tasks.spec.ts` | `test_code` | Another spec leaves a row behind |
| `board-updates.spec.ts` | `test_code` | An assertion given a fixed 120ms deadline |
| `complete.spec.ts` (fixed) | `test_code` | Read a stored value straight after an optimistic paint |

A flat "flaky" label would put all five in one bucket while they need completely different
responses, and the pair at the top — same symptom, opposite owner — is what makes the two-axis
taxonomy earn its keep. That is worth saying on the page a stranger reads first.

## The glossary defined "emergent" too narrowly

It said flakiness "arising from a real race in the application". The contrast that matters is with
**scripted**, not with *not-the-application*: it is emergent when it comes from how the system
behaves — the application, the latency, or which file a worker picked up next — rather than from a
sleep or a random number written into a test.

## Next

`npm run wiki:publish` after this merges. That is the outward-facing step, and it publishes what
this PR corrects rather than what was there.

## How this was verified

- `docs:status:check` — the generated banners in `Home.md` and `Getting-Started.md` are current
- `npm run test:unit` — 1583 green
- `lint`, `typecheck`, `format:check`, `eval:lint` — clean