### PR TITLE
fix(dataset): four fixtures described a run no reporter can produce

### DIFF
--- a/eval/dataset.test.ts
+++ b/eval/dataset.test.ts
@@ -38,10 +38,23 @@ describe('the golden dataset', () => {
   })
 
   it('describes a failure in every payload', () => {
-    // A fixture whose subject passed has nothing to classify.
     for (const { name, payload } of payloads) {
-      expect(['failed', 'timedOut'], name).toContain(payload.subject.result.status)
-      expect(payload.subject.result.error?.message, name).toBeTruthy()
+      const { status, flakyWithinRun, error } = payload.subject.result
+      /**
+       * A green run is still triageable when it only got there on a retry.
+       * `selectForTriage` has a clause for exactly that, and it is the clearest
+       * intermittency evidence a single run can carry — the alternation happened
+       * where the pass/fail sequence cannot show it.
+       *
+       * This read `['failed', 'timedOut']` until #177, which is why four
+       * fixtures had been carrying `failed` beside `flakyWithinRun: true` — a
+       * combination the Playwright normaliser cannot produce, because the flag
+       * is derived from the final attempt having passed.
+       */
+      expect(status === 'failed' || status === 'timedOut' || flakyWithinRun, name).toBe(true)
+      // Either way there is a failure to explain: a retried test keeps the error
+      // from the attempt that failed, which is what the normaliser preserves.
+      expect(error?.message, name).toBeTruthy()
     }
   })
 })

--- a/eval/golden-dataset/README.md
+++ b/eval/golden-dataset/README.md
@@ -88,10 +88,20 @@ That check exists because the alternative had already happened. Before the scori
 `PPPPPPPFFF` carried `0.03` and `0.29`, which no definition produces both of. A dataset scored by a
 rule production does not use measures the fixtures rather than the classifier.
 
-Eight histories still end somewhere production cannot put them — `analyse` always ends the history
-with the run being triaged. `eval:lint` warns about each by name; #177 tracks fixing them, and it is
-a labelling job rather than an arithmetic one, because a longer history can change what the right
-answer is.
+**And a run the reporters could have produced.** `eval:lint` also fails when a fixture's
+`statusHistory` does not end with the run being triaged, or when it claims the run passed on a later
+attempt while recording the run as failed.
+
+The second of those had happened four times, all in the hard quadrant. `flakyWithinRun` is derived
+from the final attempt having succeeded, so `failed` beside "passed on a later attempt: yes" is not
+a rare combination but an impossible one — and the context bundle renders both facts a line apart,
+so the classifier was being handed a contradiction on the cases the dataset is hardest on. Their
+justifications had said "which is why the retry passed" all along; the status was what disagreed.
+
+**A fixture whose run ended green is still a fixture.** A test that only got there on a retry is
+selected for triage by its own clause in `selectForTriage`, and it is the clearest intermittency
+evidence a single run can carry — the alternation happened where the pass/fail sequence cannot show
+it.
 
 ## Target composition
 

--- a/eval/golden-dataset/button-lookup-uses-superseded-label.run.json
+++ b/eval/golden-dataset/button-lookup-uses-superseded-label.run.json
@@ -19,12 +19,12 @@
     },
     "signal": {
       "testId": "tests/e2e/board.spec.ts›board › creates a task from the toolbar",
-      "flakinessScore": 0.11,
-      "consecutiveFailures": 3,
-      "totalRuns": 73,
+      "flakinessScore": 0.1,
+      "consecutiveFailures": 4,
+      "totalRuns": 74,
       "firstSeenAt": "2026-05-14T08:12:04.000Z",
       "lastPassedAt": "2026-08-07T09:41:12.000Z",
-      "statusHistory": "PPPPPPPPPFFF",
+      "statusHistory": "PPPPPPPPPFFFT",
       "isNew": false
     }
   },

--- a/eval/golden-dataset/control-shows-earlier-state-after-quick-toggle.run.json
+++ b/eval/golden-dataset/control-shows-earlier-state-after-quick-toggle.run.json
@@ -19,12 +19,12 @@
     },
     "signal": {
       "testId": "tests/e2e/board.spec.ts›board › the control reflects the final state after two quick toggles",
-      "flakinessScore": 0.59,
-      "consecutiveFailures": 0,
-      "totalRuns": 91,
+      "flakinessScore": 0.64,
+      "consecutiveFailures": 1,
+      "totalRuns": 92,
       "firstSeenAt": "2026-04-02T07:31:19.000Z",
       "lastPassedAt": "2026-08-10T08:13:57.000Z",
-      "statusHistory": "PFPPPFPPFPP",
+      "statusHistory": "PFPPPFPPFPPT",
       "isNew": false
     }
   },

--- a/eval/golden-dataset/debounced-save-skips-final-keystroke.run.json
+++ b/eval/golden-dataset/debounced-save-skips-final-keystroke.run.json
@@ -6,7 +6,7 @@
       "testId": "tests/e2e/editor.spec.ts›editor › keeps every character typed before closing",
       "title": "editor › keeps every character typed before closing",
       "file": "tests/e2e/editor.spec.ts",
-      "status": "timedOut",
+      "status": "passed",
       "attempts": 2,
       "flakyWithinRun": true,
       "durationMs": 8890,
@@ -19,12 +19,12 @@
     },
     "signal": {
       "testId": "tests/e2e/editor.spec.ts›editor › keeps every character typed before closing",
-      "flakinessScore": 0.55,
-      "consecutiveFailures": 1,
-      "totalRuns": 88,
+      "flakinessScore": 0.61,
+      "consecutiveFailures": 0,
+      "totalRuns": 89,
       "firstSeenAt": "2026-04-02T07:31:19.000Z",
       "lastPassedAt": "2026-08-10T09:01:48.000Z",
-      "statusHistory": "PPFPPFPPPF",
+      "statusHistory": "PPFPPFPPPFP",
       "isNew": false
     }
   },

--- a/eval/golden-dataset/delete-resurrected-by-in-flight-refetch.run.json
+++ b/eval/golden-dataset/delete-resurrected-by-in-flight-refetch.run.json
@@ -6,7 +6,7 @@
       "testId": "tests/e2e/board.spec.ts›board › a deleted task stays deleted",
       "title": "board › a deleted task stays deleted",
       "file": "tests/e2e/board.spec.ts",
-      "status": "failed",
+      "status": "passed",
       "attempts": 2,
       "flakyWithinRun": true,
       "durationMs": 7180,
@@ -19,12 +19,12 @@
     },
     "signal": {
       "testId": "tests/e2e/board.spec.ts›board › a deleted task stays deleted",
-      "flakinessScore": 0.66,
+      "flakinessScore": 0.57,
       "consecutiveFailures": 0,
-      "totalRuns": 83,
+      "totalRuns": 84,
       "firstSeenAt": "2026-04-02T07:31:19.000Z",
       "lastPassedAt": "2026-08-10T07:55:31.000Z",
-      "statusHistory": "PFPPFPPPFP",
+      "statusHistory": "PFPPFPPPFPP",
       "isNew": false
     }
   },

--- a/eval/golden-dataset/duplicate-key-when-two-clients-create-at-once.run.json
+++ b/eval/golden-dataset/duplicate-key-when-two-clients-create-at-once.run.json
@@ -6,7 +6,7 @@
       "testId": "tests/unit/tasks.repository.test.ts›createTask › gives concurrent callers distinct identifiers",
       "title": "createTask › gives concurrent callers distinct identifiers",
       "file": "tests/unit/tasks.repository.test.ts",
-      "status": "failed",
+      "status": "passed",
       "attempts": 2,
       "flakyWithinRun": true,
       "durationMs": 64,
@@ -19,12 +19,12 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.repository.test.ts›createTask › gives concurrent callers distinct identifiers",
-      "flakinessScore": 0.45,
+      "flakinessScore": 0.39,
       "consecutiveFailures": 0,
-      "totalRuns": 67,
+      "totalRuns": 68,
       "firstSeenAt": "2026-04-02T07:31:19.000Z",
       "lastPassedAt": "2026-08-10T05:40:09.000Z",
-      "statusHistory": "PPPPFPFPPP",
+      "statusHistory": "PPPPFPFPPPP",
       "isNew": false
     }
   },

--- a/eval/golden-dataset/locator-still-uses-retired-test-id.run.json
+++ b/eval/golden-dataset/locator-still-uses-retired-test-id.run.json
@@ -19,12 +19,12 @@
     },
     "signal": {
       "testId": "tests/e2e/board.spec.ts›board › opens the editor for a task",
-      "flakinessScore": 0.09,
-      "consecutiveFailures": 4,
-      "totalRuns": 91,
+      "flakinessScore": 0.08,
+      "consecutiveFailures": 5,
+      "totalRuns": 92,
       "firstSeenAt": "2026-05-14T08:12:04.000Z",
       "lastPassedAt": "2026-08-07T09:41:12.000Z",
-      "statusHistory": "PPPPPPPPPPFFFF",
+      "statusHistory": "PPPPPPPPPPFFFFT",
       "isNew": false
     }
   },

--- a/eval/golden-dataset/proxy-answers-a-data-request-with-a-login-page.run.json
+++ b/eval/golden-dataset/proxy-answers-a-data-request-with-a-login-page.run.json
@@ -6,7 +6,7 @@
       "testId": "tests/unit/tasks.client.test.ts›client › parses the task list",
       "title": "client › parses the task list",
       "file": "tests/unit/tasks.client.test.ts",
-      "status": "failed",
+      "status": "passed",
       "attempts": 2,
       "flakyWithinRun": true,
       "durationMs": 642,
@@ -19,12 +19,12 @@
     },
     "signal": {
       "testId": "tests/unit/tasks.client.test.ts›client › parses the task list",
-      "flakinessScore": 0.43,
+      "flakinessScore": 0.38,
       "consecutiveFailures": 0,
-      "totalRuns": 131,
+      "totalRuns": 132,
       "firstSeenAt": "2026-02-11T09:03:47.000Z",
       "lastPassedAt": "2026-08-10T09:22:11.000Z",
-      "statusHistory": "PPPFPPPPPFP",
+      "statusHistory": "PPPFPPPPPFPP",
       "isNew": false
     }
   },

--- a/eval/golden-dataset/reorder-reconciliation-overwrites-later-drag.run.json
+++ b/eval/golden-dataset/reorder-reconciliation-overwrites-later-drag.run.json
@@ -19,12 +19,12 @@
     },
     "signal": {
       "testId": "tests/e2e/board.spec.ts›board › reordering twice in quick succession keeps the second order",
-      "flakinessScore": 0.63,
-      "consecutiveFailures": 0,
-      "totalRuns": 96,
+      "flakinessScore": 0.68,
+      "consecutiveFailures": 1,
+      "totalRuns": 97,
       "firstSeenAt": "2026-04-02T07:31:19.000Z",
       "lastPassedAt": "2026-08-09T18:02:44.000Z",
-      "statusHistory": "PPFPPPFPPFP",
+      "statusHistory": "PPFPPPFPPFPF",
       "isNew": false
     }
   },

--- a/eval/hygiene.test.ts
+++ b/eval/hygiene.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 import type { Bucket, FixtureLabels } from '@sentra/contracts'
 import { describe, expect, it } from 'vitest'
 import { checkComposition, checkLeakage, runHygiene } from './hygiene.js'
-import { loadPayload } from './dataset.js'
+import { listFixtures, loadPayload } from './dataset.js'
 
 const real = loadPayload('create-task-returns-ok-instead-of-created').payload
 
@@ -150,6 +150,7 @@ describe('runHygiene against a directory', () => {
 
 describe('the committed dataset', () => {
   const report = runHygiene()
+  const names = listFixtures()
 
   it('has no leakage or pairing problems', () => {
     expect(report.errors).toEqual([])
@@ -169,23 +170,23 @@ describe('the committed dataset', () => {
   })
 
   /**
-   * Pinned, not tolerated. These eight are #177's list; a ninth would mean a new
-   * fixture was written with a history that ends somewhere production cannot put
-   * it, and this is where that gets noticed rather than in the next audit.
+   * Every fixture describes a run the reporters could have produced. This was a
+   * list of eight known-broken names until #177; it is an assertion now, which
+   * is the difference between a defect that is tracked and one that cannot
+   * recur.
    */
-  it('has exactly the eight histories that #177 is open about', () => {
-    expect(report.warnings.filter((w) => w.message.includes('#177')).map((w) => w.fixture)).toEqual(
-      [
-        'button-lookup-uses-superseded-label',
-        'control-shows-earlier-state-after-quick-toggle',
-        'debounced-save-skips-final-keystroke',
-        'delete-resurrected-by-in-flight-refetch',
-        'duplicate-key-when-two-clients-create-at-once',
-        'locator-still-uses-retired-test-id',
-        'proxy-answers-a-data-request-with-a-login-page',
-        'reorder-reconciliation-overwrites-later-drag',
-      ],
-    )
+  it('describes only runs the reporters could have produced', () => {
+    expect(report.errors.filter((e) => e.message.includes('history ends in'))).toEqual([])
+    expect(report.errors.filter((e) => e.message.includes('flakyWithinRun'))).toEqual([])
+  })
+
+  /** The four that carried `failed` beside "passed on a later attempt: yes". */
+  it('has four tests that passed on a retry, and none of them says it failed', () => {
+    const retried = names.filter((n) => loadPayload(n).payload.subject.result.flakyWithinRun)
+    expect(retried).toHaveLength(4)
+    for (const name of retried) {
+      expect(loadPayload(name).payload.subject.result.status, name).toBe('passed')
+    }
   })
 
   it('is still below the size where composition is enforced', () => {

--- a/eval/hygiene.ts
+++ b/eval/hygiene.ts
@@ -187,19 +187,45 @@ export function checkSignal(name: string, payload: FixturePayload): Finding[] {
   return findings
 }
 
-/** Separated from {@link checkSignal} because it is a labelling question, not arithmetic. */
-export function checkHistoryEndsWithRun(name: string, payload: FixturePayload): Finding[] {
+/**
+ * A fixture has to describe a run the reporters could have produced.
+ *
+ * Two invariants, both of which the normalisers guarantee for real data and
+ * neither of which a hand-written payload gets for free. Both were violated
+ * before #177.
+ *
+ * **The history ends with the run being triaged.** `analyse` builds it that way,
+ * so a fixture ending anywhere else is a shape production cannot emit.
+ *
+ * **A test that passed on a later attempt passed.** `flakyWithinRun` is set only
+ * when the final attempt succeeded — `contracts/reporters/playwright.ts` derives
+ * it from exactly that — so `failed` beside `passed on a later attempt: yes` is
+ * not a rare combination, it is an impossible one. Four hard-quadrant fixtures
+ * carried it, and the bundle renders both facts a line apart, which means the
+ * classifier was being asked to reason about a contradiction on the cases the
+ * dataset is hardest on.
+ */
+export function checkRunIsPossible(name: string, payload: FixturePayload): Finding[] {
   const { signal, result } = payload.subject
+  const findings: Finding[] = []
+
   const expected = STATUS_LETTER[result.status] ?? '?'
   const actual = signal.statusHistory.slice(-1)
-  return actual === expected
-    ? []
-    : [
-        {
-          fixture: name,
-          message: `history ends in ${actual} but the run being triaged ${result.status} — analyse() always ends it with this run (#177)`,
-        },
-      ]
+  if (actual !== expected) {
+    findings.push({
+      fixture: name,
+      message: `history ends in ${actual} but the run being triaged ${result.status} — analyse() always ends it with this run`,
+    })
+  }
+
+  if (result.flakyWithinRun && result.status !== 'passed') {
+    findings.push({
+      fixture: name,
+      message: `flakyWithinRun is true but the run ${result.status} — a later attempt passing is what makes the run pass`,
+    })
+  }
+
+  return findings
 }
 
 function excerpt(text: string, term: RegExp): string {
@@ -238,7 +264,7 @@ export function runHygiene(dir: string = DATASET_DIR): HygieneReport {
     const { payload } = loadPayload(name, dir)
     errors.push(...checkLeakage(name, payload))
     errors.push(...checkSignal(name, payload))
-    warnings.push(...checkHistoryEndsWithRun(name, payload))
+    errors.push(...checkRunIsPossible(name, payload))
 
     const label = loadLabels(name, dir)
     labels.push(label)

--- a/eval/metrics.json
+++ b/eval/metrics.json
@@ -3,7 +3,7 @@
   "classifier": "baseline",
   "promptVersion": null,
   "slice": "dev",
-  "datasetRevision": "27afa05e78187a00",
+  "datasetRevision": "08b6da23ebcfe892",
   "n": 26,
   "joint": {
     "point": 0.34615384615384615,

--- a/eval/report.md
+++ b/eval/report.md
@@ -10,7 +10,7 @@
 | model                  | none — a heuristic, no model call    |
 | prompt version         | none                                 |
 | dataset                | 27 fixtures in `eval/golden-dataset` |
-| dataset revision       | `27afa05e78187a00`                   |
+| dataset revision       | `08b6da23ebcfe892`                   |
 | slice                  | `dev`                                |
 | samples per fixture    | 1                                    |
 | scored in the headline | 26 (1 excluded)                      |


### PR DESCRIPTION
Closes #177 — which was filed for the history tails, and turned out to be sitting on top of something worse in four of the same fixtures.

## What #177 was filed for

Eight histories did not end with the run being triaged. `analyse` always builds the history including the run it is scoring, so four of these — ending in `P` for a test that failed — were shapes production cannot emit at all.

Each now ends with this run's letter, **appended rather than overwritten**. Appending is the conservative reading: it keeps everything the author wrote about the prior runs and adds only what the invariant requires. Overwriting the last letter would delete a pass somebody chose to put there, and for the three histories ending `...PP` it would have been plainly wrong.

Timeouts are recorded as `T` rather than folded into `F`. `TestStatusSchema` keeps that distinction on purpose — a timeout means the assertion was never reached, which is evidence for `environment` or an unsynchronised test, and quite different from an assertion that ran and disagreed.

## What was underneath it

Four of the eight carried **`flakyWithinRun: true` beside a status of `failed` or `timedOut`**.

That is not a rare combination. It is an impossible one:

```ts
// contracts/reporters/playwright.ts
const passedAfterFailing =
  status === 'passed' && attempts.some((r) => r.status === 'failed' || r.status === 'timedOut')

flakyWithinRun: test.status === 'flaky' || passedAfterFailing,
```

The flag is derived from the final attempt having succeeded. Playwright's own `flaky` means the same thing. So a run with `flakyWithinRun: true` passed, by construction — no report can say otherwise.

And the context bundle renders both facts a line apart:

```
- status: failed
- attempts in this run: 2
- passed on a later attempt: yes
```

So the classifier was being handed a flat contradiction — on four **hard-quadrant** fixtures, which is exactly where the dataset is meant to be hard for the right reasons.

## Which field was wrong is not a guess

All four justifications were already written around the retry:

> …which is why the retry passed.
> The obvious reading is an unstable spec, **because it passed on the second attempt**.
> …which is why the same spec passed on its retry.
> …which is why the retry in the same run passed once the interception window closed.

The author meant a test that failed and then passed. `flakyWithinRun` was the intended fact; the status was the error. So the status is what changed, and the justifications now agree with the payloads instead of contradicting them.

| Fixture | Status | History |
|---|---|---|
| `button-lookup-uses-superseded-label` | timedOut | `PPPPPPPPPFFF` → `PPPPPPPPPFFFT` |
| `control-shows-earlier-state-after-quick-toggle` | timedOut | `PFPPPFPPFPP` → `PFPPPFPPFPPT` |
| `debounced-save-skips-final-keystroke` | timedOut → **passed** | `PPFPPFPPPF` → `PPFPPFPPPFP` |
| `delete-resurrected-by-in-flight-refetch` | failed → **passed** | `PFPPFPPPFP` → `PFPPFPPPFPP` |
| `duplicate-key-when-two-clients-create-at-once` | failed → **passed** | `PPPPFPFPPP` → `PPPPFPFPPPP` |
| `locator-still-uses-retired-test-id` | timedOut | `PPPPPPPPPPFFFF` → `PPPPPPPPPPFFFFT` |
| `proxy-answers-a-data-request-with-a-login-page` | failed → **passed** | `PPPFPPPPPFP` → `PPPFPPPPPFPP` |
| `reorder-reconciliation-overwrites-later-drag` | failed | `PPFPPPFPPFP` → `PPFPPPFPPFPF` |

Scores and streaks recomputed from the corrected histories; `totalRuns` incremented, since each gained a run. **No ground-truth label moved.** Passing on retry is the strongest evidence for `intermittent` there is, so the four it applies to are more clearly what they were labelled, not less.

## The assertion that let them in

```ts
// A fixture whose subject passed has nothing to classify.
expect(['failed', 'timedOut'], name).toContain(payload.subject.result.status)
```

That is wrong, and it is wrong in an interesting way. `selectForTriage` has a clause for `flakyWithinRun` specifically so that a run which ended green still gets triaged:

```ts
t.result.status === 'failed' || t.result.status === 'timedOut' || t.result.flakyWithinRun || …
```

A test that only got there on a retry is the clearest intermittency evidence a single run can carry — the alternation happened where the pass/fail sequence cannot show it. A dataset that excludes those excludes the case the pipeline is best placed to catch. The assertion now matches `selectForTriage`, and the error is still required either way, because a retried test keeps the failure from the attempt that failed.

## The checks are errors now

`checkHistoryEndsWithRun` was a warning listing eight names to remember. It is `checkRunIsPossible` now, it covers both invariants, and both are errors. Reintroducing either state fails the lint with the fixture named:

```
error    delete-resurrected-by-in-flight-refetch: history ends in P but the run being triaged failed
error    delete-resurrected-by-in-flight-refetch: flakyWithinRun is true but the run failed
```

Verified by putting the defect back and watching `eval:lint` exit 1, not by reading the code.

## The baseline numbers do not move

Again — `eval/metrics.json` changes by one line, the dataset revision hash. The baseline reads `result.status` only as fallback evidence text when there is no error message, and every one of these carries one.

Two consecutive dataset repairs with no movement in the control is itself a result worth having on record before #38 publishes agent numbers against it: the control's answers do not depend on the fields that were wrong.

1692 tests.
