### PR TITLE
feat(flakemetry): the file that carries determinism between two CI jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ blob-report/
 
 # Run history lives in the CI cache (ADR-0004), not in git.
 .flakemetry/history.json
+# The temp file an atomic write renames from, left behind only by a killed job.
+.flakemetry/*.tmp
 
 # Local SQLite data for the demo app.
 app/server/*.db

--- a/contracts/history.test.ts
+++ b/contracts/history.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest'
+import {
+  HISTORY_SCHEMA_VERSION,
+  HistoryUnreadableError,
+  emptyHistory,
+  parseHistory,
+  type History,
+} from './history.js'
+
+/**
+ * The history document, checked at the boundary where it comes back off disk.
+ *
+ * Nothing reviews this file, so the schema is the only reader that ever looks at
+ * it critically. What is asserted here is mostly refusal: the shapes it must not
+ * accept, and that each refusal says which kind of wrong it is.
+ */
+
+const testId = 'tests/e2e/board.spec.ts›shows a row'
+
+const valid: History = {
+  schemaVersion: HISTORY_SCHEMA_VERSION,
+  tests: {
+    [testId]: {
+      firstSeenAt: '2026-08-01T00:00:00.000Z',
+      entries: [
+        {
+          runId: '1',
+          at: '2026-08-01T00:00:00.000Z',
+          status: 'passed',
+          flakyWithinRun: false,
+        },
+      ],
+    },
+  },
+}
+
+const clone = (): History => JSON.parse(JSON.stringify(valid)) as History
+
+describe('an empty history', () => {
+  it('carries the current version', () => {
+    expect(emptyHistory()).toEqual({ schemaVersion: HISTORY_SCHEMA_VERSION, tests: {} })
+  })
+
+  /** A shared constant would put one caller's tests into the next caller's history. */
+  it('is a new object every time', () => {
+    const first = emptyHistory()
+    first.tests[testId] = { firstSeenAt: '2026-08-01T00:00:00.000Z', entries: [] }
+    expect(emptyHistory().tests).toEqual({})
+  })
+})
+
+describe('parsing a history document', () => {
+  it('accepts a well-formed one', () => {
+    expect(parseHistory(clone(), 'h.json')).toEqual(valid)
+  })
+
+  it('accepts one with no tests in it yet', () => {
+    expect(parseHistory(emptyHistory(), 'h.json').tests).toEqual({})
+  })
+
+  /** `timedOut` and `skipped` reaching disk is what keeps them available to the scoring. */
+  it('keeps every status the reporters can produce', () => {
+    const document = clone()
+    document.tests[testId]?.entries.push(
+      { runId: '2', at: '2026-08-02T00:00:00.000Z', status: 'failed', flakyWithinRun: false },
+      { runId: '3', at: '2026-08-03T00:00:00.000Z', status: 'timedOut', flakyWithinRun: false },
+      { runId: '4', at: '2026-08-04T00:00:00.000Z', status: 'skipped', flakyWithinRun: false },
+    )
+    expect(parseHistory(document, 'h.json').tests[testId]?.entries).toHaveLength(4)
+  })
+})
+
+describe('refusing a document it cannot use', () => {
+  /**
+   * The version is read before the shape. A rollback reading a newer file would
+   * otherwise be told its fields are unrecognised, which reads like corruption
+   * and sends whoever is on the pipeline looking in the wrong place.
+   */
+  it('names both versions when they disagree', () => {
+    const future = { ...clone(), schemaVersion: HISTORY_SCHEMA_VERSION + 1 }
+    try {
+      parseHistory(future, '.flakemetry/history.json')
+      expect.unreachable('a version mismatch must not parse')
+    } catch (error) {
+      expect(error).toBeInstanceOf(HistoryUnreadableError)
+      expect((error as HistoryUnreadableError).reason).toBe('version')
+      expect((error as Error).message).toContain(String(HISTORY_SCHEMA_VERSION + 1))
+      expect((error as Error).message).toContain(String(HISTORY_SCHEMA_VERSION))
+    }
+  })
+
+  it('reports a malformed document as invalid rather than as a version problem', () => {
+    const broken = { schemaVersion: HISTORY_SCHEMA_VERSION, tests: { x: { entries: [] } } }
+    try {
+      parseHistory(broken, 'h.json')
+      expect.unreachable('a record with no firstSeenAt must not parse')
+    } catch (error) {
+      expect((error as HistoryUnreadableError).reason).toBe('invalid')
+      expect((error as Error).message).toContain('firstSeenAt')
+    }
+  })
+
+  /** An unversioned file is somebody else's JSON, not an older history. */
+  it('rejects a document with no version at all', () => {
+    expect(() => parseHistory({ tests: {} }, 'h.json')).toThrow(HistoryUnreadableError)
+  })
+
+  it('rejects a field nobody declared, because the writer and the reader are the same program', () => {
+    const extra = { ...clone(), notes: 'hand-edited' }
+    expect(() => parseHistory(extra, 'h.json')).toThrow(HistoryUnreadableError)
+  })
+
+  it('rejects a status string that is not a status', () => {
+    const document = clone()
+    document.tests[testId]?.entries.push({
+      runId: '2',
+      at: '2026-08-02T00:00:00.000Z',
+      status: 'flaky' as never,
+      flakyWithinRun: false,
+    })
+    expect(() => parseHistory(document, 'h.json')).toThrow(HistoryUnreadableError)
+  })
+
+  /**
+   * Long lists of Zod issues are how a legible error becomes a wall nobody
+   * reads. Five, then a count.
+   */
+  it('shows the first few problems and says how many more there are', () => {
+    const entries = Array.from({ length: 8 }, (_, i) => ({ runId: String(i) }))
+    const many = {
+      schemaVersion: HISTORY_SCHEMA_VERSION,
+      tests: { x: { firstSeenAt: '2026-08-01T00:00:00.000Z', entries } },
+    }
+    try {
+      parseHistory(many, 'h.json')
+      expect.unreachable('entries missing every field but runId must not parse')
+    } catch (error) {
+      expect((error as Error).message).toContain('… and')
+      expect((error as Error).message).toContain('more')
+    }
+  })
+})
+
+describe('the message a broken history produces', () => {
+  const message = new HistoryUnreadableError('.flakemetry/history.json', 'unparsable', 'why')
+    .message
+
+  it('names the file', () => {
+    expect(message).toContain('.flakemetry/history.json')
+  })
+
+  /** Whoever reads this is mid-incident and needs the next command, not a diagnosis. */
+  it('gives the command that recovers, and what recovering costs', () => {
+    expect(message).toContain('rm .flakemetry/history.json')
+    expect(message).toContain('cache, not a source of truth')
+    expect(message).toContain('every test reads as new')
+  })
+})

--- a/contracts/history.ts
+++ b/contracts/history.ts
@@ -1,0 +1,184 @@
+import { z } from 'zod'
+import { TestStatusSchema } from './test-run.js'
+
+/**
+ * The file that carries the `determinism` axis between two CI jobs.
+ *
+ * Everything else the pipeline needs is derivable from the run in front of it.
+ * This is not. Whether a failure is intermittent is a statement about runs that
+ * have already finished and whose reports are long gone, and ADR-0001 rules out
+ * a database — so the evidence survives as a file, carried by `actions/cache`
+ * per ADR-0004.
+ *
+ * That makes it the one artifact here that is written by a machine, read by a
+ * later version of the same machine, and never looked at by anyone. A committed
+ * fixture that goes wrong shows up in a diff; this shows up as a classifier that
+ * quietly gets worse. Hence a version from the first commit, strict schemas, and
+ * a parser that refuses rather than best-efforts — the alternative is a reader
+ * that finds `undefined` where a field used to be and carries on scoring.
+ *
+ * **It is a cache, not a source of truth.** Eviction is an expected operating
+ * condition, not an incident. This module's job is to say precisely what is
+ * wrong with a file; deciding that the pipeline continues anyway belongs to the
+ * caller, and #61 is where that policy lives.
+ */
+
+/**
+ * Major version of the `.flakemetry/history.json` document.
+ *
+ * Bumped when a field is removed, renamed, or changes meaning; adding an
+ * optional field is not a bump.
+ *
+ * Unlike `analysis.json` there is no regeneration path — the runs this
+ * summarises are gone, so a bump discards everyone's history and every test
+ * looks new until it refills. That cost is the point of writing the number down
+ * on day one: it has to be paid deliberately, not discovered.
+ */
+export const HISTORY_SCHEMA_VERSION = 1
+
+/**
+ * One test in one run.
+ *
+ * Deliberately not a whole `TestResult`. Errors, stacks and snippets are
+ * evidence about a *particular* failure and belong to the run that produced
+ * them; keeping fifty of them per test would multiply the file by two orders of
+ * magnitude to store text no scoring function reads. What survives is what the
+ * `determinism` axis is computed from, and nothing else.
+ */
+export const HistoryEntrySchema = z
+  .object({
+    /**
+     * The run this outcome came from.
+     *
+     * Present so a re-analysis is idempotent rather than additive. GitHub keeps
+     * `run_id` stable across "re-run all jobs" — only the attempt number
+     * changes — so a re-run that appended instead of replacing would write the
+     * same outcome twice and double a test's apparent stability.
+     */
+    runId: z.string().min(1),
+
+    /** The run's start time, so entries can be ordered by when the evidence was produced. */
+    at: z.iso.datetime(),
+
+    status: TestStatusSchema,
+
+    /**
+     * Retained because it cannot be recovered from `status`, and it is the
+     * strongest intermittency evidence a single run can produce.
+     *
+     * A test that fails on attempt 1 and passes on attempt 2 is recorded green.
+     * Store only the status and a test that does that on *every* run reads back
+     * as `PPPPPP` — a perfectly stable test, scored near zero, when it is in
+     * fact the most reliably flaky test in the suite.
+     */
+    flakyWithinRun: z.boolean(),
+  })
+  .strict()
+export type HistoryEntry = z.infer<typeof HistoryEntrySchema>
+
+export const TestHistorySchema = z
+  .object({
+    /**
+     * Stored rather than read off the oldest retained entry.
+     *
+     * The per-test cap evicts from the front, so `entries[0].at` creeps forward
+     * as history fills and a test first seen in March would report itself as
+     * first seen in June. `isNew` is derived from this, and a signal that says
+     * "new" about a year-old test is worse than no signal.
+     */
+    firstSeenAt: z.iso.datetime(),
+
+    /** Oldest first, matching `statusHistory`, which is most recent last. */
+    entries: z.array(HistoryEntrySchema),
+  })
+  .strict()
+export type TestHistory = z.infer<typeof TestHistorySchema>
+
+export const HistorySchema = z
+  .object({
+    schemaVersion: z.int().min(1),
+
+    /**
+     * Keyed by `deriveTestId`, which is the single definition of a test's
+     * identity across runs. Two spellings of the same path would split one
+     * test's history in two and make both halves look new.
+     */
+    tests: z.record(z.string().min(1), TestHistorySchema),
+  })
+  .strict()
+export type History = z.infer<typeof HistorySchema>
+
+/**
+ * A history with nothing in it — what a first run, or a cache miss, starts from.
+ *
+ * A function rather than an exported constant on purpose: a shared object would
+ * be one careless mutation away from every caller in the process inheriting
+ * another run's tests.
+ */
+export function emptyHistory(): History {
+  return { schemaVersion: HISTORY_SCHEMA_VERSION, tests: {} }
+}
+
+/**
+ * A history file that cannot be used, with the reason separated from the prose.
+ *
+ * `reason` exists so the caller can branch without matching on a message.
+ * Degrading on a cache-shaped problem while still failing loudly on a bug is the
+ * whole of #61, and a `catch` that greps English is how that distinction gets
+ * lost the first time someone rewords an error.
+ */
+export class HistoryUnreadableError extends Error {
+  constructor(
+    readonly file: string,
+    readonly reason: 'unparsable' | 'invalid' | 'version',
+    detail: string,
+  ) {
+    super(
+      [
+        `${file} cannot be read as run history: ${detail}`,
+        '',
+        'History is a cache, not a source of truth. Deleting it costs the determinism',
+        'signal until it refills — every test reads as new meanwhile — and costs nothing else:',
+        '',
+        `    rm ${file}`,
+      ].join('\n'),
+    )
+    this.name = 'HistoryUnreadableError'
+  }
+}
+
+/**
+ * Parse a history document, refusing an incompatible major version.
+ *
+ * The version is checked before the shape so a rollback reports the real
+ * problem. Validating first would produce a list of unexpected fields, which
+ * reads like a corrupt file and sends whoever is on the pipeline looking in the
+ * wrong place.
+ */
+export function parseHistory(value: unknown, file: string): History {
+  const versioned = z.looseObject({ schemaVersion: z.unknown() }).safeParse(value)
+  const found = versioned.success ? versioned.data.schemaVersion : undefined
+
+  if (typeof found === 'number' && found !== HISTORY_SCHEMA_VERSION) {
+    throw new HistoryUnreadableError(
+      file,
+      'version',
+      `written by schema version ${String(found)}, this build reads version ` +
+        `${String(HISTORY_SCHEMA_VERSION)}`,
+    )
+  }
+
+  const parsed = HistorySchema.safeParse(value)
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .slice(0, 5)
+      .map((i) => `  ${i.path.join('.') || '<root>'}: ${i.message}`)
+      .join('\n')
+    const more =
+      parsed.error.issues.length > 5
+        ? `\n  … and ${String(parsed.error.issues.length - 5)} more`
+        : ''
+    throw new HistoryUnreadableError(file, 'invalid', `\n${issues}${more}`)
+  }
+  return parsed.data
+}

--- a/contracts/index.ts
+++ b/contracts/index.ts
@@ -9,6 +9,7 @@
 export * from './test-run.js'
 export * from './reporters/playwright.js'
 export * from './reporters/vitest.js'
+export * from './history.js'
 export * from './analysis.js'
 export * from './agent-output.js'
 export * from './fixture.js'

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,8 +99,58 @@ type FlakySignal = {
 }
 ```
 
-History is capped (last N runs per test, N configurable) so the file cannot grow without bound.
-Writes are atomic (write temp, rename) so an interrupted job cannot leave a truncated file.
+#### The history file
+
+`.flakemetry/history.json` is the only artifact here that is written by a machine, read by a later
+version of the same machine, and never looked at by anyone. It stores what the scoring reads and
+nothing else — errors, stacks and snippets belong to the run that produced them:
+
+```ts
+type History = {
+  schemaVersion: number
+  tests: Record<
+    string, // deriveTestId(file, title)
+    {
+      firstSeenAt: string
+      entries: {
+        runId: string
+        at: string // the run's start time
+        status: 'passed' | 'failed' | 'timedOut' | 'skipped'
+        flakyWithinRun: boolean
+      }[] // oldest first
+    }
+  >
+}
+```
+
+**The merge rule**, in full:
+
+1. Every result in the run becomes one entry against its `testId`.
+2. An entry already carrying this `runId` is **replaced**, not duplicated. GitHub keeps `run_id`
+   stable across "re-run all jobs", so appending would double a test's apparent stability every
+   time somebody retried a build.
+3. Tests in the history and not in the run are untouched. Absence has too many innocent causes —
+   sharding, a `--grep` filter, a suite that failed to start — and recording it as a status would
+   inject invented alternations into the signal.
+4. `firstSeenAt` only ever moves earlier. It is stored rather than read off the oldest retained
+   entry, because the cap evicts from the front: a test first seen in March would otherwise start
+   reporting itself as new.
+5. Entries are ordered by run start time, not by arrival, so a job for an older commit finishing
+   late cannot make its result the most recent one. `consecutiveFailures` reads the tail of that
+   order.
+6. The oldest entries beyond the cap are dropped. The cap defaults to 50 runs per test — several
+   times the scoring half-life, so the cap does not shape the score, and small enough that the file
+   is not what breaks the cache.
+
+`flakyWithinRun` is retained per entry because it cannot be recovered from `status`. A test that
+fails on attempt 1 and passes on attempt 2 is recorded green; store only the status and a test that
+does that on _every_ run reads back as `PPPPPP` — scored as the most stable test in the suite when
+it is the least.
+
+Writes are atomic (write temp, rename) so an interrupted job cannot leave a truncated file. A
+missing file is an empty history, not an error; a file that exists and cannot be understood **is**
+an error, because treating it as empty would hide the one symptom that says something is writing
+the file wrongly.
 
 ### 3. `analysis.json` → agent inputs
 

--- a/flakemetry-lib/history.test.ts
+++ b/flakemetry-lib/history.test.ts
@@ -1,0 +1,398 @@
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  HISTORY_SCHEMA_VERSION,
+  HistoryUnreadableError,
+  emptyHistory,
+  type History,
+  type TestResult,
+  type TestRun,
+} from '@sentra/contracts'
+import { DEFAULT_RUN_CAP, mergeRun, readHistory, tempPathFor, writeHistory } from './history.js'
+
+/**
+ * Against a real directory, not a mocked filesystem.
+ *
+ * The behaviour under test *is* filesystem behaviour — that a rename replaces a
+ * file in one step, that a missing path reports `ENOENT`, that a directory is
+ * created on the way. A mock would assert that the mock was called, which is a
+ * claim about this test file rather than about the disk any of this runs on.
+ * The same lesson `app/server/api.test.ts` learned when `:memory:` turned out to
+ * ignore `journal_mode = WAL` and every concurrency assertion in it had been
+ * running against a database with no write-ahead log at all.
+ */
+
+let workspace = ''
+let file = ''
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), 'flakemetry-history-'))
+  file = join(workspace, '.flakemetry', 'history.json')
+})
+
+const result = (over: Partial<TestResult> = {}): TestResult => ({
+  testId: 'tests/e2e/board.spec.ts›shows a row',
+  title: 'shows a row',
+  file: 'tests/e2e/board.spec.ts',
+  status: 'passed',
+  attempts: 1,
+  flakyWithinRun: false,
+  durationMs: 12,
+  annotations: [],
+  ...over,
+})
+
+const run = (over: Partial<TestRun> = {}): TestRun => ({
+  runId: 'run-1',
+  commitSha: 'abc1234',
+  branch: 'main',
+  startedAt: '2026-08-01T00:00:00.000Z',
+  durationMs: 100,
+  source: 'playwright',
+  results: [result()],
+  ...over,
+})
+
+/**
+ * Run `n`, a day after run `n - 1`.
+ *
+ * Built by adding to a fixed instant rather than by formatting the number into a
+ * date string, which stops working at the thirty-second run — a cap of fifty
+ * needs more days than August has, and `2026-08-53` parses as `NaN` and sorts
+ * silently wrong.
+ */
+const day = (n: number): string =>
+  new Date(Date.UTC(2026, 7, 1) + (n - 1) * 86_400_000).toISOString()
+
+const statuses = (history: History, testId = 'tests/e2e/board.spec.ts›shows a row'): string =>
+  (history.tests[testId]?.entries ?? []).map((e) => e.status.charAt(0).toUpperCase()).join('')
+
+// ---------------------------------------------------------------------------
+// Reading
+// ---------------------------------------------------------------------------
+
+describe('reading a history that is not there', () => {
+  /** A cache miss after seven idle days, and a first run on a new branch. Both ordinary. */
+  it('is an empty history rather than an error', () => {
+    expect(readHistory(file)).toEqual(emptyHistory())
+  })
+
+  it('does not need the directory to exist either', () => {
+    expect(readHistory(join(workspace, 'nowhere', 'at', 'all.json'))).toEqual(emptyHistory())
+  })
+
+  /** Creating it on read would make a read-only PR job write into the workspace. */
+  it('creates nothing on the way', () => {
+    readHistory(file)
+    expect(readdirSync(workspace)).toEqual([])
+  })
+})
+
+describe('reading a history that cannot be understood', () => {
+  const unreadable = (contents: string): HistoryUnreadableError => {
+    mkdirSync(join(workspace, '.flakemetry'), { recursive: true })
+    writeFileSync(file, contents)
+    try {
+      readHistory(file)
+    } catch (error) {
+      return error as HistoryUnreadableError
+    }
+    return expect.unreachable(`${contents.slice(0, 20)} must not read as a history`)
+  }
+
+  it('names the file and offers the command that recovers', () => {
+    const error = unreadable('{"schemaVersion": 1, "tests"')
+    expect(error).toBeInstanceOf(HistoryUnreadableError)
+    expect(error.message).toContain(file)
+    expect(error.message).toContain(`rm ${file}`)
+  })
+
+  it('reports broken JSON as unparsable', () => {
+    expect(unreadable('{"schemaVersion": 1, "tests"').reason).toBe('unparsable')
+  })
+
+  /**
+   * Zero bytes is the signature of the interrupted write this module renames to
+   * avoid. Reading it as "nothing yet" would erase the only evidence that
+   * something is writing this file the naive way.
+   */
+  it('refuses an empty file instead of treating it as a fresh start', () => {
+    const error = unreadable('')
+    expect(error.reason).toBe('unparsable')
+    expect(error.message).toContain('interrupted')
+  })
+
+  it('reports a valid JSON document of the wrong shape as invalid', () => {
+    expect(unreadable('{"schemaVersion": 1, "tests": []}').reason).toBe('invalid')
+  })
+
+  it('reports a version it does not read as a version problem', () => {
+    expect(unreadable('{"schemaVersion": 99, "tests": {}}').reason).toBe('version')
+  })
+
+  /** Anything that is not "this file is wrong" belongs to the caller, unwrapped. */
+  it('lets a permission error through as itself', () => {
+    expect(() => readHistory(workspace)).toThrow(/EISDIR|EPERM|EACCES/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Merging
+// ---------------------------------------------------------------------------
+
+describe('merging a run', () => {
+  it('records a test that has never been seen before', () => {
+    const merged = mergeRun(emptyHistory(), run())
+    expect(statuses(merged)).toBe('P')
+    expect(merged.tests['tests/e2e/board.spec.ts›shows a row']?.firstSeenAt).toBe(day(1))
+    expect(merged.schemaVersion).toBe(HISTORY_SCHEMA_VERSION)
+  })
+
+  it('appends to a test that has', () => {
+    const first = mergeRun(emptyHistory(), run())
+    const second = mergeRun(
+      first,
+      run({ runId: 'run-2', startedAt: day(2), results: [result({ status: 'failed' })] }),
+    )
+    expect(statuses(second)).toBe('PF')
+  })
+
+  /**
+   * Absence has too many innocent causes — a shard, a `--grep`, a suite that
+   * failed to start — and every one of them would inject an invented
+   * alternation into the signal this file exists to carry.
+   */
+  it('leaves a test the run did not mention completely alone', () => {
+    const first = mergeRun(emptyHistory(), run())
+    const second = mergeRun(
+      first,
+      run({ runId: 'run-2', startedAt: day(2), results: [result({ testId: 'other' })] }),
+    )
+    expect(statuses(second)).toBe('P')
+    expect(second.tests['tests/e2e/board.spec.ts›shows a row']?.entries).toHaveLength(1)
+    expect(statuses(second, 'other')).toBe('P')
+  })
+
+  /**
+   * GitHub keeps `run_id` stable across "re-run all jobs" — only the attempt
+   * number changes. Appending would write the same outcome twice and double a
+   * test's apparent stability every time somebody retried a build.
+   */
+  it('replaces the entry for a run it has already merged rather than adding a second', () => {
+    const once = mergeRun(emptyHistory(), run())
+    const again = mergeRun(once, run({ results: [result({ status: 'failed' })] }))
+    expect(statuses(again)).toBe('F')
+  })
+
+  it('is unchanged by merging the same run twice', () => {
+    const once = mergeRun(emptyHistory(), run())
+    expect(mergeRun(once, run())).toEqual(once)
+  })
+
+  it('does not modify the history it was given', () => {
+    const before = mergeRun(emptyHistory(), run())
+    const snapshot = structuredClone(before)
+    mergeRun(before, run({ runId: 'run-2', startedAt: day(2) }))
+    expect(before).toEqual(snapshot)
+  })
+
+  /**
+   * A job for an older commit can finish after a newer one. Appending in arrival
+   * order would put a stale result last, and `consecutiveFailures` reads the
+   * tail — a fixed test would report an unbroken failing streak.
+   */
+  it('orders by when the run started, not by when it was merged', () => {
+    const newest = mergeRun(
+      emptyHistory(),
+      run({ runId: 'run-9', startedAt: day(9), results: [result({ status: 'failed' })] }),
+    )
+    const late = mergeRun(newest, run({ runId: 'run-2', startedAt: day(2) }))
+    expect(statuses(late)).toBe('PF')
+  })
+
+  it('orders two runs that started at the same instant the same way twice', () => {
+    const a = mergeRun(emptyHistory(), run({ runId: 'b', results: [result({ status: 'failed' })] }))
+    const both = mergeRun(a, run({ runId: 'a' }))
+    expect(statuses(both)).toBe('PF')
+  })
+
+  it('only ever moves firstSeenAt earlier', () => {
+    const first = mergeRun(emptyHistory(), run({ runId: 'run-5', startedAt: day(5) }))
+    const backfilled = mergeRun(first, run({ runId: 'run-2', startedAt: day(2) }))
+    expect(backfilled.tests['tests/e2e/board.spec.ts›shows a row']?.firstSeenAt).toBe(day(2))
+
+    const forward = mergeRun(backfilled, run({ runId: 'run-8', startedAt: day(8) }))
+    expect(forward.tests['tests/e2e/board.spec.ts›shows a row']?.firstSeenAt).toBe(day(2))
+  })
+
+  /**
+   * A test that fails on attempt 1 and passes on attempt 2 is recorded green.
+   * Drop this flag and a test that does it every single run reads back as
+   * `PPPPPP` — the most reliably flaky test in the suite, scored as the most
+   * stable one.
+   */
+  it('keeps the within-run retry evidence that the status cannot express', () => {
+    const merged = mergeRun(
+      emptyHistory(),
+      run({ results: [result({ attempts: 2, flakyWithinRun: true })] }),
+    )
+    expect(merged.tests['tests/e2e/board.spec.ts›shows a row']?.entries[0]).toMatchObject({
+      status: 'passed',
+      flakyWithinRun: true,
+    })
+  })
+})
+
+describe('the retained window', () => {
+  /** Merges `count` single-result runs, one per day, so the oldest is day 1. */
+  const overRuns = (count: number, cap?: number): History => {
+    let history = emptyHistory()
+    for (let i = 1; i <= count; i += 1) {
+      history = mergeRun(
+        history,
+        run({
+          runId: `run-${String(i)}`,
+          startedAt: day(i),
+          results: [result({ status: i === 1 ? 'failed' : 'passed' })],
+        }),
+        cap === undefined ? {} : { cap },
+      )
+    }
+    return history
+  }
+
+  it('keeps everything while the history is under the cap', () => {
+    expect(statuses(overRuns(4, 5))).toBe('FPPP')
+  })
+
+  it('keeps everything at exactly the cap', () => {
+    expect(statuses(overRuns(5, 5))).toBe('FPPPP')
+  })
+
+  it('evicts oldest first once over it', () => {
+    expect(statuses(overRuns(7, 5))).toBe('PPPPP')
+  })
+
+  it('never retains more than the cap however many runs arrive', () => {
+    expect(statuses(overRuns(30, 5))).toHaveLength(5)
+  })
+
+  /**
+   * The reason `firstSeenAt` is stored rather than read off `entries[0]`. Once
+   * the cap starts evicting, the oldest retained entry is not the first one, and
+   * a test first seen in March would begin reporting itself as new.
+   */
+  it('remembers when the test was first seen after its first run has been evicted', () => {
+    const history = overRuns(20, 5)
+    const record = history.tests['tests/e2e/board.spec.ts›shows a row']
+    expect(record?.firstSeenAt).toBe(day(1))
+    expect(record?.entries[0]?.at).not.toBe(day(1))
+  })
+
+  it('defaults to a documented cap rather than to unbounded growth', () => {
+    expect(DEFAULT_RUN_CAP).toBe(50)
+    expect(statuses(overRuns(DEFAULT_RUN_CAP + 3))).toHaveLength(DEFAULT_RUN_CAP)
+  })
+
+  /** A cap of zero would report a working pipeline that stores nothing at all. */
+  it('refuses a cap that could not retain anything', () => {
+    for (const cap of [0, -1, 1.5, Number.NaN]) {
+      expect(() => mergeRun(emptyHistory(), run(), { cap }), String(cap)).toThrow(RangeError)
+    }
+  })
+
+  it('allows a cap of one, which is a choice rather than a mistake', () => {
+    expect(statuses(overRuns(4, 1))).toBe('P')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Writing
+// ---------------------------------------------------------------------------
+
+describe('writing a history', () => {
+  const merged = (): History => mergeRun(emptyHistory(), run())
+
+  it('round-trips through the reader', () => {
+    writeHistory(merged(), file)
+    expect(readHistory(file)).toEqual(merged())
+  })
+
+  it('creates the directory it was pointed at', () => {
+    writeHistory(merged(), join(workspace, 'a', 'b', 'history.json'))
+    expect(readHistory(join(workspace, 'a', 'b', 'history.json'))).toEqual(merged())
+  })
+
+  it('leaves nothing behind but the file', () => {
+    writeHistory(merged(), file)
+    expect(readdirSync(join(workspace, '.flakemetry'))).toEqual(['history.json'])
+  })
+
+  /**
+   * What "atomic" means, checked rather than asserted in a comment.
+   *
+   * A rename replaces the directory entry, so the file at that path is a
+   * *different* inode afterwards and any reader holding the old one still sees a
+   * complete document. Writing in place reuses the inode and passes through a
+   * truncated state that a concurrent reader can observe — which is the failure
+   * this module exists to prevent, and the one a passing round-trip test would
+   * not notice.
+   */
+  it('replaces the file rather than truncating it in place', () => {
+    writeHistory(merged(), file)
+    const before = statSync(file).ino
+    expect(
+      before,
+      'this platform reports no inode, so the assertion below proves nothing',
+    ).toBeGreaterThan(0)
+
+    writeHistory(mergeRun(merged(), run({ runId: 'run-2', startedAt: day(2) })), file)
+    expect(statSync(file).ino).not.toBe(before)
+  })
+
+  /** The property the rename buys: a write that cannot finish costs nothing. */
+  it('leaves the last good history in place when the write cannot complete', () => {
+    writeHistory(merged(), file)
+
+    // A directory where the temp file goes, so the write fails part-way through
+    // exactly as it does when the runner is killed mid-job.
+    mkdirSync(tempPathFor(file))
+    expect(() => writeHistory(emptyHistory(), file)).toThrow()
+
+    expect(readHistory(file)).toEqual(merged())
+  })
+
+  /**
+   * The cache archives the directory, not the file, so a temp file left behind
+   * is restored on the next run and accumulates one per distinct pid until
+   * somebody notices the cache growing.
+   *
+   * Blocking the *target* rather than the temp path is what makes this
+   * observable: the temp file gets written, the rename onto a directory fails,
+   * and the cleanup has something real to remove.
+   */
+  it('removes its temp file when the rename fails', () => {
+    const blocked = join(workspace, 'blocked.json')
+    mkdirSync(blocked)
+
+    expect(() => writeHistory(merged(), blocked)).toThrow()
+    expect(readdirSync(workspace)).toEqual(['blocked.json'])
+  })
+
+  /** A leftover from a job that died between writing and renaming is not history. */
+  it('ignores a temp file that was never renamed', () => {
+    writeHistory(merged(), file)
+    writeFileSync(tempPathFor(file), '{"schemaVersion": 1, "tests"')
+    expect(readHistory(file)).toEqual(merged())
+  })
+
+  /** Nobody reviews this file, but somebody eventually reads it to find out why a score is wrong. */
+  it('writes it indented, so it can be read when the pipeline is the suspect', () => {
+    writeHistory(merged(), file)
+    const text = readFileSync(file, 'utf8')
+    expect(text).toContain('\n  "tests"')
+    expect(text.endsWith('\n')).toBe(true)
+  })
+})

--- a/flakemetry-lib/history.ts
+++ b/flakemetry-lib/history.ts
@@ -1,0 +1,215 @@
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import {
+  HISTORY_SCHEMA_VERSION,
+  HistoryUnreadableError,
+  emptyHistory,
+  parseHistory,
+  type History,
+  type HistoryEntry,
+  type TestHistory,
+  type TestRun,
+} from '@sentra/contracts'
+
+/**
+ * Read, merge and write `.flakemetry/history.json`.
+ *
+ * Three behaviours, and each of them is here because of a specific way the naive
+ * version fails in CI rather than because it seemed tidy.
+ *
+ * **The write is atomic.** The job that writes this file can be cancelled at any
+ * moment — a pushed commit supersedes a running build, and the runner is killed
+ * mid-syscall. A plain `writeFileSync` interrupted there leaves a truncated JSON
+ * file, and the *next* run crashes on parse. A cancelled build would take the
+ * pipeline down with it, one run later, with nothing in either log connecting
+ * the two. Write to a temp file in the same directory, then rename: the swap is
+ * one directory operation, so a reader sees either the whole old file or the
+ * whole new one.
+ *
+ * **The merge is per-test and additive.** A test absent from a run is left
+ * alone, never recorded as anything. Absence has too many innocent causes —
+ * sharding, a `--grep` filter, a suite that failed to start — and recording it
+ * as a status would inject invented alternations into precisely the signal this
+ * file exists to carry.
+ *
+ * **The retained window is capped.** Without one the file grows linearly forever
+ * and eventually exceeds the cache size limit, at which point history stops
+ * persisting and nothing says so: the pipeline keeps running, every test starts
+ * reading as new, and the `determinism` axis quietly loses its evidence.
+ */
+
+/** Where the history lives, relative to the repository root. Set by ADR-0004, not by preference. */
+export const HISTORY_FILE = '.flakemetry/history.json'
+
+/**
+ * Runs retained per test.
+ *
+ * Fifty is roughly a month of history for a repository that runs CI on every
+ * merge, and it is bounded on both sides for a reason. It has to be several
+ * times the scoring half-life, or the cap — not the decay — is what ends up
+ * shaping the score. And it has to stay small enough that the file is not the
+ * thing that breaks the cache: five hundred tests at fifty entries is about two
+ * megabytes of JSON, which is inside the budget with room to spare and parses in
+ * milliseconds.
+ *
+ * Configurable per call, because a suite that runs on every push accumulates a
+ * month of runs in a week.
+ */
+export const DEFAULT_RUN_CAP = 50
+
+export interface MergeOptions {
+  /** Entries retained per test, oldest evicted first. Defaults to {@link DEFAULT_RUN_CAP}. */
+  cap?: number
+}
+
+/**
+ * The temp file a write goes through before it is renamed into place.
+ *
+ * The pid is in the name so two writers cannot land on the same temp file. They
+ * are not supposed to exist — ADR-0004 confines writes to `main` — but the
+ * failure if they ever do is the one the atomic write was introduced to
+ * prevent: two processes interleaving into one temp file and renaming a
+ * scrambled result over a good one.
+ *
+ * Exported so a test can look for one rather than hard-coding the convention in
+ * two places.
+ */
+export function tempPathFor(file: string): string {
+  return `${file}.${String(process.pid)}.tmp`
+}
+
+/**
+ * Read the history at `file`.
+ *
+ * A missing file is an empty history, not an error: a first run on a new branch
+ * and a seven-day cache eviction both produce one, and both are ordinary.
+ *
+ * A file that exists and cannot be understood is an error, and the difference
+ * matters. Quietly treating a corrupt file as empty would hide the one symptom
+ * that says something is writing the file wrongly, and would do it in the exact
+ * situation where the output still looks completely normal.
+ */
+export function readHistory(file: string = HISTORY_FILE): History {
+  let text: string
+  try {
+    text = readFileSync(file, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return emptyHistory()
+    throw error
+  }
+
+  /**
+   * A zero-byte file is not an empty history — it is the signature of the
+   * truncated write this module writes atomically to avoid. Reading it as
+   * "nothing yet" would erase the only evidence that something is bypassing
+   * that.
+   */
+  if (text.trim() === '') {
+    throw new HistoryUnreadableError(
+      file,
+      'unparsable',
+      'the file is empty, which usually means a write was interrupted',
+    )
+  }
+
+  let value: unknown
+  try {
+    value = JSON.parse(text)
+  } catch (error) {
+    throw new HistoryUnreadableError(file, 'unparsable', (error as Error).message)
+  }
+
+  return parseHistory(value, file)
+}
+
+/**
+ * Merge a run into a history. Pure — no clock, no filesystem.
+ *
+ * The rule, in full:
+ *
+ * 1. Every result in the run becomes one entry against its `testId`.
+ * 2. An entry already carrying this `runId` is **replaced**, not duplicated, so
+ *    re-analysing the same report twice leaves the same history.
+ * 3. Tests in the history and not in the run are untouched.
+ * 4. `firstSeenAt` only ever moves earlier.
+ * 5. Entries are ordered by run start time, not by arrival, so a job for an
+ *    older commit finishing late cannot make its result the most recent one.
+ *    `consecutiveFailures` reads the tail of that order; getting it wrong would
+ *    turn a fixed test into a failing streak.
+ * 6. The oldest entries beyond `cap` are dropped.
+ */
+export function mergeRun(history: History, run: TestRun, options: MergeOptions = {}): History {
+  const cap = options.cap ?? DEFAULT_RUN_CAP
+  if (!Number.isInteger(cap) || cap < 1) {
+    throw new RangeError(
+      `run cap must be a positive integer, received ${String(cap)}. A cap of zero would ` +
+        'discard every entry on write and report a working pipeline with no history at all.',
+    )
+  }
+
+  const tests: Record<string, TestHistory> = { ...history.tests }
+
+  for (const result of run.results) {
+    const previous = tests[result.testId]
+    const entry: HistoryEntry = {
+      runId: run.runId,
+      at: run.startedAt,
+      status: result.status,
+      flakyWithinRun: result.flakyWithinRun,
+    }
+    const kept = (previous?.entries ?? []).filter((e) => e.runId !== run.runId)
+
+    tests[result.testId] = {
+      firstSeenAt: earlier(previous?.firstSeenAt, run.startedAt),
+      entries: ordered([...kept, entry]).slice(-cap),
+    }
+  }
+
+  return { schemaVersion: HISTORY_SCHEMA_VERSION, tests }
+}
+
+/**
+ * Write a history to `file`, atomically, creating the directory if needed.
+ *
+ * A failed write removes its own temp file before rethrowing. The leftover would
+ * otherwise be picked up by `actions/cache`, which archives the directory rather
+ * than the file, and restored on the next run — where it accumulates, one per
+ * distinct pid, until somebody notices the cache growing.
+ */
+export function writeHistory(history: History, file: string = HISTORY_FILE): void {
+  mkdirSync(dirname(file), { recursive: true })
+
+  const temp = tempPathFor(file)
+  try {
+    writeFileSync(temp, `${JSON.stringify(history, null, 2)}\n`)
+    renameSync(temp, file)
+  } catch (error) {
+    try {
+      rmSync(temp, { force: true })
+    } catch {
+      // Best-effort. The write has already failed; reporting a problem tidying
+      // up instead of the reason it failed would hide the diagnosis behind the
+      // cleanup, which is how a legible error becomes a confusing one.
+    }
+    throw error
+  }
+}
+
+/** Oldest first. `runId` breaks ties so two runs with one start time still order the same way twice. */
+function ordered(entries: HistoryEntry[]): HistoryEntry[] {
+  return [...entries].sort(
+    (a, b) => Date.parse(a.at) - Date.parse(b.at) || a.runId.localeCompare(b.runId),
+  )
+}
+
+/**
+ * Compared as instants rather than as strings.
+ *
+ * The schema pins these to UTC, so lexicographic order is *nearly* right — and
+ * wrong exactly when two writers disagree about trailing milliseconds, which is
+ * the kind of difference nobody looks for.
+ */
+function earlier(previous: string | undefined, next: string): string {
+  if (previous === undefined) return next
+  return Date.parse(previous) <= Date.parse(next) ? previous : next
+}

--- a/flakemetry-lib/index.ts
+++ b/flakemetry-lib/index.ts
@@ -3,9 +3,9 @@
  *
  * Flakiness scoring and run history. Reads a normalised test run plus the stored history and emits a per-test signal.
  *
- * The implementation lands in M6; this file exists so the
- * workspace, its TypeScript project reference and its public entry point are
- * in place before anything depends on them.
+ * The scoring half lands in #58; what is here is the history the scoring reads —
+ * the file that carries the `determinism` axis from one ephemeral CI job to the
+ * next.
  */
 
-export {}
+export * from './history.js'

--- a/flakemetry-lib/package.json
+++ b/flakemetry-lib/package.json
@@ -10,5 +10,8 @@
       "types": "./dist/index.d.ts",
       "default": "./index.ts"
     }
+  },
+  "dependencies": {
+    "@sentra/contracts": "*"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,10 @@
     "flakemetry-lib": {
       "name": "@sentra/flakemetry",
       "version": "0.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@sentra/contracts": "*"
+      }
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.116.0",


### PR DESCRIPTION
Closes #57 — the first of M6.

`.flakemetry/history.json` is the one artifact in this repository that is written by a machine, read by a later version of the same machine, and never looked at by anyone. A committed fixture that goes wrong shows up in a diff. This shows up as a classifier that quietly gets worse.

So the module is small and almost all of it is refusal.

## Why each behaviour is there

**The write is atomic.** The job that writes this file is cancelled routinely — a pushed commit supersedes a running build, and the runner is killed mid-syscall. A plain `writeFileSync` interrupted there leaves truncated JSON, and the *next* run crashes on parse. A cancelled build takes the pipeline down one run later, with nothing in either log connecting the two.

**The merge is per-test and additive.** A test absent from a run is left alone, never recorded as anything. Absence has too many innocent causes — sharding, a `--grep` filter, a suite that failed to start — and every one of them would inject an invented alternation into precisely the signal this file exists to carry.

**The window is capped at 50 runs per test.** Without a cap the file grows linearly forever and eventually exceeds the cache size limit, at which point history stops persisting and *nothing says so*: the pipeline keeps running, every test starts reading as new, and the `determinism` axis loses its evidence silently. Fifty is bounded on both sides — several times the scoring half-life, so the cap does not shape the score, and about 2 MB at five hundred tests, so the file is not what breaks the cache.

## Two fields are stored rather than derived

Both are eviction bugs waiting to happen, and both have a test that fails if the derivation comes back.

`firstSeenAt` is kept per test because the cap evicts from the front. Read it off `entries[0].at` and it creeps forward as history fills — a test first seen in March starts reporting itself as new in June, and `isNew` is derived from it.

`flakyWithinRun` is kept per entry because it cannot be recovered from the status. A test that fails on attempt 1 and passes on attempt 2 is recorded green; store only the status and a test that does that on *every* run reads back as `PPPPPP` — the most reliably flaky test in the suite, scored as the most stable.

## Idempotency, and why it is not a nicety

GitHub keeps `run_id` stable across "re-run all jobs" — only the attempt number changes. An entry already carrying this `runId` is replaced rather than appended, so re-analysing a report leaves the same history. Appending would double a test's apparent stability every time somebody retried a build.

Entries are also ordered by run start time rather than by arrival, because a job for an older commit can finish after a newer one. `consecutiveFailures` reads the tail of that order; getting it wrong turns a fixed test into a failing streak.

## Missing is fine, corrupt is not

A missing file is an empty history — a cache miss after seven idle days and a first run on a new branch both produce one, and both are ordinary.

A file that exists and cannot be understood is an error, and quietly treating it as empty would hide the one symptom that says something is writing this file wrongly, in the exact situation where the output still looks completely normal. A zero-byte file counts: that is the signature of the interrupted write the rename exists to prevent.

The error carries `reason: 'unparsable' | 'invalid' | 'version'` alongside the prose. #61 has to degrade on a cache-shaped problem while still failing loudly on a bug, and a `catch` that greps English is how that distinction gets lost the first time somebody rewords a message. The message itself gives the recovery command and what recovery costs:

```
.flakemetry/history.json cannot be read as run history: the file is empty, which
usually means a write was interrupted

History is a cache, not a source of truth. Deleting it costs the determinism
signal until it refills — every test reads as new meanwhile — and costs nothing else:

    rm .flakemetry/history.json
```

## Testing

**Against a real directory, not a mocked filesystem.** The behaviour under test *is* filesystem behaviour. A mock would assert that the mock was called — a claim about the test file rather than about the disk any of this runs on. Same lesson `app/server/api.test.ts` learned when `:memory:` turned out to ignore `journal_mode = WAL` and every concurrency assertion in it had been running without a write-ahead log.

Which makes "atomic" checkable rather than something a comment asserts. A rename replaces the directory entry, so the file at that path is a **different inode** afterwards; writing in place reuses the inode and passes through a truncated state a concurrent reader can observe. The test compares inodes, and a round-trip test would not have noticed the difference.

47 new tests, 100% statements/branches/functions/lines on both new files, 1631 total. Nine mutations run against the implementation:

| Mutation | Caught by |
|---|---|
| Write in place instead of renaming | `replaces the file rather than truncating it in place` |
| Always append, never replace by `runId` | `is unchanged by merging the same run twice` |
| Drop the ordering by run start time | `orders by when the run started, not by when it was merged` |
| `firstSeenAt` always takes the new run | `only ever moves firstSeenAt earlier` |
| `firstSeenAt` read off the oldest retained entry | `remembers when the test was first seen after its first run has been evicted` |
| Remove the cap | 5 tests |
| Empty file reads as a fresh start | `refuses an empty file instead of treating it as a fresh start` |
| Accept a cap of zero | `refuses a cap that could not retain anything` |
| Skip the temp-file cleanup | `removes its temp file when the rename fails` |

The last one **survived the first version.** The code claimed to clean up its temp file and the test named after that claim did not check it — it could not, because the failure it staged blocked the temp path itself, so there was nothing left to remove. Split into two tests: one blocks the temp path and checks the last good history survives, one blocks the target so the rename fails and the temp file is real.

## Also

`docs/architecture.md` now carries the document shape and the merge rule as six numbered points. `.gitignore` picks up `.flakemetry/*.tmp` — the cache archives the directory rather than the file, so a temp file left by a killed job is restored on the next run and accumulates one per distinct pid.
