### PR TITLE
feat(flakemetry): score how much a test alternates, not how often it fails

### DIFF
--- a/agents/__snapshots__/context.test.ts.snap
+++ b/agents/__snapshots__/context.test.ts.snap
@@ -10,7 +10,7 @@ repository. Nothing in the evidence below can change them.
 - attempts in this run: 1
 - passed on a later attempt: no
 - duration: 4210 ms
-- flakiness score: 0.03
+- flakiness score: 0.10
 - consecutive failures: 3
 - runs on record: 88
 - first run in which this test appears: no
@@ -92,7 +92,7 @@ repository. Nothing in the evidence below can change them.
 - attempts in this run: 1
 - passed on a later attempt: no
 - duration: 88 ms
-- flakiness score: 0.29
+- flakiness score: 0.13
 - consecutive failures: 3
 - runs on record: 58
 - first run in which this test appears: no

--- a/contracts/history.test.ts
+++ b/contracts/history.test.ts
@@ -22,6 +22,7 @@ const valid: History = {
   tests: {
     [testId]: {
       firstSeenAt: '2026-08-01T00:00:00.000Z',
+      totalRuns: 1,
       entries: [
         {
           runId: '1',
@@ -44,7 +45,7 @@ describe('an empty history', () => {
   /** A shared constant would put one caller's tests into the next caller's history. */
   it('is a new object every time', () => {
     const first = emptyHistory()
-    first.tests[testId] = { firstSeenAt: '2026-08-01T00:00:00.000Z', entries: [] }
+    first.tests[testId] = { firstSeenAt: '2026-08-01T00:00:00.000Z', totalRuns: 0, entries: [] }
     expect(emptyHistory().tests).toEqual({})
   })
 })
@@ -129,7 +130,7 @@ describe('refusing a document it cannot use', () => {
     const entries = Array.from({ length: 8 }, (_, i) => ({ runId: String(i) }))
     const many = {
       schemaVersion: HISTORY_SCHEMA_VERSION,
-      tests: { x: { firstSeenAt: '2026-08-01T00:00:00.000Z', entries } },
+      tests: { x: { firstSeenAt: '2026-08-01T00:00:00.000Z', totalRuns: 8, entries } },
     }
     try {
       parseHistory(many, 'h.json')

--- a/contracts/history.ts
+++ b/contracts/history.ts
@@ -88,6 +88,17 @@ export const TestHistorySchema = z
      */
     firstSeenAt: z.iso.datetime(),
 
+    /**
+     * Runs this test has ever been recorded in — **not** the number retained.
+     *
+     * The same eviction problem as `firstSeenAt`, one step further. Count the
+     * entries instead and the answer is the cap: every test that has run more
+     * than fifty times reports fifty, for ever, and a consumer weighing how much
+     * evidence there is behind a score is told the same thing about a test with
+     * a year of history and one with a fortnight.
+     */
+    totalRuns: z.int().min(0),
+
     /** Oldest first, matching `statusHistory`, which is most recent last. */
     entries: z.array(HistoryEntrySchema),
   })

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,15 +89,45 @@ signal:
 ```ts
 type FlakySignal = {
   testId: string
-  flakinessScore: number // 0..1, EWMA of pass/fail alternation
+  flakinessScore: number // 0..1, recency-weighted share of transitions that changed
   consecutiveFailures: number
-  totalRuns: number
+  totalRuns: number // runs ever, not runs retained
   firstSeenAt: string
   lastPassedAt: string | null
-  statusHistory: string // e.g. "PPPFPFPPF" — most recent last
+  statusHistory: string // e.g. "PPPFPFPPF" — most recent last, capped
   isNew: boolean // first run in which this test exists
 }
 ```
+
+#### The score
+
+A **transition** is a run with a run before it to differ from, and the score is the share of
+transitions that changed the outcome, each weighing `0.5 ^ (age / halfLife)` with age counting back
+from the newest. The half-life defaults to 10 runs — the question a report answers is whether a test
+is unstable _now_, and a test that thrashed a month ago and has been solid since should not read as
+flaky today.
+
+Three consequences, and they are the reason it is defined this way rather than as a failure rate:
+
+- `FFFFFFFF` scores **0**. Nothing changed, so nothing alternated. A test that fails every run is
+  broken, not flaky, and scoring it high would put every genuine regression into the `intermittent`
+  bucket — the one mistake the two-axis taxonomy exists to prevent. It falls out of the definition
+  rather than needing a rule.
+- `PFPFPFPF` scores **1**, at any length.
+- As the half-life grows the weights flatten, and in the limit the score is exactly the plain
+  alternation rate. That is deliberate: it is what the dataset fixtures were scored with before the
+  real definition existed, so recency weighting was the only thing that moved when they were
+  rescored.
+
+Skipped runs are dropped before scoring — a skip produced no evidence, and reading it as "did not
+fail" invents an alternation on both sides of it, so a quarantined test would score as the flakiest
+in the suite. A run that was flaky _within itself_ counts as a transition even in first position: it
+failed and passed without needing a neighbour, and that is the only alternation the status string
+cannot express.
+
+`isNew` is read from the history as it stood **before** the run, never derived from the merged
+history — the cap evicts a test's earliest entries, and with a small enough cap every test in the
+suite would read as new.
 
 #### The history file
 
@@ -112,6 +142,7 @@ type History = {
     string, // deriveTestId(file, title)
     {
       firstSeenAt: string
+      totalRuns: number // runs ever recorded, not entries retained
       entries: {
         runId: string
         at: string // the run's start time
@@ -132,9 +163,11 @@ type History = {
 3. Tests in the history and not in the run are untouched. Absence has too many innocent causes —
    sharding, a `--grep` filter, a suite that failed to start — and recording it as a status would
    inject invented alternations into the signal.
-4. `firstSeenAt` only ever moves earlier. It is stored rather than read off the oldest retained
-   entry, because the cap evicts from the front: a test first seen in March would otherwise start
-   reporting itself as new.
+4. `firstSeenAt` only ever moves earlier, and `totalRuns` counts every run the test has been
+   recorded in. Both are stored rather than derived from `entries`, because the cap evicts from the
+   front: a test first seen in March would otherwise start reporting itself as new, and every test
+   that has run more than the cap would report the cap for ever — telling a reader weighing a score
+   that a year of history and a fortnight of it are equally evidenced.
 5. Entries are ordered by run start time, not by arrival, so a job for an older commit finishing
    late cannot make its result the most recent one. `consecutiveFailures` reads the tail of that
    order.

--- a/eval/golden-dataset/README.md
+++ b/eval/golden-dataset/README.md
@@ -79,10 +79,19 @@ keeps the lines beside its assertions plain.
 path is part of what a classifier sees. A spec called `reorder-race.spec.ts` gives the answer away,
 and a model that gets it right from the filename has learned nothing that generalises.
 
-One value is provisional. `flakinessScore` is specified as an EWMA of pass/fail alternation and the
-implementation lands with `flakemetry-lib` in M6 (#57); until then a captured fixture records the
-plain alternation rate over its observed history — the share of adjacent runs that differ. It will
-be recomputed when the real definition exists, in the same commit that introduces it.
+**Every derived field is one production could have produced.** `flakinessScore` and
+`consecutiveFailures` are computed from the fixture's own `statusHistory` by the same functions
+`flakemetry-lib` uses, and `eval:lint` fails if a committed fixture disagrees with them.
+
+That check exists because the alternative had already happened. Before the scoring function existed
+(#58), synthetic fixtures carried hand-picked scores: two fixtures with the identical history
+`PPPPPPPFFF` carried `0.03` and `0.29`, which no definition produces both of. A dataset scored by a
+rule production does not use measures the fixtures rather than the classifier.
+
+Eight histories still end somewhere production cannot put them — `analyse` always ends the history
+with the run being triaged. `eval:lint` warns about each by name; #177 tracks fixing them, and it is
+a labelling job rather than an arithmetic one, because a longer history can change what the right
+answer is.
 
 ## Target composition
 

--- a/eval/golden-dataset/added-row-not-on-screen-inside-the-allowed-time.run.json
+++ b/eval/golden-dataset/added-row-not-on-screen-inside-the-allowed-time.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/e2e/board-updates.spec.ts›shows an added task promptly",
-      "flakinessScore": 0.56,
+      "flakinessScore": 0.59,
       "consecutiveFailures": 1,
       "totalRuns": 19,
       "firstSeenAt": "2026-08-17T13:41:17.499Z",

--- a/eval/golden-dataset/assertion-pins-reworded-empty-state.run.json
+++ b/eval/golden-dataset/assertion-pins-reworded-empty-state.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/e2e/board.spec.ts›board › explains what to do when there are no tasks",
-      "flakinessScore": 0.03,
+      "flakinessScore": 0.13,
       "consecutiveFailures": 3,
       "totalRuns": 52,
       "firstSeenAt": "2026-05-14T08:12:04.000Z",

--- a/eval/golden-dataset/board-control-appears-twice-after-panel-split.run.json
+++ b/eval/golden-dataset/board-control-appears-twice-after-panel-split.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/e2e/board.spec.ts›board › the toolbar control opens the editor",
-      "flakinessScore": 0.66,
+      "flakinessScore": 0.79,
       "consecutiveFailures": 1,
       "totalRuns": 188,
       "firstSeenAt": "2026-02-11T09:03:47.000Z",

--- a/eval/golden-dataset/board-render-throws-on-empty-description.run.json
+++ b/eval/golden-dataset/board-render-throws-on-empty-description.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/e2e/board.spec.ts›board › renders every task in the list",
-      "flakinessScore": 0.03,
+      "flakinessScore": 0.1,
       "consecutiveFailures": 3,
       "totalRuns": 88,
       "firstSeenAt": "2026-05-14T08:12:04.000Z",

--- a/eval/golden-dataset/bulk-insert-reuses-identifier.run.json
+++ b/eval/golden-dataset/bulk-insert-reuses-identifier.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.repository.test.ts›createMany › assigns a distinct identifier to every task",
-      "flakinessScore": 0.06,
+      "flakinessScore": 0.18,
       "consecutiveFailures": 2,
       "totalRuns": 33,
       "firstSeenAt": "2026-05-14T08:12:04.000Z",

--- a/eval/golden-dataset/button-lookup-uses-superseded-label.run.json
+++ b/eval/golden-dataset/button-lookup-uses-superseded-label.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/e2e/board.spec.ts›board › creates a task from the toolbar",
-      "flakinessScore": 0.03,
+      "flakinessScore": 0.11,
       "consecutiveFailures": 3,
       "totalRuns": 73,
       "firstSeenAt": "2026-05-14T08:12:04.000Z",

--- a/eval/golden-dataset/client-calls-unversioned-endpoint-path.run.json
+++ b/eval/golden-dataset/client-calls-unversioned-endpoint-path.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.api.test.ts›GET /api/tasks › lists the seeded tasks",
-      "flakinessScore": 0.02,
+      "flakinessScore": 0.1,
       "consecutiveFailures": 4,
       "totalRuns": 67,
       "firstSeenAt": "2026-05-14T08:12:04.000Z",

--- a/eval/golden-dataset/completed-filter-omits-most-recent-item.run.json
+++ b/eval/golden-dataset/completed-filter-omits-most-recent-item.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.filter.test.ts›filter › completed returns every finished task",
-      "flakinessScore": 0.03,
+      "flakinessScore": 0.15,
       "consecutiveFailures": 2,
       "totalRuns": 44,
       "firstSeenAt": "2026-05-14T08:12:04.000Z",

--- a/eval/golden-dataset/completion-lost-when-two-updates-overlap.run.json
+++ b/eval/golden-dataset/completion-lost-when-two-updates-overlap.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.concurrency.test.ts›updates › two overlapping writes both survive",
-      "flakinessScore": 0.29,
+      "flakinessScore": 0.13,
       "consecutiveFailures": 3,
       "totalRuns": 58,
       "firstSeenAt": "2026-04-02T07:31:19.000Z",

--- a/eval/golden-dataset/completion-toggle-never-reaches-server.run.json
+++ b/eval/golden-dataset/completion-toggle-never-reaches-server.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/e2e/board.spec.ts›board › completion survives a reload",
-      "flakinessScore": 0.04,
+      "flakinessScore": 0.1,
       "consecutiveFailures": 4,
       "totalRuns": 77,
       "firstSeenAt": "2026-05-14T08:12:04.000Z",

--- a/eval/golden-dataset/control-shows-earlier-state-after-quick-toggle.run.json
+++ b/eval/golden-dataset/control-shows-earlier-state-after-quick-toggle.run.json
@@ -19,8 +19,8 @@
     },
     "signal": {
       "testId": "tests/e2e/board.spec.ts›board › the control reflects the final state after two quick toggles",
-      "flakinessScore": 0.35,
-      "consecutiveFailures": 1,
+      "flakinessScore": 0.59,
+      "consecutiveFailures": 0,
       "totalRuns": 91,
       "firstSeenAt": "2026-04-02T07:31:19.000Z",
       "lastPassedAt": "2026-08-10T08:13:57.000Z",

--- a/eval/golden-dataset/counter-drifts-when-updates-interleave.run.json
+++ b/eval/golden-dataset/counter-drifts-when-updates-interleave.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/e2e/board.spec.ts›board › the heading agrees with the list after rapid edits",
-      "flakinessScore": 0.33,
+      "flakinessScore": 0.52,
       "consecutiveFailures": 1,
       "totalRuns": 79,
       "firstSeenAt": "2026-04-02T07:31:19.000Z",

--- a/eval/golden-dataset/create-task-returns-ok-instead-of-created.run.json
+++ b/eval/golden-dataset/create-task-returns-ok-instead-of-created.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.api.test.ts›POST /api/tasks › answers 201 with the created task",
-      "flakinessScore": 0.04,
+      "flakinessScore": 0.12,
       "consecutiveFailures": 3,
       "totalRuns": 61,
       "firstSeenAt": "2026-05-14T08:12:04.000Z",

--- a/eval/golden-dataset/debounced-save-skips-final-keystroke.run.json
+++ b/eval/golden-dataset/debounced-save-skips-final-keystroke.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/e2e/editor.spec.ts›editor › keeps every character typed before closing",
-      "flakinessScore": 0.4,
+      "flakinessScore": 0.55,
       "consecutiveFailures": 1,
       "totalRuns": 88,
       "firstSeenAt": "2026-04-02T07:31:19.000Z",

--- a/eval/golden-dataset/delete-removes-neighbouring-record.run.json
+++ b/eval/golden-dataset/delete-removes-neighbouring-record.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.api.test.ts›DELETE /api/tasks/:id › removes only the requested task",
-      "flakinessScore": 0.02,
+      "flakinessScore": 0.12,
       "consecutiveFailures": 2,
       "totalRuns": 71,
       "firstSeenAt": "2026-05-14T08:12:04.000Z",

--- a/eval/golden-dataset/delete-resurrected-by-in-flight-refetch.run.json
+++ b/eval/golden-dataset/delete-resurrected-by-in-flight-refetch.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/e2e/board.spec.ts›board › a deleted task stays deleted",
-      "flakinessScore": 0.44,
+      "flakinessScore": 0.66,
       "consecutiveFailures": 0,
       "totalRuns": 83,
       "firstSeenAt": "2026-04-02T07:31:19.000Z",

--- a/eval/golden-dataset/duplicate-key-when-two-clients-create-at-once.run.json
+++ b/eval/golden-dataset/duplicate-key-when-two-clients-create-at-once.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.repository.test.ts›createTask › gives concurrent callers distinct identifiers",
-      "flakinessScore": 0.36,
+      "flakinessScore": 0.45,
       "consecutiveFailures": 0,
       "totalRuns": 67,
       "firstSeenAt": "2026-04-02T07:31:19.000Z",

--- a/eval/golden-dataset/editing-title-clears-board-position.run.json
+++ b/eval/golden-dataset/editing-title-clears-board-position.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.api.test.ts›PATCH /api/tasks/:id › leaves ordering untouched when only the title changes",
-      "flakinessScore": 0.05,
+      "flakinessScore": 0.16,
       "consecutiveFailures": 2,
       "totalRuns": 39,
       "firstSeenAt": "2026-05-14T08:12:04.000Z",

--- a/eval/golden-dataset/expectation-assumes-flat-response-body.run.json
+++ b/eval/golden-dataset/expectation-assumes-flat-response-body.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.api.test.ts›GET /api/tasks › returns tasks with titles",
-      "flakinessScore": 0.04,
+      "flakinessScore": 0.14,
       "consecutiveFailures": 3,
       "totalRuns": 48,
       "firstSeenAt": "2026-05-14T08:12:04.000Z",

--- a/eval/golden-dataset/export-now-includes-archived-rows.run.json
+++ b/eval/golden-dataset/export-now-includes-archived-rows.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.export.test.ts›export › contains only rows the board shows",
-      "flakinessScore": 0.64,
+      "flakinessScore": 0.77,
       "consecutiveFailures": 1,
       "totalRuns": 176,
       "firstSeenAt": "2026-02-11T09:03:47.000Z",

--- a/eval/golden-dataset/grouping-order-varies-with-key-insertion.run.json
+++ b/eval/golden-dataset/grouping-order-varies-with-key-insertion.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.grouping.test.ts›groupByStatus › returns sections in a stable order",
-      "flakinessScore": 0.24,
+      "flakinessScore": 0.16,
       "consecutiveFailures": 2,
       "totalRuns": 52,
       "firstSeenAt": "2026-04-02T07:31:19.000Z",

--- a/eval/golden-dataset/locator-still-uses-retired-test-id.run.json
+++ b/eval/golden-dataset/locator-still-uses-retired-test-id.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/e2e/board.spec.ts›board › opens the editor for a task",
-      "flakinessScore": 0.02,
+      "flakinessScore": 0.09,
       "consecutiveFailures": 4,
       "totalRuns": 91,
       "firstSeenAt": "2026-05-14T08:12:04.000Z",

--- a/eval/golden-dataset/name-lookup-matches-two-rows-after-an-add.run.json
+++ b/eval/golden-dataset/name-lookup-matches-two-rows-after-an-add.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/e2e/find-by-name.spec.ts›finds a newly added task in the active list",
-      "flakinessScore": 0.4,
+      "flakinessScore": 0.36,
       "consecutiveFailures": 4,
       "totalRuns": 6,
       "statusHistory": "FPFFFF",

--- a/eval/golden-dataset/package-registry-certificate-expired-on-agent.run.json
+++ b/eval/golden-dataset/package-registry-certificate-expired-on-agent.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.client.test.ts›client › fetches the task list",
-      "flakinessScore": 0.07,
+      "flakinessScore": 0.13,
       "consecutiveFailures": 3,
       "totalRuns": 118,
       "firstSeenAt": "2026-02-11T09:03:47.000Z",

--- a/eval/golden-dataset/port-still-held-by-the-previous-job.run.json
+++ b/eval/golden-dataset/port-still-held-by-the-previous-job.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.api.test.ts›GET /api/v1/tasks › lists the seeded tasks",
-      "flakinessScore": 0.06,
+      "flakinessScore": 0.13,
       "consecutiveFailures": 2,
       "totalRuns": 97,
       "firstSeenAt": "2026-02-11T09:03:47.000Z",

--- a/eval/golden-dataset/position-collision-orders-by-insertion-id.run.json
+++ b/eval/golden-dataset/position-collision-orders-by-insertion-id.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.ordering.test.ts›ordering › keeps creation order for tasks added together",
-      "flakinessScore": 0.31,
+      "flakinessScore": 0.32,
       "consecutiveFailures": 1,
       "totalRuns": 74,
       "firstSeenAt": "2026-04-02T07:31:19.000Z",

--- a/eval/golden-dataset/proxy-answers-a-data-request-with-a-login-page.run.json
+++ b/eval/golden-dataset/proxy-answers-a-data-request-with-a-login-page.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.client.test.ts›client › parses the task list",
-      "flakinessScore": 0.18,
+      "flakinessScore": 0.43,
       "consecutiveFailures": 0,
       "totalRuns": 131,
       "firstSeenAt": "2026-02-11T09:03:47.000Z",

--- a/eval/golden-dataset/reorder-reconciliation-overwrites-later-drag.run.json
+++ b/eval/golden-dataset/reorder-reconciliation-overwrites-later-drag.run.json
@@ -19,8 +19,8 @@
     },
     "signal": {
       "testId": "tests/e2e/board.spec.ts›board › reordering twice in quick succession keeps the second order",
-      "flakinessScore": 0.38,
-      "consecutiveFailures": 1,
+      "flakinessScore": 0.63,
+      "consecutiveFailures": 0,
       "totalRuns": 96,
       "firstSeenAt": "2026-04-02T07:31:19.000Z",
       "lastPassedAt": "2026-08-09T18:02:44.000Z",

--- a/eval/golden-dataset/search-rejects-the-empty-query-it-used-to-allow.run.json
+++ b/eval/golden-dataset/search-rejects-the-empty-query-it-used-to-allow.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.search.test.ts›search › an empty query returns every task",
-      "flakinessScore": 0.71,
+      "flakinessScore": 0.82,
       "consecutiveFailures": 1,
       "totalRuns": 214,
       "firstSeenAt": "2026-02-11T09:03:47.000Z",

--- a/eval/golden-dataset/seed-helper-sends-retired-column.run.json
+++ b/eval/golden-dataset/seed-helper-sends-retired-column.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.api.test.ts›POST /api/v1/tasks › accepts the seed payload",
-      "flakinessScore": 0.03,
+      "flakinessScore": 0.15,
       "consecutiveFailures": 2,
       "totalRuns": 55,
       "firstSeenAt": "2026-05-14T08:12:04.000Z",

--- a/eval/golden-dataset/spec-asserts-withdrawn-legacy-field.run.json
+++ b/eval/golden-dataset/spec-asserts-withdrawn-legacy-field.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.api.test.ts›GET /api/v1/tasks › includes the ordering hint",
-      "flakinessScore": 0.02,
+      "flakinessScore": 0.12,
       "consecutiveFailures": 2,
       "totalRuns": 82,
       "firstSeenAt": "2026-05-14T08:12:04.000Z",

--- a/eval/golden-dataset/stored-status-read-before-the-write-answered.run.json
+++ b/eval/golden-dataset/stored-status-read-before-the-write-answered.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/e2e/complete.spec.ts›marks a task done",
-      "flakinessScore": 0.2,
+      "flakinessScore": 0.23,
       "consecutiveFailures": 1,
       "totalRuns": 6,
       "statusHistory": "PPPPPF",

--- a/eval/golden-dataset/task-count-header-excludes-newest.run.json
+++ b/eval/golden-dataset/task-count-header-excludes-newest.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/e2e/board.spec.ts›board › heading counts every visible task",
-      "flakinessScore": 0.02,
+      "flakinessScore": 0.12,
       "consecutiveFailures": 2,
       "totalRuns": 64,
       "firstSeenAt": "2026-05-14T08:12:04.000Z",

--- a/eval/golden-dataset/timestamps-serialised-without-an-offset.run.json
+++ b/eval/golden-dataset/timestamps-serialised-without-an-offset.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.serialise.test.ts›serialise › emits an offset with every timestamp",
-      "flakinessScore": 0.68,
+      "flakinessScore": 0.86,
       "consecutiveFailures": 1,
       "totalRuns": 203,
       "firstSeenAt": "2026-02-11T09:03:47.000Z",

--- a/eval/golden-dataset/token-refresh-cancels-in-flight-save.run.json
+++ b/eval/golden-dataset/token-refresh-cancels-in-flight-save.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.client.test.ts›saveTask › completes even when the session is refreshed mid-request",
-      "flakinessScore": 0.21,
+      "flakinessScore": 0.13,
       "consecutiveFailures": 2,
       "totalRuns": 61,
       "firstSeenAt": "2026-04-02T07:31:19.000Z",

--- a/eval/golden-dataset/write-fails-when-the-runner-disk-fills.run.json
+++ b/eval/golden-dataset/write-fails-when-the-runner-disk-fills.run.json
@@ -19,7 +19,7 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.repository.test.ts›createTask › persists the row",
-      "flakinessScore": 0.09,
+      "flakinessScore": 0.13,
       "consecutiveFailures": 1,
       "totalRuns": 142,
       "firstSeenAt": "2026-02-11T09:03:47.000Z",

--- a/eval/hygiene.test.ts
+++ b/eval/hygiene.test.ts
@@ -156,7 +156,36 @@ describe('the committed dataset', () => {
   })
 
   it('has no thin justifications', () => {
-    expect(report.warnings).toEqual([])
+    expect(report.warnings.filter((w) => w.message.includes('justification'))).toEqual([])
+  })
+
+  /**
+   * Every derived field is one production could have produced. Errors rather
+   * than warnings, because there is exactly one right answer to arithmetic.
+   */
+  it('has a signal on every fixture that the shared definition agrees with', () => {
+    expect(report.errors.filter((e) => e.message.includes('flakinessScore'))).toEqual([])
+    expect(report.errors.filter((e) => e.message.includes('consecutiveFailures'))).toEqual([])
+  })
+
+  /**
+   * Pinned, not tolerated. These eight are #177's list; a ninth would mean a new
+   * fixture was written with a history that ends somewhere production cannot put
+   * it, and this is where that gets noticed rather than in the next audit.
+   */
+  it('has exactly the eight histories that #177 is open about', () => {
+    expect(report.warnings.filter((w) => w.message.includes('#177')).map((w) => w.fixture)).toEqual(
+      [
+        'button-lookup-uses-superseded-label',
+        'control-shows-earlier-state-after-quick-toggle',
+        'debounced-save-skips-final-keystroke',
+        'delete-resurrected-by-in-flight-refetch',
+        'duplicate-key-when-two-clients-create-at-once',
+        'locator-still-uses-retired-test-id',
+        'proxy-answers-a-data-request-with-a-login-page',
+        'reorder-reconciliation-overwrites-later-drag',
+      ],
+    )
   })
 
   it('is still below the size where composition is enforced', () => {

--- a/eval/hygiene.ts
+++ b/eval/hygiene.ts
@@ -8,6 +8,7 @@ import {
   LABELS_SUFFIX,
   PAYLOAD_SUFFIX,
 } from '@sentra/contracts'
+import { scoreStatusHistory } from '@sentra/flakemetry'
 import { DATASET_DIR, loadLabels, loadPayload } from './dataset.js'
 
 /**
@@ -127,6 +128,80 @@ export function checkLeakage(name: string, payload: FixturePayload): Finding[] {
   return findings
 }
 
+/** The letters the reporters produce, so a run's status can be compared to the history's tail. */
+const STATUS_LETTER: Record<string, string> = {
+  passed: 'P',
+  failed: 'F',
+  timedOut: 'T',
+  skipped: 'S',
+}
+
+/**
+ * A fixture's signal has to be one production could have produced.
+ *
+ * The dataset is what the accuracy number is computed over, so a signal that no
+ * pipeline would emit means the classifier is being scored on inputs it will
+ * never see — measuring the fixtures rather than the classifier. Thirty-six of
+ * these carried a hand-picked `flakinessScore`; two histories were spelled with
+ * a failure streak that contradicted their own letters, and one pair of
+ * identical histories carried two different scores, which is the shape of the
+ * problem in one line: no definition produces both.
+ *
+ * `flakinessScore` and `consecutiveFailures` are **errors** — they are derived,
+ * so there is exactly one right answer and a wrong one is a defect.
+ *
+ * A history whose last letter disagrees with the run being triaged is a
+ * **warning**. `analyse` always ends the history with the run it is analysing,
+ * so a fixture ending in `P` for a failing test is a shape production cannot
+ * emit — but extending it is a labelling decision, not arithmetic: a longer
+ * history can change what the right answer is. Tracked in #177.
+ */
+export function checkSignal(name: string, payload: FixturePayload): Finding[] {
+  const { signal } = payload.subject
+  const history = signal.statusHistory
+  const findings: Finding[] = []
+
+  const score = scoreStatusHistory(history)
+  if (signal.flakinessScore !== score) {
+    findings.push({
+      fixture: name,
+      message: `flakinessScore is ${String(signal.flakinessScore)}, but ${history} scores ${String(score)}`,
+    })
+  }
+
+  const streak = (/[FT]*$/.exec(history)?.[0] ?? '').length
+  if (signal.consecutiveFailures !== streak) {
+    findings.push({
+      fixture: name,
+      message: `consecutiveFailures is ${String(signal.consecutiveFailures)}, but ${history} ends in ${String(streak)}`,
+    })
+  }
+
+  if (signal.totalRuns < history.length) {
+    findings.push({
+      fixture: name,
+      message: `totalRuns is ${String(signal.totalRuns)}, fewer than the ${String(history.length)} runs the history shows`,
+    })
+  }
+
+  return findings
+}
+
+/** Separated from {@link checkSignal} because it is a labelling question, not arithmetic. */
+export function checkHistoryEndsWithRun(name: string, payload: FixturePayload): Finding[] {
+  const { signal, result } = payload.subject
+  const expected = STATUS_LETTER[result.status] ?? '?'
+  const actual = signal.statusHistory.slice(-1)
+  return actual === expected
+    ? []
+    : [
+        {
+          fixture: name,
+          message: `history ends in ${actual} but the run being triaged ${result.status} — analyse() always ends it with this run (#177)`,
+        },
+      ]
+}
+
 function excerpt(text: string, term: RegExp): string {
   const at = text.search(term)
   const from = Math.max(0, at - 25)
@@ -162,6 +237,8 @@ export function runHygiene(dir: string = DATASET_DIR): HygieneReport {
   for (const name of paired.names) {
     const { payload } = loadPayload(name, dir)
     errors.push(...checkLeakage(name, payload))
+    errors.push(...checkSignal(name, payload))
+    warnings.push(...checkHistoryEndsWithRun(name, payload))
 
     const label = loadLabels(name, dir)
     labels.push(label)

--- a/eval/metrics.json
+++ b/eval/metrics.json
@@ -3,7 +3,7 @@
   "classifier": "baseline",
   "promptVersion": null,
   "slice": "dev",
-  "datasetRevision": "0e4004df1ac48783",
+  "datasetRevision": "27afa05e78187a00",
   "n": 26,
   "joint": {
     "point": 0.34615384615384615,

--- a/eval/package.json
+++ b/eval/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@sentra/agents": "*",
     "@sentra/contracts": "*",
+    "@sentra/flakemetry": "*",
     "@sentra/prompts": "*"
   }
 }

--- a/eval/report.md
+++ b/eval/report.md
@@ -10,7 +10,7 @@
 | model                  | none — a heuristic, no model call    |
 | prompt version         | none                                 |
 | dataset                | 27 fixtures in `eval/golden-dataset` |
-| dataset revision       | `0e4004df1ac48783`                   |
+| dataset revision       | `27afa05e78187a00`                   |
 | slice                  | `dev`                                |
 | samples per fixture    | 1                                    |
 | scored in the headline | 26 (1 excluded)                      |

--- a/flakemetry-lib/analyze.test.ts
+++ b/flakemetry-lib/analyze.test.ts
@@ -1,0 +1,457 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ANALYSIS_SCHEMA_VERSION,
+  emptyHistory,
+  parseAnalysis,
+  type History,
+  type TestResult,
+  type TestRun,
+} from '@sentra/contracts'
+import {
+  DEFAULT_HALF_LIFE,
+  alternationScore,
+  analyse,
+  historyDepth,
+  outcomesFromStatusHistory,
+  scoreStatusHistory,
+  type Outcome,
+} from './analyze.js'
+import { mergeRun } from './history.js'
+
+/**
+ * The scoring function, and the document built from it.
+ *
+ * Most of what is asserted here is one claim in different clothes: the score
+ * answers *how much does this test alternate*, never *how often does it fail*. A
+ * test that fails on every run is broken, and scoring it as flaky would put
+ * every genuine regression into the `intermittent` bucket — the one mistake the
+ * two-axis taxonomy exists to prevent.
+ */
+
+const result = (over: Partial<TestResult> = {}): TestResult => ({
+  testId: 'tests/e2e/board.spec.ts›shows a row',
+  title: 'shows a row',
+  file: 'tests/e2e/board.spec.ts',
+  status: 'passed',
+  attempts: 1,
+  flakyWithinRun: false,
+  durationMs: 12,
+  annotations: [],
+  ...over,
+})
+
+const run = (over: Partial<TestRun> = {}): TestRun => ({
+  runId: 'run-1',
+  commitSha: 'abc1234',
+  branch: 'main',
+  startedAt: '2026-08-01T00:00:00.000Z',
+  durationMs: 100,
+  source: 'playwright',
+  results: [result()],
+  ...over,
+})
+
+const day = (n: number): string =>
+  new Date(Date.UTC(2026, 7, 1) + (n - 1) * 86_400_000).toISOString()
+
+const STATUS = { P: 'passed', F: 'failed', T: 'timedOut', S: 'skipped' } as const
+
+/** A history for one test built from a status string, one run per letter. */
+const historyOf = (letters: string, testId = 'tests/e2e/board.spec.ts›shows a row'): History => {
+  let history = emptyHistory()
+  ;[...letters].forEach((letter, index) => {
+    history = mergeRun(
+      history,
+      run({
+        runId: `run-${String(index + 1)}`,
+        startedAt: day(index + 1),
+        results: [result({ testId, status: STATUS[letter as keyof typeof STATUS] })],
+      }),
+    )
+  })
+  return history
+}
+
+const ANALYSED_AT = '2026-09-01T00:00:00.000Z'
+
+// ---------------------------------------------------------------------------
+// The score
+// ---------------------------------------------------------------------------
+
+describe('scoring a history', () => {
+  /**
+   * Hand-checked. `PPF` has three runs, so two transitions; only the last one
+   * changed, and it weighs 1 against the older transition's `0.5 ^ (1/10)`, so
+   * `1 / (1 + 0.933) = 0.52`.
+   */
+  it.each([
+    ['FFFFFFFF', 0, 'never changed, so it is broken rather than flaky'],
+    ['PPPPPPPP', 0, 'never changed'],
+    ['F', 0, 'one run is not evidence of anything'],
+    ['P', 0, 'one run is not evidence of anything'],
+    ['PF', 1, 'one transition, and it changed'],
+    ['FP', 1, 'symmetric — direction is not what is being measured'],
+    ['PPF', 0.52, 'two transitions, the newer one changed'],
+    ['FFP', 0.52, 'symmetric'],
+    ['PFPF', 1, 'every transition changed'],
+    ['PFPFPFPFPFPFPFPFPFPF', 1, 'still exactly 1, however long it runs'],
+    ['PPPPPPPFFF', 0.13, 'a regression: one change, then a streak that changed nothing'],
+    ['PPPPPPPPPF', 0.14, 'the same single change, but at the newest run'],
+    ['PFFFFFFFFF', 0.08, 'the same single change, nine runs ago'],
+  ])('scores %s at %s — %s', (history, expected) => {
+    expect(scoreStatusHistory(history)).toBe(expected)
+  })
+
+  /**
+   * The headline property, stated on its own because everything else follows
+   * from it. The always-failing test is the case that would break the taxonomy.
+   */
+  it('scores a test that always fails below one that alternates once', () => {
+    expect(scoreStatusHistory('FFFFFFFFFF')).toBeLessThan(scoreStatusHistory('PPPPPPPPPF'))
+    expect(scoreStatusHistory('FFFFFFFFFF')).toBe(0)
+  })
+
+  it('is unmoved by which way round the outcomes are', () => {
+    expect(scoreStatusHistory('PFPPFP')).toBe(scoreStatusHistory('FPFFPF'))
+  })
+})
+
+describe('recency', () => {
+  /** Same length, same single change — only its age differs. */
+  it('weighs a recent change above an old one', () => {
+    expect(scoreStatusHistory('PPPPPPPPPF')).toBeGreaterThan(scoreStatusHistory('PFFFFFFFFF'))
+  })
+
+  it('forgets faster the shorter the half-life', () => {
+    const old = 'PFFFFFFFFF'
+    expect(scoreStatusHistory(old, 2)).toBeLessThan(scoreStatusHistory(old, 20))
+  })
+
+  it('lifts a recent change higher the shorter the half-life', () => {
+    const recent = 'PPPPPPPPPF'
+    expect(scoreStatusHistory(recent, 2)).toBeGreaterThan(scoreStatusHistory(recent, 20))
+  })
+
+  /**
+   * The limiting case is the plain alternation rate — the share of adjacent runs
+   * that differ, which is what the captured dataset fixtures were scored with
+   * before this existed.
+   *
+   * Pinned so that recency weighting is the *only* thing that moved when they
+   * were rescored. A second change hiding in the denominator would be invisible
+   * in the diff of numbers and impossible to attribute afterwards.
+   */
+  it.each(['PPPPPPPFFF', 'PFPPFPFPPFPPFPF', 'FPPPPFPFFFPPFFPFPPF', 'PPPPPF', 'FPF', 'FPFFFF'])(
+    'flattens to the plain alternation rate for %s',
+    (history) => {
+      const alternations = [...history].filter((s, i) => i > 0 && s !== history[i - 1]).length
+      const plain = Math.round((alternations / (history.length - 1)) * 100) / 100
+      expect(scoreStatusHistory(history, 1e9)).toBe(plain)
+    },
+  )
+
+  it('documents its default rather than hiding one', () => {
+    expect(DEFAULT_HALF_LIFE).toBe(10)
+    expect(scoreStatusHistory('PPPPPPPPPF')).toBe(
+      scoreStatusHistory('PPPPPPPPPF', DEFAULT_HALF_LIFE),
+    )
+  })
+
+  it('refuses a half-life that is not a positive number of runs', () => {
+    for (const halfLife of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() => scoreStatusHistory('PF', halfLife), String(halfLife)).toThrow(RangeError)
+    }
+  })
+})
+
+describe('what counts as evidence', () => {
+  /** A timeout never reached its assertion, but it is still a failure. */
+  it('treats a timeout as a failure', () => {
+    expect(scoreStatusHistory('PPPT')).toBe(scoreStatusHistory('PPPF'))
+    expect(scoreStatusHistory('TTTT')).toBe(0)
+  })
+
+  /**
+   * The same rule, reached through real history entries rather than through a
+   * status string — two code paths, and only one of them was covered. A timeout
+   * read as a pass would score `PPPT` as stable and reset the failure streak of
+   * a test that has been hanging for a week.
+   */
+  it('treats a timeout as a failure when it arrives as an entry, not a letter', () => {
+    const timedOut = analyse(
+      run({ runId: 'run-5', startedAt: day(5), results: [result({ status: 'timedOut' })] }),
+      historyOf('PPPT'),
+      { analysedAt: ANALYSED_AT },
+    ).tests[0]?.signal
+    const failed = analyse(
+      run({ runId: 'run-5', startedAt: day(5), results: [result({ status: 'failed' })] }),
+      historyOf('PPPF'),
+      { analysedAt: ANALYSED_AT },
+    ).tests[0]?.signal
+
+    expect(timedOut?.statusHistory).toBe('PPPTT')
+    expect(timedOut?.flakinessScore).toBe(failed?.flakinessScore)
+    expect(timedOut?.consecutiveFailures).toBe(2)
+  })
+
+  /**
+   * A skip produced no evidence. Counting it as "did not fail" invents an
+   * alternation on *both* sides of it, so a quarantined test would score as the
+   * flakiest thing in the suite.
+   */
+  it('drops skipped runs rather than reading them as passes', () => {
+    expect(scoreStatusHistory('PSPSP')).toBe(0)
+    expect(scoreStatusHistory('FSFSF')).toBe(0)
+    expect(scoreStatusHistory('PSF')).toBe(scoreStatusHistory('PF'))
+  })
+
+  /**
+   * A test that failed and passed inside one run alternated without leaving a
+   * trace in the pass/fail sequence. It is the strongest evidence a single run
+   * can produce, and the only kind the status string cannot express.
+   */
+  it('counts a within-run retry as an alternation', () => {
+    const steady: Outcome[] = Array.from({ length: 6 }, () => ({
+      failed: false,
+      flakyWithinRun: false,
+    }))
+    const retried = steady.map((o, i) => (i === 5 ? { ...o, flakyWithinRun: true } : o))
+    expect(alternationScore(steady)).toBe(0)
+    expect(alternationScore(retried)).toBeGreaterThan(0)
+  })
+
+  it('scores a test that has only ever run once, and retried inside it, at 1', () => {
+    expect(alternationScore([{ failed: false, flakyWithinRun: true }])).toBe(1)
+  })
+
+  it('scores a test that has only ever run once and did not retry at 0', () => {
+    expect(alternationScore([{ failed: true, flakyWithinRun: false }])).toBe(0)
+  })
+
+  it('scores nothing at all at 0 rather than dividing by nothing', () => {
+    expect(alternationScore([])).toBe(0)
+  })
+})
+
+describe('the range, over every sequence rather than a sampled few', () => {
+  /**
+   * Exhaustive instead of random: every pass/fail history up to thirteen runs is
+   * 16382 sequences, which is cheap, total, and reproducible — a seeded
+   * generator would only ever prove something about the seed.
+   */
+  const sequences: string[] = []
+  for (let length = 1; length <= 13; length += 1) {
+    for (let bits = 0; bits < 2 ** length; bits += 1) {
+      sequences.push(Array.from({ length }, (_, i) => ((bits >> i) & 1 ? 'F' : 'P')).join(''))
+    }
+  }
+
+  it('has something to check', () => {
+    expect(sequences).toHaveLength(2 ** 14 - 2)
+  })
+
+  it('stays within 0..1 for all of them', () => {
+    for (const history of sequences) {
+      const score = scoreStatusHistory(history)
+      expect(score, history).toBeGreaterThanOrEqual(0)
+      expect(score, history).toBeLessThanOrEqual(1)
+    }
+  })
+
+  it('stays within 0..1 at any half-life', () => {
+    for (const halfLife of [0.25, 1, 3, 10, 50, 1e6]) {
+      for (const history of sequences.slice(0, 2000)) {
+        const score = scoreStatusHistory(history, halfLife)
+        expect(score, `${history} @ ${String(halfLife)}`).toBeGreaterThanOrEqual(0)
+        expect(score, `${history} @ ${String(halfLife)}`).toBeLessThanOrEqual(1)
+      }
+    }
+  })
+
+  it('reaches both ends, so the bounds above are not vacuous', () => {
+    const scores = sequences.map((h) => scoreStatusHistory(h))
+    expect(Math.min(...scores)).toBe(0)
+    expect(Math.max(...scores)).toBe(1)
+  })
+
+  it('reads a status string into one observation per run that produced evidence', () => {
+    expect(outcomesFromStatusHistory('PFTS')).toEqual([
+      { failed: false, flakyWithinRun: false },
+      { failed: true, flakyWithinRun: false },
+      { failed: true, flakyWithinRun: false },
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The document
+// ---------------------------------------------------------------------------
+
+describe('analysing a run', () => {
+  const analysis = analyse(
+    run({ runId: 'run-4', startedAt: day(4), results: [result({ status: 'failed' })] }),
+    historyOf('PPP'),
+    { analysedAt: ANALYSED_AT },
+  )
+  const signal = analysis.tests[0]?.signal
+
+  it('produces a document the contract accepts', () => {
+    expect(() => parseAnalysis(analysis, 'analysis.json')).not.toThrow()
+    expect(analysis.schemaVersion).toBe(ANALYSIS_SCHEMA_VERSION)
+  })
+
+  it('carries the run’s identity, and the timestamp it was handed', () => {
+    expect(analysis).toMatchObject({
+      runId: 'run-4',
+      commitSha: 'abc1234',
+      branch: 'main',
+      analysedAt: ANALYSED_AT,
+    })
+  })
+
+  it('ends the status history with the run being analysed', () => {
+    expect(signal?.statusHistory).toBe('PPPF')
+  })
+
+  it('counts the failures at the end, which is what the streak rule reads', () => {
+    expect(signal?.consecutiveFailures).toBe(1)
+    expect(
+      analyse(run({ runId: 'r', startedAt: day(9) }), historyOf('PFF'), {
+        analysedAt: ANALYSED_AT,
+      }).tests[0]?.signal.consecutiveFailures,
+    ).toBe(0)
+  })
+
+  it('reports when the test was first seen and when it last passed', () => {
+    expect(signal).toMatchObject({ firstSeenAt: day(1), lastPassedAt: day(3), totalRuns: 4 })
+  })
+
+  it('reports no last pass when the retained history holds none', () => {
+    const never = analyse(run({ results: [result({ status: 'failed' })] }), emptyHistory(), {
+      analysedAt: ANALYSED_AT,
+    })
+    expect(never.tests[0]?.signal.lastPassedAt).toBeNull()
+  })
+
+  /** The agents filter; an analysis that dropped the passes would decide that for them. */
+  it('includes every test in the run, not only the failures', () => {
+    const both = analyse(
+      run({
+        results: [
+          result({ testId: 'a', status: 'passed' }),
+          result({ testId: 'b', status: 'failed' }),
+        ],
+      }),
+      emptyHistory(),
+      { analysedAt: ANALYSED_AT },
+    )
+    expect(both.tests.map((t) => t.result.testId)).toEqual(['a', 'b'])
+  })
+
+  it('passes the half-life through to the score', () => {
+    const options = { analysedAt: ANALYSED_AT }
+    const history = historyOf('PPPPPPPPP')
+    const recent = run({
+      runId: 'run-10',
+      startedAt: day(10),
+      results: [result({ status: 'failed' })],
+    })
+    expect(
+      analyse(recent, history, { ...options, halfLife: 2 }).tests[0]?.signal.flakinessScore,
+    ).toBeGreaterThan(
+      analyse(recent, history, { ...options, halfLife: 20 }).tests[0]?.signal.flakinessScore ?? 1,
+    )
+  })
+
+  it('passes the cap through, so a shorter window scores a shorter history', () => {
+    const capped = analyse(run({ runId: 'run-9', startedAt: day(9) }), historyOf('PFPFPFPF'), {
+      analysedAt: ANALYSED_AT,
+      cap: 3,
+    })
+    expect(capped.tests[0]?.signal.statusHistory).toHaveLength(3)
+  })
+
+  /**
+   * `statusHistory` shows the window; `totalRuns` says how much sits behind it.
+   * Reporting the window twice would tell a reader weighing the score that a
+   * test with a year of history and one with a fortnight are equally evidenced.
+   */
+  it('reports runs ever rather than runs retained', () => {
+    const capped = analyse(run({ runId: 'run-9', startedAt: day(9) }), historyOf('PFPFPFPF'), {
+      analysedAt: ANALYSED_AT,
+      cap: 3,
+    })
+    // Eight runs of `PFPFPFPF`, then a ninth that passed — of which three are kept.
+    expect(capped.tests[0]?.signal).toMatchObject({ totalRuns: 9, statusHistory: 'PFP' })
+  })
+})
+
+describe('whether the test is new, and whether there was any history', () => {
+  /**
+   * Read from the history as it stood *before* this run. Deriving it from the
+   * merged history breaks the moment the cap evicts a test's earliest entries —
+   * or the cap is 1, at which point every test in the suite reads as new.
+   */
+  it('calls a test new when this run is the first it appears in', () => {
+    const first = analyse(run(), emptyHistory(), { analysedAt: ANALYSED_AT })
+    expect(first.tests[0]?.signal.isNew).toBe(true)
+  })
+
+  it('does not call a test new because the cap evicted its earliest runs', () => {
+    const analysis = analyse(run({ runId: 'run-9', startedAt: day(9) }), historyOf('PPPPPPPP'), {
+      analysedAt: ANALYSED_AT,
+      cap: 1,
+    })
+    expect(analysis.tests[0]?.signal.isNew).toBe(false)
+  })
+
+  it('calls a test new even when other tests have history', () => {
+    const analysis = analyse(
+      run({ runId: 'run-9', startedAt: day(9), results: [result({ testId: 'brand new' })] }),
+      historyOf('PPPP'),
+      { analysedAt: ANALYSED_AT },
+    )
+    expect(analysis.tests[0]?.signal.isNew).toBe(true)
+    expect(analysis.historyAvailable).toBe(true)
+  })
+
+  /**
+   * A cache miss and a genuinely new suite are indistinguishable from `isNew`
+   * alone, which is why the document says which situation it was.
+   */
+  it('reports no history available on the first run there has ever been', () => {
+    const first = analyse(run(), emptyHistory(), { analysedAt: ANALYSED_AT })
+    expect(first).toMatchObject({ historyAvailable: false, historyDepth: 0 })
+  })
+
+  it('keeps the flag and the depth from ever disagreeing', () => {
+    for (const letters of ['', 'P', 'PPPP', 'PFPFPF']) {
+      const analysis = analyse(run({ runId: 'run-99', startedAt: day(20) }), historyOf(letters), {
+        analysedAt: ANALYSED_AT,
+      })
+      expect(analysis.historyAvailable, letters).toBe(analysis.historyDepth > 0)
+    }
+  })
+
+  /**
+   * Runs, not entries. A suite where one test has eight entries and the rest
+   * have one has still only been through eight runs, and the report says how
+   * much evidence there was rather than how it was spread.
+   */
+  it('counts distinct runs rather than entries', () => {
+    let history = emptyHistory()
+    history = mergeRun(
+      history,
+      run({ runId: 'a', results: [result({ testId: 'x' }), result({ testId: 'y' })] }),
+    )
+    history = mergeRun(
+      history,
+      run({ runId: 'b', startedAt: day(2), results: [result({ testId: 'x' })] }),
+    )
+    expect(historyDepth(history)).toBe(2)
+  })
+
+  it('counts nothing when there is nothing', () => {
+    expect(historyDepth(emptyHistory())).toBe(0)
+  })
+})

--- a/flakemetry-lib/analyze.ts
+++ b/flakemetry-lib/analyze.ts
@@ -1,0 +1,290 @@
+import {
+  ANALYSIS_SCHEMA_VERSION,
+  type AnalysedTest,
+  type Analysis,
+  type FlakySignal,
+  type History,
+  type HistoryEntry,
+  type TestHistory,
+  type TestRun,
+  type TestStatus,
+} from '@sentra/contracts'
+import { mergeRun } from './history.js'
+
+/**
+ * The scoring half of `flakemetry-lib`. Pure — no clock, no filesystem.
+ *
+ * One question decides the shape of everything here: **how much does this test
+ * alternate**, not how often it fails. A test that fails on every single run is
+ * broken, not flaky, and scoring it high would put every genuine regression into
+ * the `intermittent` bucket — which is the one mistake the whole two-axis
+ * taxonomy exists to prevent. So the score is built from *changes* of outcome,
+ * and the always-failing sequence lands at zero by construction rather than by a
+ * special case.
+ *
+ * The spelling is `analyse`, matching `analysedAt` and `AnalysedTest` next door
+ * in the contract. The npm script stays `flakemetry:analyze` because that name
+ * is already in the README and in an error message `parseAnalysis` prints.
+ *
+ * It is a scoring function over a few hundred booleans. The interesting work in
+ * this project is elsewhere, and this file is deliberately boring.
+ */
+
+// ---------------------------------------------------------------------------
+// Scoring
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs after which an observation counts half as much.
+ *
+ * Ten, because the question a report answers is "is this test unstable *now*".
+ * A test that thrashed a month ago and has been solid since should not read as
+ * flaky today, and one that started thrashing yesterday should — inside a
+ * working week of CI, not a quarter.
+ *
+ * Bounded by the retained window either way: at the default cap of 50 runs the
+ * oldest entry still counts for about 3% of the newest, so the tail is present
+ * without being able to outvote the present.
+ */
+export const DEFAULT_HALF_LIFE = 10
+
+/**
+ * One run's evidence, reduced to what the score reads.
+ *
+ * `flakyWithinRun` is kept separate from `failed` rather than folded into it
+ * because it is an alternation *by itself*: the test failed and passed inside a
+ * single run, which is the strongest intermittency evidence one run can produce
+ * and the only kind that leaves no trace in the pass/fail sequence.
+ */
+export interface Outcome {
+  failed: boolean
+  flakyWithinRun: boolean
+}
+
+/** A timeout is a failure that never reached its assertion. Both are failures for scoring. */
+const isFailure = (status: TestStatus): boolean => status === 'failed' || status === 'timedOut'
+
+const STATUS_LETTER: Record<TestStatus, string> = {
+  passed: 'P',
+  failed: 'F',
+  timedOut: 'T',
+  skipped: 'S',
+}
+
+/**
+ * Recency-weighted share of **transitions** that changed the outcome.
+ *
+ * A transition is a run with a run before it to differ from. The first run in a
+ * history is not one — it had no opportunity to alternate — and leaving it out
+ * of the denominator is what keeps the number interpretable as a share and what
+ * makes `PFPFPF` score exactly 1 rather than approaching it. A run that was
+ * flaky *within itself* is a transition even in first position: it failed and
+ * passed without needing a neighbour.
+ *
+ * Each transition weighs `0.5 ^ (age / halfLife)`, age counting backwards from
+ * the newest. Three consequences, and they are the whole point:
+ *
+ * - `FFFFFFFF` scores **0**. Nothing changed, so nothing alternated. The
+ *   broken-not-flaky case falls out of the definition instead of needing a rule.
+ * - `PFPFPFPF` scores **1**.
+ * - A test that alternated a month ago and has been stable since decays towards
+ *   0 without anybody deciding when to forget it.
+ *
+ * As the half-life grows the weights flatten, and in the limit this is exactly
+ * the plain alternation rate — the share of adjacent runs that differ. That is
+ * deliberate: the captured dataset fixtures were scored with the plain rate, so
+ * keeping it as the limiting case means recency weighting is the only thing that
+ * moved when they were rescored, rather than a second silent change to the
+ * denominator hiding inside the first.
+ *
+ * Skipped runs are dropped before scoring. A skip produced no evidence, and
+ * treating it as "did not fail" invents an alternation on *both* sides of it —
+ * a quarantined test would score as the flakiest thing in the suite.
+ *
+ * Rounded to two decimals, which is the precision the report and the prompt
+ * render anyway. An unrounded ratio would put `0.30000000000000004` into a
+ * committed fixture and into a cassette key.
+ */
+export function alternationScore(
+  outcomes: Outcome[],
+  halfLife: number = DEFAULT_HALF_LIFE,
+): number {
+  if (!Number.isFinite(halfLife) || halfLife <= 0) {
+    throw new RangeError(
+      `half-life must be a positive number of runs, received ${String(halfLife)}. ` +
+        'A half-life of zero weights every run but the newest at nothing, which is not a ' +
+        'trend, it is the last result.',
+    )
+  }
+
+  const decay = 0.5 ** (1 / halfLife)
+  let alternated = 0
+  let transitions = 0
+
+  outcomes.forEach((outcome, index) => {
+    const previous = outcomes[index - 1]
+    // Nothing to differ from, and nothing observed inside the run either.
+    if (previous === undefined && !outcome.flakyWithinRun) return
+
+    // The newest observation weighs 1; everything older decays from there.
+    const weight = decay ** (outcomes.length - 1 - index)
+    if (outcome.flakyWithinRun || (previous !== undefined && outcome.failed !== previous.failed)) {
+      alternated += weight
+    }
+    transitions += weight
+  })
+
+  // A single run that was not flaky within itself has nothing to divide by, and
+  // a test seen once is not evidence of instability either way.
+  if (transitions === 0) return 0
+  return Math.round((alternated / transitions) * 100) / 100
+}
+
+/** Retained runs, as the score reads them. */
+export function outcomesFromEntries(entries: HistoryEntry[]): Outcome[] {
+  return entries
+    .filter((entry) => entry.status !== 'skipped')
+    .map((entry) => ({ failed: isFailure(entry.status), flakyWithinRun: entry.flakyWithinRun }))
+}
+
+/**
+ * The same, for a history that survives only as a `statusHistory` string.
+ *
+ * Captured dataset fixtures keep the string and not the entries, and this is
+ * what lets them be scored by the same definition production uses rather than by
+ * a second one that drifts. Within-run retries are unrecoverable from a string,
+ * so they read as absent — which understates rather than invents.
+ */
+export function outcomesFromStatusHistory(history: string): Outcome[] {
+  return [...history]
+    .filter((letter) => letter !== 'S')
+    .map((letter) => ({ failed: letter === 'F' || letter === 'T', flakyWithinRun: false }))
+}
+
+/** Convenience for the one caller that has a string rather than entries. */
+export function scoreStatusHistory(history: string, halfLife: number = DEFAULT_HALF_LIFE): number {
+  return alternationScore(outcomesFromStatusHistory(history), halfLife)
+}
+
+// ---------------------------------------------------------------------------
+// The per-test signal
+// ---------------------------------------------------------------------------
+
+/**
+ * Failures at the end of the retained history, counted over the same runs the
+ * score reads.
+ *
+ * Skips are stepped over rather than treated as the end of a streak. A
+ * quarantined run tells you nothing about whether the test stopped failing, and
+ * resetting the streak on one would report a test as recovered because nobody
+ * ran it.
+ */
+function trailingFailures(outcomes: Outcome[]): number {
+  let count = 0
+  for (let i = outcomes.length - 1; i >= 0 && outcomes[i]?.failed === true; i -= 1) count += 1
+  return count
+}
+
+function signalFor(
+  testId: string,
+  record: TestHistory,
+  isNew: boolean,
+  halfLife: number,
+): FlakySignal {
+  const outcomes = outcomesFromEntries(record.entries)
+  const lastPassed = [...record.entries].reverse().find((entry) => entry.status === 'passed')
+
+  return {
+    testId,
+    flakinessScore: alternationScore(outcomes, halfLife),
+    consecutiveFailures: trailingFailures(outcomes),
+    // Runs ever, not runs retained. `statusHistory` shows the window; this says
+    // how much sits behind it, which is what a reader weighing the score needs.
+    totalRuns: record.totalRuns,
+    firstSeenAt: record.firstSeenAt,
+    lastPassedAt: lastPassed?.at ?? null,
+    statusHistory: record.entries.map((entry) => STATUS_LETTER[entry.status]).join(''),
+    isNew,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The document
+// ---------------------------------------------------------------------------
+
+export interface AnalyseOptions {
+  /**
+   * When this analysis was produced.
+   *
+   * A value rather than a clock, so the function stays pure and two runs of the
+   * evaluation over the same inputs produce byte-identical documents.
+   */
+  analysedAt: string
+  /** Defaults to {@link DEFAULT_HALF_LIFE}. */
+  halfLife?: number
+  /** Retained runs per test. Defaults to the history module's cap. */
+  cap?: number
+}
+
+/**
+ * Score a run against the history that existed **before** it.
+ *
+ * Pre-merge, deliberately. `isNew` means "the first run in which this test
+ * appears", and the only way to know that without corner cases is to look at
+ * what was there beforehand — deriving it from the merged history breaks the
+ * moment the cap evicts a test's earliest entries, or the cap is 1, or a job for
+ * an older commit is merged late.
+ *
+ * The merge happens here too, so the signal describes history *including* this
+ * run. The caller writes `mergeRun(history, run)` itself rather than getting it
+ * back: one function that scores and one that persists, so a report can be
+ * regenerated without touching the file, which is exactly what a pull-request
+ * job does.
+ */
+export function analyse(run: TestRun, history: History, options: AnalyseOptions): Analysis {
+  const halfLife = options.halfLife ?? DEFAULT_HALF_LIFE
+  const merged = mergeRun(history, run, options.cap === undefined ? {} : { cap: options.cap })
+
+  const tests: AnalysedTest[] = run.results.map((result) => ({
+    result,
+    signal: signalFor(
+      result.testId,
+      // `mergeRun` has just recorded every result in the run, so the fallback
+      // describes a test as this run alone rather than papering over a gap.
+      merged.tests[result.testId] ?? { firstSeenAt: run.startedAt, totalRuns: 1, entries: [] },
+      history.tests[result.testId] === undefined,
+      halfLife,
+    ),
+  }))
+
+  const depth = historyDepth(history)
+
+  return {
+    schemaVersion: ANALYSIS_SCHEMA_VERSION,
+    runId: run.runId,
+    commitSha: run.commitSha,
+    branch: run.branch,
+    analysedAt: options.analysedAt,
+    // Both read the history as it was before this run, so they cannot disagree:
+    // `historyAvailable` is false exactly when `historyDepth` is 0.
+    historyAvailable: depth > 0,
+    historyDepth: depth,
+    tests,
+  }
+}
+
+/**
+ * Distinct runs the history holds, across all tests.
+ *
+ * Not the entry count and not the deepest single test: a suite where one test
+ * has forty entries and the rest have one has still only been through forty
+ * runs, and the report says how much evidence there was, not how it was
+ * distributed.
+ */
+export function historyDepth(history: History): number {
+  const runs = new Set<string>()
+  for (const record of Object.values(history.tests)) {
+    for (const entry of record.entries) runs.add(entry.runId)
+  }
+  return runs.size
+}

--- a/flakemetry-lib/history.test.ts
+++ b/flakemetry-lib/history.test.ts
@@ -191,6 +191,28 @@ describe('merging a run', () => {
     expect(mergeRun(once, run())).toEqual(once)
   })
 
+  it('counts a run once however many times it is merged', () => {
+    let history = mergeRun(emptyHistory(), run())
+    expect(history.tests['tests/e2e/board.spec.ts›shows a row']?.totalRuns).toBe(1)
+    history = mergeRun(history, run({ results: [result({ status: 'failed' })] }))
+    expect(history.tests['tests/e2e/board.spec.ts›shows a row']?.totalRuns).toBe(1)
+    history = mergeRun(history, run({ runId: 'run-2', startedAt: day(2) }))
+    expect(history.tests['tests/e2e/board.spec.ts›shows a row']?.totalRuns).toBe(2)
+  })
+
+  it('counts per test, not per run, so a test the run skipped does not advance', () => {
+    let history = mergeRun(
+      emptyHistory(),
+      run({ results: [result({ testId: 'a' }), result({ testId: 'b' })] }),
+    )
+    history = mergeRun(
+      history,
+      run({ runId: 'run-2', startedAt: day(2), results: [result({ testId: 'a' })] }),
+    )
+    expect(history.tests.a?.totalRuns).toBe(2)
+    expect(history.tests.b?.totalRuns).toBe(1)
+  })
+
   it('does not modify the history it was given', () => {
     const before = mergeRun(emptyHistory(), run())
     const snapshot = structuredClone(before)
@@ -289,6 +311,19 @@ describe('the retained window', () => {
     const record = history.tests['tests/e2e/board.spec.ts›shows a row']
     expect(record?.firstSeenAt).toBe(day(1))
     expect(record?.entries[0]?.at).not.toBe(day(1))
+  })
+
+  /**
+   * The same eviction problem as `firstSeenAt`, one step further out. Count the
+   * entries instead and every test that has run more than the cap reports the
+   * cap, for ever — a year of history and a fortnight of it become the same
+   * number to anyone weighing how much is behind a score.
+   */
+  it('keeps counting runs after it has stopped keeping them', () => {
+    const history = overRuns(20, 5)
+    const record = history.tests['tests/e2e/board.spec.ts›shows a row']
+    expect(record?.totalRuns).toBe(20)
+    expect(record?.entries).toHaveLength(5)
   })
 
   it('defaults to a documented cap rather than to unbounded growth', () => {

--- a/flakemetry-lib/history.ts
+++ b/flakemetry-lib/history.ts
@@ -131,7 +131,8 @@ export function readHistory(file: string = HISTORY_FILE): History {
  * 2. An entry already carrying this `runId` is **replaced**, not duplicated, so
  *    re-analysing the same report twice leaves the same history.
  * 3. Tests in the history and not in the run are untouched.
- * 4. `firstSeenAt` only ever moves earlier.
+ * 4. `firstSeenAt` only ever moves earlier, and `totalRuns` counts every run
+ *    ever recorded — both survive the eviction that `entries` does not.
  * 5. Entries are ordered by run start time, not by arrival, so a job for an
  *    older commit finishing late cannot make its result the most recent one.
  *    `consecutiveFailures` reads the tail of that order; getting it wrong would
@@ -158,9 +159,14 @@ export function mergeRun(history: History, run: TestRun, options: MergeOptions =
       flakyWithinRun: result.flakyWithinRun,
     }
     const kept = (previous?.entries ?? []).filter((e) => e.runId !== run.runId)
+    // Only a run this test has not been recorded in before adds to the lifetime
+    // count. Re-merging a report must leave the number where it was, for the
+    // same reason it must not append a second entry.
+    const alreadyRecorded = (previous?.entries.length ?? 0) !== kept.length
 
     tests[result.testId] = {
       firstSeenAt: earlier(previous?.firstSeenAt, run.startedAt),
+      totalRuns: (previous?.totalRuns ?? 0) + (alreadyRecorded ? 0 : 1),
       entries: ordered([...kept, entry]).slice(-cap),
     }
   }

--- a/flakemetry-lib/index.ts
+++ b/flakemetry-lib/index.ts
@@ -3,9 +3,10 @@
  *
  * Flakiness scoring and run history. Reads a normalised test run plus the stored history and emits a per-test signal.
  *
- * The scoring half lands in #58; what is here is the history the scoring reads —
- * the file that carries the `determinism` axis from one ephemeral CI job to the
- * next.
+ * Two halves. `history.ts` carries the `determinism` axis from one ephemeral CI
+ * job to the next; `analyze.ts` scores a run against it. The split is the seam
+ * a pull-request job needs: it reads history and scores, and never writes.
  */
 
 export * from './history.js'
+export * from './analyze.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
       "dependencies": {
         "@sentra/agents": "*",
         "@sentra/contracts": "*",
+        "@sentra/flakemetry": "*",
         "@sentra/prompts": "*"
       }
     },

--- a/scripts/capture.ts
+++ b/scripts/capture.ts
@@ -7,6 +7,7 @@ import {
   type TestResult,
   type TestRun,
 } from '@sentra/contracts'
+import { scoreStatusHistory } from '@sentra/flakemetry'
 
 /**
  * `npm run capture` — turn real Playwright reports into golden-dataset payloads.
@@ -150,22 +151,20 @@ export interface Signal {
 /**
  * A signal from what the runs actually did.
  *
- * `flakinessScore` is the share of adjacent runs whose outcome differs. That is
- * a reading of "alternation" and not the EWMA `docs/architecture.md` specifies —
- * the real definition arrives with `flakemetry-lib` in M6 (#57), and every
- * captured signal is recomputed in the commit that introduces it. The dataset
- * README says so next to the fixtures rather than only here.
+ * `flakinessScore` comes from `@sentra/flakemetry` rather than from a second
+ * implementation here. It used to be a local one — the plain share of adjacent
+ * runs whose outcome differs — because the real definition did not exist yet,
+ * and a fixture scored by a rule production does not use is a fixture that
+ * measures the pipeline's inputs instead of the pipeline.
+ *
+ * The streak is counted over `[FT]` because a timeout is a failure that never
+ * reached its assertion, which is the same rule `analyse` applies.
  */
 export function signalFrom(history: string): Signal {
-  const runs = [...history]
-  const alternations = runs.filter(
-    (status, index) => index > 0 && status !== runs[index - 1],
-  ).length
-
   return {
-    flakinessScore: runs.length < 2 ? 0 : Number((alternations / (runs.length - 1)).toFixed(2)),
-    consecutiveFailures: (/F*$/.exec(history)?.[0] ?? '').length,
-    totalRuns: runs.length,
+    flakinessScore: scoreStatusHistory(history),
+    consecutiveFailures: (/[FT]*$/.exec(history)?.[0] ?? '').length,
+    totalRuns: history.length,
     statusHistory: history,
   }
 }


### PR DESCRIPTION
Closes #58. Also does the dataset rescoring the golden-dataset README has promised since the fixtures were written — and that turned out to be the interesting half.

## The definition

A **transition** is a run with a run before it to differ from. The score is the recency-weighted share of transitions that changed the outcome, each weighing `0.5 ^ (age / halfLife)` with age counting back from the newest. Half-life ten runs, configurable.

Everything else follows from choosing *changes* rather than *failures*:

| History | Score | |
|---|---|---|
| `FFFFFFFF` | **0** | broken, not flaky — falls out of the definition rather than needing a rule |
| `PFPFPFPF` | **1** | at any length |
| `PPPPPPPPPF` | 0.14 | one change, at the newest run |
| `PFFFFFFFFF` | 0.08 | the same single change, nine runs ago |

The always-failing case is the one that matters. Score by failure rate and every genuine regression lands in the `intermittent` bucket, which is exactly what the two-axis taxonomy exists to prevent.

**The limit is load-bearing.** As the half-life grows the weights flatten and the score becomes exactly the plain alternation rate — which is what the fixtures were scored with before. That is deliberate and pinned by a test: it means recency weighting is the *only* thing that moved when they were rescored, rather than a second silent change hiding in the denominator where nobody could attribute it afterwards.

Two smaller decisions with the same shape. **Skipped runs are dropped** — a skip produced no evidence, and reading it as "did not fail" invents an alternation on *both* sides of it, so a quarantined test would score as the flakiest thing in the suite. **A run that was flaky within itself is a transition even in first position** — it failed and passed without needing a neighbour, and it is the one alternation a status string cannot express.

## `totalRuns` — the same eviction bug, one step further out

Found by comparing what `analyse` would emit against what the dataset already said. Synthetic fixtures carry `totalRuns: 214` against a 17-run history, which is the lifetime reading — and `analyse` would have returned the window.

Count the entries and every test that has run more than the cap reports the cap, for ever. A reader weighing a score is told that a year of history and a fortnight of it are equally evidenced. Same lesson as `firstSeenAt` in #57, so `TestHistory` gains a counter that survives eviction, incremented only for a `runId` the test has not been recorded in.

No file of schema version 1 can exist yet — nothing writes one until #59 — so this is an addition to a format with no readers rather than a break.

## The dataset was scored by a rule nothing used

`scripts/capture.ts` had its own scoring function, written before the real one existed. The synthetic fixtures did not use even that: their scores were picked by hand.

```
PPPPPPPFFF   0.03  (assertion-pins-reworded-empty-state)
PPPPPPPFFF   0.29  (completion-lost-when-two-updates-overlap)
PPPPPPPPFF   0.06  (port-still-held-by-the-previous-job)
PPPPPPPPFF   0.21  (token-refresh-cancels-in-flight-save)
```

Identical histories, different scores. No definition produces both, so at most one of each pair could ever have matched production — and a dataset scored by a rule production does not use measures the fixtures rather than the classifier.

**36 scores rewritten, 2 failure streaks corrected** (both claimed a streak of 1 for a history ending in `P`). `capture.ts` now scores through the shared function, so there is one definition.

`eval:lint` gained `checkSignal`, which fails when a committed fixture's `flakinessScore` or `consecutiveFailures` disagrees with its own `statusHistory` under the shared definition. Arithmetic has one right answer; this is what stops the drift returning quietly.

## What is left, and why it is not here

Eight histories end somewhere production cannot put them — `analyse` always ends the history with the run being triaged, and four of these end in `P` for a test that failed. `eval:lint` warns about each by name and a test pins the list at exactly those eight, so a ninth goes red.

They are not fixed here because it is not arithmetic. Appending a letter changes the history the classifier reads, and a longer history can change what the right answer *is* — so each label needs re-checking against the corrected history. **#177** tracks it.

## The baseline numbers do not move

Not one of them. `eval/metrics.json` changes by exactly one line, the dataset revision hash.

The reason is worth stating rather than celebrating: the baseline heuristic reads `consecutiveFailures` and `statusHistory` and **never looks at `flakinessScore` at all**. So rescoring changed what the agent will see and nothing about what the control decides. That is a useful thing to know before #79 asks whether history context earns its place — the control has already answered for its own half.

## Testing

1691 tests. `flakemetry-lib` at 100% statements/functions/lines; the one uncovered branch is the `??` on an indexed access that `mergeRun` has just written.

The property test is **exhaustive rather than sampled**: every pass/fail history up to thirteen runs, 16382 sequences, checked to stay within 0..1 — and checked to *reach* both ends, so the bounds are not vacuous. A seeded generator would only ever have proved something about the seed.

Eight mutations, all caught:

| Mutation | Caught by |
|---|---|
| Score failures instead of alternations | 6 table rows |
| Remove recency weighting | 6 tests |
| Count the first run as a transition | 6 table rows |
| Read skipped runs as passes | `drops skipped runs rather than reading them as passes` |
| Ignore the within-run retry | `counts a within-run retry as an alternation` |
| Treat a timeout as a pass | `treats a timeout as a failure when it arrives as an entry` |
| `totalRuns` reads the window | `reports runs ever rather than runs retained` |
| `isNew` derived from the merged history | `does not call a test new because the cap evicted its earliest runs` |

The timeout mutation **survived the first version**. `isFailure` and the string reader are two paths to the same rule, and only the string one was covered — so a timeout arriving as a history *entry* could have been scored as a pass, and the failure streak of a test that had been hanging for a week would have read as zero. The test now goes through `analyse`.
