### PR TITLE
feat(flakemetry): one command from test reports to analysis.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ cat eval/report.md
 | `npm run test:coverage`      | M2        | Vitest with coverage, enforcing the floor in vitest.config.ts                     |
 | `npm run test:e2e`           | M5        | Playwright — TaskFlow UI flows, one server per worker; emits results.json         |
 | `npm test`                   | M5        | Unit and E2E together                                                             |
-| `npm run flakemetry:analyze` | M6 🚧     | Test report + history → analysis.json                                             |
+| `npm run flakemetry:analyze` | M6        | Test report + history → analysis.json                                             |
 | `npm run agents:analyze`     | M7 🚧     | analysis.json → report.md                                                         |
 | `npm run analyze`            | M8 🚧     | flakemetry and agents in sequence                                                 |
 | `npm run capture`            | M5        | Turn a real Playwright report into golden-dataset payloads                        |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -185,6 +185,31 @@ missing file is an empty history, not an error; a file that exists and cannot be
 an error, because treating it as empty would hide the one symptom that says something is writing
 the file wrongly.
 
+#### The command
+
+```
+npm run flakemetry:analyze [-- --report <path>… --history <path> --out <path> --write-history]
+```
+
+Defaults to reading both `results.json` and `results-unit.json` when they exist — a default that is
+absent is a suite that did not run in this job, while a path somebody typed and got wrong is a
+mistake worth stopping for. The two are analysed separately against the same history and their
+results concatenated rather than merged into a single `TestRun` first, because a merged run would
+need one value for `source` and there is no honest one.
+
+**History is written only with `--write-history`.** ADR-0004 confines writes to `main`, and
+read-only is the direction for a flag to be forgotten in: a default that persisted would have every
+pull-request job contribute its own branch's failures to the history that judges the next one.
+
+**It exits 0 when tests failed.** The command describes a run, and a run full of failures is the
+case it exists for. A non-zero exit would stop the pipeline exactly where it should be producing its
+most useful output, and CI already knows the suite went red from the suite.
+
+When CI supplies no `GITHUB_RUN_ID`, the run's identity is a hash of the reports rather than
+anything drawn from the clock or the process. `mergeRun` keys idempotency on `runId`, so a local id
+that moved between invocations would append a second entry for every test and double the history —
+the exact double-counting the id exists to prevent.
+
 ### 3. `analysis.json` → agent inputs
 
 For each failing or newly-flaky test the orchestrator assembles a **context bundle**:

--- a/eval/metrics.test.ts
+++ b/eval/metrics.test.ts
@@ -64,10 +64,20 @@ describe('wilsonInterval against published values', () => {
 })
 
 describe('wilsonInterval against an independent derivation', () => {
+  /**
+   * Deduplicated, because the generator repeats itself at small `n`: for `n = 1`
+   * the six expressions collapse to `k = 0` four times and `k = 1` twice. Six
+   * identical cases are six identical assertions, and — since `deriveTestId` is
+   * file plus full title — six tests sharing one identity, which would have made
+   * them share one row of flakiness history the moment the suite was analysed.
+   */
   const cases: [number, number][] = []
+  const seen = new Set<string>()
   for (const n of [1, 2, 3, 5, 10, 33, 60, 100, 997]) {
     for (const k of [0, 1, Math.floor(n / 3), Math.floor(n / 2), n - 1, n]) {
-      if (k >= 0 && k <= n) cases.push([k, n])
+      if (k < 0 || k > n || seen.has(`${String(k)}/${String(n)}`)) continue
+      seen.add(`${String(k)}/${String(n)}`)
+      cases.push([k, n])
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eval": "tsx eval/run-eval.ts",
     "eval:ablation": "node scripts/pending.mjs eval:ablation",
     "eval:lint": "tsx eval/hygiene.ts",
-    "flakemetry:analyze": "node scripts/pending.mjs flakemetry:analyze",
+    "flakemetry:analyze": "tsx scripts/analyze.ts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "help": "node scripts/help.mjs",

--- a/scripts/analyze.ts
+++ b/scripts/analyze.ts
@@ -1,0 +1,374 @@
+import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import {
+  normalisePlaywrightReport,
+  normaliseVitestReport,
+  parseTestRun,
+  selectForTriage,
+  type AnalysedTest,
+  type Analysis,
+  type History,
+  type RunMetadata,
+  type TestRun,
+} from '@sentra/contracts'
+import {
+  HISTORY_FILE,
+  analyse,
+  historyDepth,
+  mergeRun,
+  readHistory,
+  scoreStatusHistory,
+  writeHistory,
+} from '@sentra/flakemetry'
+
+/**
+ * `npm run flakemetry:analyze` — reports plus history in, `analysis.json` out.
+ *
+ * The statistical half of the pipeline, as one command. Everything it does lives
+ * in `flakemetry-lib` already; what is here is the wiring, and three decisions
+ * that are not obvious from the library's side.
+ *
+ * **It writes history only when asked.** ADR-0004 confines writes to `main`, and
+ * a default that persists would make every pull-request job contribute its own
+ * branch's failures to the history that judges the next one. Read-only is the
+ * safe direction for a flag to be forgotten in.
+ *
+ * **It exits 0 when tests failed.** The command's job is to describe a run, and
+ * a run full of failures is the case it exists for. A non-zero exit here would
+ * make the pipeline stop exactly where it should be producing its most useful
+ * output — and CI already knows the suite went red, from the suite.
+ *
+ * **It reads both reports and produces one document.** Playwright and Vitest
+ * write separate files on purpose: sharing one would have whichever finished
+ * second erase the other's failures. They are analysed separately against the
+ * same history and their results concatenated, rather than merged into a single
+ * `TestRun` first — a merged run would need one value for `source`, and there
+ * is no honest one.
+ */
+
+const PLAYWRIGHT_REPORT = 'results.json'
+const VITEST_REPORT = 'results-unit.json'
+const ANALYSIS = 'analysis.json'
+
+export interface AnalyzeOptions {
+  reports: string[]
+  /** True when the caller named reports itself, so a missing one is an error rather than a skip. */
+  explicitReports: boolean
+  history: string
+  out: string
+  writeHistory: boolean
+  cap?: number | undefined
+  halfLife?: number | undefined
+}
+
+export interface AnalyzeDeps {
+  env?: NodeJS.ProcessEnv
+  root?: string
+  read?: (path: string) => string
+  write?: (path: string, contents: string) => void
+  exists?: (path: string) => boolean
+  loadHistory?: (path: string) => History
+  saveHistory?: (history: History, path: string) => void
+  now?: () => string
+  log?: (message: string) => void
+}
+
+export function parseArgs(argv: string[]): AnalyzeOptions {
+  const reports: string[] = []
+  let history = HISTORY_FILE
+  let out = ANALYSIS
+  let writeHistory = false
+  let cap: number | undefined
+  let halfLife: number | undefined
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i]
+    const value = argv[i + 1]
+
+    if (flag === '--write-history') {
+      writeHistory = true
+      continue
+    }
+    // A flag with nothing after it is ignored rather than swallowing the next
+    // one, which is how `--out --write-history` silently writes to a file called
+    // `--write-history` and skips the history update nobody notices missing.
+    if (value === undefined) continue
+
+    if (flag === '--report') reports.push(value)
+    else if (flag === '--history') history = value
+    else if (flag === '--out') out = value
+    else if (flag === '--cap') cap = Number(value)
+    else if (flag === '--half-life') halfLife = Number(value)
+    else continue
+    i += 1
+  }
+
+  return {
+    reports: reports.length > 0 ? reports : [PLAYWRIGHT_REPORT, VITEST_REPORT],
+    explicitReports: reports.length > 0,
+    history,
+    out,
+    writeHistory,
+    cap,
+    halfLife,
+  }
+}
+
+/**
+ * Which reporter wrote a file, from its shape rather than from its name.
+ *
+ * Both are `results*.json` and either can be pointed anywhere by a flag, so the
+ * filename is a convention and the contents are the fact. Each normaliser
+ * already refuses the other's format with a message naming the field that did
+ * not match; sniffing first means the caller gets *that* message rather than the
+ * wrong reporter's.
+ */
+export function reporterOf(raw: unknown): 'playwright' | 'vitest' | null {
+  if (raw === null || typeof raw !== 'object') return null
+  if (Array.isArray((raw as { suites?: unknown }).suites)) return 'playwright'
+  if (Array.isArray((raw as { testResults?: unknown }).testResults)) return 'vitest'
+  return null
+}
+
+/**
+ * Identity for a run CI did not give a number to.
+ *
+ * Derived from the reports rather than from the clock or the process, so
+ * analysing the same reports twice is the same run twice. `mergeRun` keys its
+ * idempotency on `runId`: with a pid in there, running the command a second time
+ * locally appended a second entry for every test and doubled the history, which
+ * is exactly the double-counting the run id exists to prevent. In CI the
+ * question does not arise, because `GITHUB_RUN_ID` is stable across re-runs —
+ * and that is the behaviour local runs should match, not diverge from.
+ */
+export function localRunId(reports: string[]): string {
+  const digest = createHash('sha256')
+  for (const contents of reports) digest.update(contents)
+  return `local-${digest.digest('hex').slice(0, 12)}`
+}
+
+/** Where this run came from. Falls back to git, then to a placeholder that says so. */
+export function metadata(env: NodeJS.ProcessEnv, root: string, runId: string): RunMetadata {
+  const git = (args: string[]): string | null => {
+    const result = spawnSync('git', args, { cwd: root, encoding: 'utf8' })
+    const value = result.stdout?.trim() ?? ''
+    return result.status === 0 && value !== '' ? value : null
+  }
+
+  return {
+    runId: env.GITHUB_RUN_ID ?? runId,
+    commitSha: env.GITHUB_SHA ?? git(['rev-parse', 'HEAD']) ?? 'unknown',
+    branch: env.GITHUB_REF_NAME ?? git(['rev-parse', '--abbrev-ref', 'HEAD']) ?? 'unknown',
+  }
+}
+
+/**
+ * Test identities used by more than one test in the same run.
+ *
+ * `deriveTestId` is the file path plus the full title, so two cases with the
+ * same name in the same file are one test as far as everything downstream is
+ * concerned: they share a row of history, and the last one merged decides what
+ * that row says. It is a warning rather than an error because it is the calling
+ * repository's test names that cause it, and a pipeline that refuses to run over
+ * a suite with two identically-named cases is a pipeline nobody adopts.
+ */
+export function duplicateIds(runs: TestRun[]): { testId: string; count: number }[] {
+  const counts = new Map<string, number>()
+  for (const run of runs) {
+    for (const result of run.results) {
+      counts.set(result.testId, (counts.get(result.testId) ?? 0) + 1)
+    }
+  }
+  return [...counts]
+    .filter(([, count]) => count > 1)
+    .map(([testId, count]) => ({ testId, count }))
+    .sort((a, b) => b.count - a.count || a.testId.localeCompare(b.testId))
+}
+
+/**
+ * Tests that started alternating in this run.
+ *
+ * Not "everything with a non-zero score", which after a fortnight is most of a
+ * real suite and tells a reader nothing they can act on. The question is what
+ * *changed*: a test whose recorded history had never alternated, and now has.
+ *
+ * A retry counts even when the sequence cannot show it — passing on attempt two
+ * is the alternation, and it leaves the status history reading `…P`.
+ */
+export function newlyFlaky(tests: AnalysedTest[]): AnalysedTest[] {
+  return tests.filter(({ result, signal }) => {
+    const alternatingNow = signal.flakinessScore > 0 || result.flakyWithinRun
+    return alternatingNow && scoreStatusHistory(signal.statusHistory.slice(0, -1)) === 0
+  })
+}
+
+/** One line, because it is read in a CI log beside a hundred others. */
+export function summarise(analysis: Analysis): string {
+  const failures = analysis.tests.filter(
+    (t) => t.result.status === 'failed' || t.result.status === 'timedOut',
+  ).length
+
+  return [
+    `${String(analysis.tests.length)} tests`,
+    `${String(failures)} failing`,
+    `${String(newlyFlaky(analysis.tests).length)} newly flaky`,
+    `${String(selectForTriage(analysis).length)} to triage`,
+    analysis.historyAvailable
+      ? `${String(analysis.historyDepth)} runs of history`
+      : 'no history — every test reads as new',
+  ].join(', ')
+}
+
+export function main(argv: string[], deps: AnalyzeDeps = {}): number {
+  const options = parseArgs(argv)
+  const env = deps.env ?? process.env
+  const root = deps.root ?? process.cwd()
+  const read = deps.read ?? ((path: string) => readFileSync(path, 'utf8'))
+  const exists = deps.exists ?? ((path: string) => existsSync(path))
+  const log =
+    deps.log ??
+    ((message: string) => {
+      console.log(message)
+    })
+  const write =
+    deps.write ??
+    ((path: string, contents: string) => {
+      mkdirSync(dirname(path), { recursive: true })
+      writeFileSync(path, contents)
+    })
+  const loadHistory = deps.loadHistory ?? readHistory
+  const saveHistory = deps.saveHistory ?? writeHistory
+  const now = deps.now ?? (() => new Date().toISOString())
+
+  // Every report is read before anything is normalised, because the run's
+  // identity is derived from their contents when CI has not supplied one.
+  const sources: { path: string; contents: string }[] = []
+  for (const path of options.reports) {
+    if (!exists(path)) {
+      // A default that is not there is a suite that did not run in this job.
+      // A path somebody typed is a mistake worth stopping for.
+      if (options.explicitReports) {
+        console.error(`\n  ${path} does not exist.\n`)
+        return 1
+      }
+      continue
+    }
+    sources.push({ path, contents: read(path) })
+  }
+
+  const meta = {
+    ...metadata(env, root, localRunId(sources.map((s) => s.contents))),
+    repositoryRoot: root,
+  }
+
+  const runs: TestRun[] = []
+  for (const { path, contents } of sources) {
+    let raw: unknown
+    try {
+      raw = JSON.parse(contents)
+    } catch (error) {
+      console.error(`\n  ${path} is not valid JSON: ${(error as Error).message}\n`)
+      return 1
+    }
+
+    const reporter = reporterOf(raw)
+    if (reporter === null) {
+      console.error(
+        `\n  ${path} is neither a Playwright nor a Vitest JSON report — it has no ` +
+          `"suites" and no "testResults".\n`,
+      )
+      return 1
+    }
+
+    try {
+      runs.push(
+        parseTestRun(
+          reporter === 'playwright'
+            ? normalisePlaywrightReport(raw, meta)
+            : normaliseVitestReport(raw, meta),
+          path,
+        ),
+      )
+    } catch (error) {
+      console.error(`\n  ${(error as Error).message}\n`)
+      return 1
+    }
+    log(`  read ${path} (${reporter})`)
+  }
+
+  if (runs.length === 0) {
+    console.error(
+      [
+        '',
+        `  No test report to analyse. Looked for: ${options.reports.join(', ')}`,
+        '',
+        '  Run the suites first, or name a report with --report <path>.',
+        '',
+      ].join('\n'),
+    )
+    return 1
+  }
+
+  const duplicates = duplicateIds(runs)
+  if (duplicates.length > 0) {
+    const extra = duplicates.reduce((total, d) => total + d.count - 1, 0)
+    log(
+      `  warning: ${String(duplicates.length)} test identities are used by more than one test ` +
+        `(${String(extra)} extra results). They share one row of history:`,
+    )
+    for (const { testId, count } of duplicates.slice(0, 5)) {
+      log(`      x${String(count)}  ${testId}`)
+    }
+    if (duplicates.length > 5) log(`      … and ${String(duplicates.length - 5)} more`)
+  }
+
+  let history: History
+  try {
+    history = loadHistory(options.history)
+  } catch (error) {
+    console.error(`\n  ${(error as Error).message}\n`)
+    return 1
+  }
+
+  const scoring = {
+    analysedAt: now(),
+    ...(options.cap === undefined ? {} : { cap: options.cap }),
+    ...(options.halfLife === undefined ? {} : { halfLife: options.halfLife }),
+  }
+
+  // Every report is scored against the history as it stood *before* this run, so
+  // `isNew` and `historyDepth` describe the run rather than the order the
+  // reports happened to be read in.
+  const analyses = runs.map((run) => analyse(run, history, scoring))
+  const first = analyses[0]
+  if (first === undefined) return 1
+
+  const analysis: Analysis = { ...first, tests: analyses.flatMap((a) => a.tests) }
+
+  write(options.out, `${JSON.stringify(analysis, null, 2)}\n`)
+  log(`  wrote ${options.out}`)
+  log(`  ${summarise(analysis)}`)
+
+  if (options.writeHistory) {
+    const merged = runs.reduce(
+      (carried, run) =>
+        mergeRun(carried, run, options.cap === undefined ? {} : { cap: options.cap }),
+      history,
+    )
+    saveHistory(merged, options.history)
+    log(
+      `  wrote ${options.history} — ${String(Object.keys(merged.tests).length)} tests, ` +
+        `${String(historyDepth(merged))} runs`,
+    )
+  } else {
+    log('  history not written (pass --write-history; ADR-0004 confines that to main)')
+  }
+
+  return 0
+}
+
+if (process.argv[1]?.endsWith('analyze.ts') === true) {
+  process.exitCode = main(process.argv.slice(2))
+}

--- a/scripts/script-manifest.json
+++ b/scripts/script-manifest.json
@@ -55,7 +55,7 @@
       "description": "Test report + history \u2192 analysis.json",
       "milestone": "M6",
       "issue": 59,
-      "status": "pending"
+      "status": "shipped"
     },
     {
       "name": "agents:analyze",

--- a/tests/unit/analyze.test.ts
+++ b/tests/unit/analyze.test.ts
@@ -1,0 +1,502 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { emptyHistory, type AnalysedTest, type Analysis, type History } from '@sentra/contracts'
+import { mergeRun } from '@sentra/flakemetry'
+import {
+  duplicateIds,
+  localRunId,
+  main,
+  metadata,
+  newlyFlaky,
+  parseArgs,
+  reporterOf,
+  summarise,
+} from '../../scripts/analyze.js'
+
+/**
+ * `npm run flakemetry:analyze`, the command that turns reports into a document.
+ *
+ * The behaviour worth pinning is mostly about what it refuses to do: write
+ * history it was not asked to write, fail the build because tests failed, or
+ * count one set of reports as two runs. All three are the kind of thing that
+ * looks fine until it has been running in CI for a fortnight.
+ */
+
+const root = new URL('../..', import.meta.url).pathname
+const playwrightReport = readFileSync(
+  join(root, 'tests/fixtures/reporters/playwright-1.62.1.json'),
+  'utf8',
+)
+const vitestReport = readFileSync(join(root, 'tests/fixtures/reporters/vitest-4.1.10.json'), 'utf8')
+
+interface Run {
+  code: number
+  written: Record<string, string>
+  histories: { history: History; path: string }[]
+  output: string
+}
+
+const run = (
+  argv: string[],
+  over: {
+    files?: Record<string, string>
+    history?: History
+    loadHistory?: (path: string) => History
+    env?: NodeJS.ProcessEnv
+  } = {},
+): Run => {
+  const files = over.files ?? {
+    'results.json': playwrightReport,
+    'results-unit.json': vitestReport,
+  }
+  const written: Record<string, string> = {}
+  const histories: { history: History; path: string }[] = []
+  const lines: string[] = []
+
+  const code = main(argv, {
+    env: over.env ?? { GITHUB_RUN_ID: 'run-1', GITHUB_SHA: 'abc1234', GITHUB_REF_NAME: 'main' },
+    root,
+    read: (path) => files[path] ?? '',
+    exists: (path) => path in files,
+    write: (path, contents) => {
+      written[path] = contents
+    },
+    loadHistory: over.loadHistory ?? (() => over.history ?? emptyHistory()),
+    saveHistory: (history, path) => histories.push({ history, path }),
+    now: () => '2026-08-18T00:00:00.000Z',
+    log: (message) => lines.push(message),
+  })
+
+  return { code, written, histories, output: lines.join('\n') }
+}
+
+const analysisFrom = (result: Run): Analysis =>
+  JSON.parse(result.written['analysis.json'] ?? '{}') as Analysis
+
+describe('the arguments', () => {
+  it('defaults to both reports, the ADR-0004 history path, and analysis.json', () => {
+    expect(parseArgs([])).toMatchObject({
+      reports: ['results.json', 'results-unit.json'],
+      explicitReports: false,
+      history: '.flakemetry/history.json',
+      out: 'analysis.json',
+      writeHistory: false,
+    })
+  })
+
+  it('reads every flag it documents', () => {
+    expect(
+      parseArgs([
+        '--report',
+        'a.json',
+        '--report',
+        'b.json',
+        '--history',
+        'h.json',
+        '--out',
+        'o.json',
+        '--write-history',
+        '--cap',
+        '20',
+        '--half-life',
+        '5',
+      ]),
+    ).toMatchObject({
+      reports: ['a.json', 'b.json'],
+      explicitReports: true,
+      history: 'h.json',
+      out: 'o.json',
+      writeHistory: true,
+      cap: 20,
+      halfLife: 5,
+    })
+  })
+
+  /** `--out --write-history` would otherwise write to a file of that name and skip the update. */
+  it('ignores a flag with nothing after it rather than swallowing the next one', () => {
+    expect(parseArgs(['--out'])).toMatchObject({ out: 'analysis.json', writeHistory: false })
+  })
+
+  it('does not treat --write-history as a flag that takes a value', () => {
+    expect(parseArgs(['--write-history', '--out', 'o.json'])).toMatchObject({
+      writeHistory: true,
+      out: 'o.json',
+    })
+  })
+})
+
+describe('recognising a report', () => {
+  it('knows both formats by shape rather than by filename', () => {
+    expect(reporterOf(JSON.parse(playwrightReport))).toBe('playwright')
+    expect(reporterOf(JSON.parse(vitestReport))).toBe('vitest')
+  })
+
+  it('recognises neither in something that is not a report', () => {
+    expect(reporterOf({ hello: 'world' })).toBeNull()
+    expect(reporterOf(null)).toBeNull()
+    expect(reporterOf([])).toBeNull()
+    expect(reporterOf('a string')).toBeNull()
+  })
+})
+
+describe('the identity of a run CI did not number', () => {
+  /**
+   * `mergeRun` keys idempotency on `runId`. A pid in there meant a second local
+   * invocation appended a second entry for every test, doubling the history —
+   * exactly the double-counting the run id exists to prevent.
+   */
+  it('is the same for the same reports', () => {
+    expect(localRunId(['a', 'b'])).toBe(localRunId(['a', 'b']))
+  })
+
+  it('differs when the reports do', () => {
+    expect(localRunId(['a'])).not.toBe(localRunId(['b']))
+    expect(localRunId(['a', 'b'])).not.toBe(localRunId(['b', 'a']))
+  })
+
+  it('says it is local, so a run id in a report is never mistaken for a CI one', () => {
+    expect(localRunId(['a'])).toMatch(/^local-[0-9a-f]{12}$/)
+  })
+
+  it('yields to the number CI supplies', () => {
+    expect(metadata({ GITHUB_RUN_ID: '12345' }, root, 'local-x').runId).toBe('12345')
+    expect(metadata({}, root, 'local-x').runId).toBe('local-x')
+  })
+
+  it('falls back to git for the commit and branch, and says unknown rather than guessing', () => {
+    const meta = metadata({}, root, 'local-x')
+    expect(meta.commitSha).toMatch(/^[0-9a-f]{7,40}$|^unknown$/)
+    expect(meta.branch).not.toBe('')
+  })
+})
+
+describe('test identities used twice', () => {
+  const testRun = (ids: string[]) =>
+    ({
+      runId: 'r',
+      commitSha: 'abc1234',
+      branch: 'main',
+      startedAt: '2026-08-01T00:00:00.000Z',
+      durationMs: 1,
+      source: 'playwright' as const,
+      results: ids.map((testId) => ({
+        testId,
+        title: testId,
+        file: 'f.spec.ts',
+        status: 'passed' as const,
+        attempts: 1,
+        flakyWithinRun: false,
+        durationMs: 1,
+        annotations: [],
+      })),
+    }) as const
+
+  /**
+   * `deriveTestId` is file plus full title, so two cases with the same name in
+   * the same file are one test to everything downstream — they share a row of
+   * history and the last one merged decides what it says.
+   */
+  it('finds them, counted and worst first', () => {
+    expect(duplicateIds([testRun(['a', 'b', 'a', 'c', 'a', 'b'])])).toEqual([
+      { testId: 'a', count: 3 },
+      { testId: 'b', count: 2 },
+    ])
+  })
+
+  it('counts across reports, because both feed one history', () => {
+    expect(duplicateIds([testRun(['a']), testRun(['a'])])).toEqual([{ testId: 'a', count: 2 }])
+  })
+
+  it('finds none in a run where every test is itself', () => {
+    expect(duplicateIds([testRun(['a', 'b', 'c'])])).toEqual([])
+  })
+})
+
+describe('what counts as newly flaky', () => {
+  const test = (
+    statusHistory: string,
+    over: Partial<AnalysedTest['result']> = {},
+  ): AnalysedTest => ({
+    result: {
+      testId: 't',
+      title: 't',
+      file: 'f.spec.ts',
+      status: 'failed',
+      attempts: 1,
+      flakyWithinRun: false,
+      durationMs: 1,
+      annotations: [],
+      ...over,
+    },
+    signal: {
+      testId: 't',
+      flakinessScore: 0,
+      consecutiveFailures: 0,
+      totalRuns: statusHistory.length,
+      firstSeenAt: '2026-08-01T00:00:00.000Z',
+      lastPassedAt: null,
+      statusHistory,
+      isNew: false,
+    },
+  })
+
+  /** Scores are recomputed from the history here, so the fixture cannot disagree with itself. */
+  const scored = (
+    statusHistory: string,
+    over: Partial<AnalysedTest['result']> = {},
+  ): AnalysedTest => {
+    const entry = test(statusHistory, over)
+    return {
+      ...entry,
+      signal: { ...entry.signal, flakinessScore: statusHistory.includes('F') ? 1 : 0 },
+    }
+  }
+
+  it('names a test whose history had never alternated before this run', () => {
+    expect(newlyFlaky([scored('PPPPF')])).toHaveLength(1)
+  })
+
+  /**
+   * Not "everything with a non-zero score", which after a fortnight is most of a
+   * real suite and tells a reader nothing they can act on.
+   */
+  it('does not name one that was already alternating', () => {
+    expect(newlyFlaky([scored('PFPFP')])).toEqual([])
+  })
+
+  it('does not name a test that has only ever failed', () => {
+    expect(newlyFlaky([test('FFFF')])).toEqual([])
+  })
+
+  /** The alternation happened inside the run, where the sequence cannot show it. */
+  it('names a test that passed only on a retry', () => {
+    expect(
+      newlyFlaky([test('PPPP', { status: 'passed', attempts: 2, flakyWithinRun: true })]),
+    ).toHaveLength(1)
+  })
+})
+
+describe('the command', () => {
+  it('writes a schema-valid analysis carrying the version', () => {
+    const result = run([])
+    expect(result.code).toBe(0)
+    const analysis = analysisFrom(result)
+    expect(analysis.schemaVersion).toBe(1)
+    expect(analysis).toMatchObject({
+      runId: 'run-1',
+      commitSha: 'abc1234',
+      branch: 'main',
+      analysedAt: '2026-08-18T00:00:00.000Z',
+    })
+    expect(analysis.tests.length).toBeGreaterThan(0)
+  })
+
+  it('analyses both reports into one document', () => {
+    const files = analysisFrom(run([])).tests.map((t) => t.result.file)
+    expect(files.some((f) => f.endsWith('.spec.ts'))).toBe(true)
+    expect(new Set(files).size).toBeGreaterThan(1)
+  })
+
+  it('names which reporter wrote each report it read', () => {
+    const { output } = run([])
+    expect(output).toContain('results.json (playwright)')
+    expect(output).toContain('results-unit.json (vitest)')
+  })
+
+  /**
+   * ADR-0004 confines writes to `main`, so read-only is the direction for this
+   * flag to be forgotten in. A default that persisted would have every
+   * pull-request job contribute its own branch's failures to the history that
+   * judges the next one.
+   */
+  it('does not touch the history unless asked', () => {
+    const result = run([])
+    expect(result.histories).toEqual([])
+    expect(result.output).toContain('--write-history')
+  })
+
+  it('writes the history when asked, to the path it was given', () => {
+    const result = run(['--write-history', '--history', 'h.json'])
+    expect(result.histories).toHaveLength(1)
+    expect(result.histories[0]?.path).toBe('h.json')
+    expect(Object.keys(result.histories[0]?.history.tests ?? {}).length).toBeGreaterThan(0)
+  })
+
+  it('reports how much history it wrote, so approaching the cap is noticeable', () => {
+    expect(run(['--write-history']).output).toMatch(/wrote .* — \d+ tests, \d+ runs/)
+  })
+
+  /**
+   * The command describes a run; a run full of failures is the case it exists
+   * for. A non-zero exit would stop the pipeline exactly where it should be
+   * producing its most useful output.
+   */
+  it('exits 0 when the suite it is describing failed', () => {
+    const result = run([])
+    expect(result.code).toBe(0)
+    const failed = analysisFrom(result).tests.filter((t) => t.result.status === 'failed')
+    expect(failed.length).toBeGreaterThan(0)
+  })
+
+  it('prints a summary of what it found', () => {
+    expect(run([]).output).toMatch(/\d+ tests, \d+ failing, \d+ newly flaky, \d+ to triage/)
+  })
+
+  it('says so when there was no history to read', () => {
+    expect(run([]).output).toContain('no history')
+  })
+
+  it('reports the depth when there was', () => {
+    const history = mergeRun(emptyHistory(), {
+      runId: 'older',
+      commitSha: 'abc1234',
+      branch: 'main',
+      startedAt: '2026-07-01T00:00:00.000Z',
+      durationMs: 1,
+      source: 'playwright',
+      results: [
+        {
+          testId: 'x',
+          title: 'x',
+          file: 'f.spec.ts',
+          status: 'passed',
+          attempts: 1,
+          flakyWithinRun: false,
+          durationMs: 1,
+          annotations: [],
+        },
+      ],
+    })
+    expect(run([], { history }).output).toContain('1 runs of history')
+  })
+
+  it('warns when two tests share one identity, and names them', () => {
+    // The Vitest fixture read twice: every identity in it appears exactly twice.
+    const { output } = run(['--report', 'a.json', '--report', 'b.json'], {
+      files: { 'a.json': vitestReport, 'b.json': vitestReport },
+    })
+    expect(output).toContain('share one row of history')
+    expect(output).toMatch(/x2 {2}\S/)
+  })
+
+  /**
+   * The end-to-end version of the run-id property. Two invocations over the same
+   * reports with no CI number are one run, so the second must leave the history
+   * exactly where the first did — which is what `mergeRun`'s idempotency
+   * guarantees, and only if the id does not move between them.
+   */
+  it('counts the same reports as one run however many times it is invoked locally', () => {
+    const local = { env: {} }
+    const first = run(['--write-history'], local)
+    const second = run(['--write-history'], {
+      ...local,
+      history: first.histories[0]?.history ?? emptyHistory(),
+    })
+
+    expect(first.histories[0]?.history).toEqual(second.histories[0]?.history)
+    const record = Object.values(second.histories[0]?.history.tests ?? {})[0]
+    expect(record?.totalRuns).toBe(1)
+    expect(record?.entries).toHaveLength(1)
+  })
+
+  it('passes the scoring options through', () => {
+    const result = run(['--half-life', '1', '--cap', '3', '--write-history'])
+    expect(result.code).toBe(0)
+    for (const record of Object.values(result.histories[0]?.history.tests ?? {})) {
+      expect(record.entries.length).toBeLessThanOrEqual(3)
+    }
+  })
+})
+
+describe('when it cannot do its job', () => {
+  const quiet = <T>(body: () => T): { value: T; errors: string } => {
+    const errors: string[] = []
+    const spy = vi.spyOn(console, 'error').mockImplementation((m: unknown) => {
+      errors.push(String(m))
+    })
+    try {
+      return { value: body(), errors: errors.join('\n') }
+    } finally {
+      spy.mockRestore()
+    }
+  }
+
+  /** A default that is absent is a suite that did not run in this job. */
+  it('skips a default report that is not there', () => {
+    const result = run([], { files: { 'results-unit.json': vitestReport } })
+    expect(result.code).toBe(0)
+    expect(result.output).not.toContain('results.json (playwright)')
+  })
+
+  /** A path somebody typed is a mistake worth stopping for. */
+  it('fails on a named report that is not there', () => {
+    const { value, errors } = quiet(() => run(['--report', 'nope.json']))
+    expect(value.code).toBe(1)
+    expect(errors).toContain('nope.json does not exist')
+  })
+
+  it('fails, and says what it looked for, when no report exists at all', () => {
+    const { value, errors } = quiet(() => run([], { files: {} }))
+    expect(value.code).toBe(1)
+    expect(errors).toContain('results.json')
+    expect(errors).toContain('--report')
+  })
+
+  it('fails on a report that is not JSON', () => {
+    const { value, errors } = quiet(() =>
+      run(['--report', 'x.json'], { files: { 'x.json': '{oh no' } }),
+    )
+    expect(value.code).toBe(1)
+    expect(errors).toContain('not valid JSON')
+  })
+
+  it('fails on JSON that is not a report either reporter wrote', () => {
+    const { value, errors } = quiet(() =>
+      run(['--report', 'x.json'], { files: { 'x.json': '{"hello":"world"}' } }),
+    )
+    expect(value.code).toBe(1)
+    expect(errors).toContain('neither a Playwright nor a Vitest')
+  })
+
+  /**
+   * Reported rather than swallowed. A history that cannot be read is either a
+   * cache-shaped problem or a bug, and #61 is where that distinction turns into
+   * a policy — this only has to not hide it.
+   */
+  it('fails on a history it cannot read, with the library’s own message', () => {
+    const { value, errors } = quiet(() =>
+      run([], {
+        loadHistory: () => {
+          throw new Error('h.json cannot be read as run history: the file is empty')
+        },
+      }),
+    )
+    expect(value.code).toBe(1)
+    expect(errors).toContain('cannot be read as run history')
+  })
+})
+
+describe('the summary line', () => {
+  const analysis = (tests: AnalysedTest[], over: Partial<Analysis> = {}): Analysis => ({
+    schemaVersion: 1,
+    runId: 'r',
+    commitSha: 'abc1234',
+    branch: 'main',
+    analysedAt: '2026-08-18T00:00:00.000Z',
+    historyAvailable: true,
+    historyDepth: 4,
+    tests,
+    ...over,
+  })
+
+  it('says there is no history rather than printing a depth of zero', () => {
+    const line = summarise(analysis([], { historyAvailable: false, historyDepth: 0 }))
+    expect(line).toContain('no history')
+    expect(line).toContain('every test reads as new')
+  })
+
+  it('states the depth when there is one', () => {
+    expect(summarise(analysis([]))).toContain('4 runs of history')
+  })
+})


### PR DESCRIPTION
Closes #59. The statistical half of the pipeline as one command — `results.json` and `results-unit.json` in, `analysis.json` out, history updated only when asked.

```
$ npm run flakemetry:analyze

  read results.json (playwright)
  read results-unit.json (vitest)
  wrote analysis.json
  1734 tests, 1 failing, 0 newly flaky, 1 to triage, 4 runs of history
  history not written (pass --write-history; ADR-0004 confines that to main)
```

Everything it does lives in `flakemetry-lib` already, so what is here is wiring plus three decisions the library had no reason to make.

**History is written only with `--write-history`.** ADR-0004 confines writes to `main`, and read-only is the direction for a flag to be forgotten in — a default that persisted would have every pull-request job contribute its own branch's failures to the history that judges the next one.

**It exits 0 when the suite it describes failed.** A run full of failures is the case the command exists for. A non-zero exit would stop the pipeline exactly where it should be producing its most useful output, and CI already knows the suite went red from the suite.

**It reads both reports and produces one document.** Playwright and Vitest write separate files on purpose — sharing one would have whichever finished second erase the other's failures. They are analysed separately against the same history and their results concatenated, rather than merged into one `TestRun` first: a merged run would need a single value for `source`, and there is no honest one.

A default report that is absent is a suite that did not run in this job, so it is skipped. A path somebody typed and got wrong is a mistake worth stopping for.

## Two things that only showed up by running it

Not against fixtures — against this repository's own reports.

### The run id was the process id

```
run 1:  wrote history.json — 1735 tests, 1 runs
run 2:  wrote history.json — 1735 tests, 2 runs     ← same reports
```

`mergeRun` keys its idempotency on `runId`. A local id drawn from the pid moves between invocations, so analysing the same reports twice appended a second entry for every test and doubled the history — defeating the exact double-counting the run id exists to prevent. It also diverged from CI, where `GITHUB_RUN_ID` is stable across "re-run all jobs" and re-analysis is already idempotent.

It is a hash of the report contents now: the same reports are the same run, locally and in CI alike. Pinned by a test that invokes the command twice and asserts the history is byte-identical.

### 1765 results carried 1735 identities

Eighteen `testId`s were used by more than one test:

```
x4  eval/metrics.test.ts›wilsonInterval against an independent derivation › agrees with the quadratic roots at 0/1
x4  eval/metrics.test.ts›wilsonInterval against an independent derivation › brackets the point estimate at 0/1
```

`deriveTestId` is the file path plus the full title, so those are one test as far as everything downstream is concerned — they share a row of history, and the last one merged decides what it says.

The cause here is not naming, it is a generator that repeats itself:

```ts
for (const n of [1, 2, 3, 5, 10, 33, 60, 100, 997]) {
  for (const k of [0, 1, Math.floor(n / 3), Math.floor(n / 2), n - 1, n]) {
```

At `n = 1` the six expressions collapse to `k = 0` four times and `k = 1` twice. Six identical cases are six identical assertions — and, given how identity works, six tests sharing one row of history. Deduplicated, so this repository's own suite is clean.

The command **warns and names them** rather than failing. It is the calling repository's test names that cause this, and a pipeline that refuses to run over a suite with two identically-named cases is a pipeline nobody adopts.

## "Newly flaky"

Defined narrowly on purpose: a test whose recorded history had **never** alternated before this run, and now has. "Everything with a non-zero score" is most of a real suite after a fortnight and tells a reader nothing they can act on. A test that passed only on a retry counts too — the alternation happened where the pass/fail sequence cannot show it.

## Testing

1700 tests, 39 of them new. Six mutations, all caught:

| Mutation | Caught by |
|---|---|
| Write history without the flag | `does not touch the history unless asked` |
| Run id back to the pid | `counts the same reports as one run however many times it is invoked locally` |
| Exit 1 when tests failed | 5 tests |
| Drop the duplicate-identity warning | `warns when two tests share one identity, and names them` |
| Skip a named report that is missing | `fails on a named report that is not there` |
| `newlyFlaky` = anything alternating | `does not name one that was already alternating` |

Every failure path is covered: missing report, no report at all, invalid JSON, JSON that is neither reporter's format, and a history that cannot be read — the last one passes the library's own message through rather than wrapping it, because #61 is where that distinction turns into a policy and this only has to not hide it.

`README.md` drops the 🚧 on the command; `scripts/script-manifest.json` marks it shipped; `docs/architecture.md` documents the flags and the three decisions.
