### PR TITLE
feat(flakemetry): a cache that failed is a warning, not a red pipeline

### DIFF
--- a/agents/context.test.ts
+++ b/agents/context.test.ts
@@ -265,8 +265,30 @@ describe('assembling', () => {
     const bundle = assembleContext(input({ historyAvailable: false }))
     expect(bundle.facts).toContainEqual({
       label: 'history available',
-      value: 'no — the run had no history to read',
+      value:
+        'no — the run had no history to read, so determinism rests on this run’s attempts alone',
     })
+  })
+
+  /**
+   * Naming the fallback, not only the absence. `determinism` is normally decided
+   * across runs; with none, the evidence is the attempts inside this one. Saying
+   * "no history" and stopping there invites absence to be read as stability,
+   * which turns every uncached run into a page of confident `deterministic`.
+   */
+  it('names what determinism rests on when there is no history', () => {
+    const bundle = assembleContext(input({ historyAvailable: false }))
+    const stated = bundle.facts.find((f) => f.label === 'history available')?.value ?? ''
+    expect(stated).toContain('determinism')
+    expect(stated).toContain('attempts')
+  })
+
+  it('says nothing of the sort when there was history', () => {
+    const stated =
+      assembleContext(input({ historyAvailable: true })).facts.find(
+        (f) => f.label === 'history available',
+      )?.value ?? ''
+    expect(stated).toBe('yes')
   })
 
   it('says "none" rather than printing an empty history', () => {

--- a/agents/context.ts
+++ b/agents/context.ts
@@ -250,10 +250,21 @@ export function assembleContext(
     facts.push(
       {
         label: 'history available',
-        // Stated even when false, and especially then: without it a cache miss
-        // and a genuinely new test are the same input, and they are not the same
-        // situation.
-        value: input.historyAvailable ? 'yes' : 'no — the run had no history to read',
+        /**
+         * Stated even when false, and especially then: without it a cache miss
+         * and a genuinely new test are the same input, and they are not the same
+         * situation.
+         *
+         * The false branch also names what is left. `determinism` is normally
+         * decided across runs; with no history there is only this run, so the
+         * evidence is the attempts inside it — a retry that passed, or the
+         * absence of one. Saying "no history" without saying that invites the
+         * model to read absence as stability, which is the reading that turns
+         * every uncached run into a page of confident `deterministic`.
+         */
+        value: input.historyAvailable
+          ? 'yes'
+          : 'no — the run had no history to read, so determinism rests on this run’s attempts alone',
       },
       {
         label: 'status history, oldest first',

--- a/contracts/analysis.ts
+++ b/contracts/analysis.ts
@@ -98,6 +98,22 @@ export const AnalysisSchema = z
     /** How many runs of history the scoring could draw on. */
     historyDepth: z.int().min(0),
 
+    /**
+     * Why there was history, or why there was not.
+     *
+     * `historyAvailable` says the signal is thin; this says whose problem that
+     * is. A cache that missed is Tuesday — seven idle days, or a first run on a
+     * new branch. A cache that was *there and unreadable* means something is
+     * writing the file wrongly, and the two produce identical output otherwise:
+     * every test new, `determinism` resting on within-run retries, and a
+     * pipeline that looks like it is working.
+     *
+     * Optional because documents written before it existed are still valid, and
+     * because only the caller that opened the file knows the answer — `analyse`
+     * is handed a history and cannot tell an empty one from an absent one.
+     */
+    historySource: z.enum(['read', 'missing', 'unreadable']).optional(),
+
     /** Every test in the run, not only the failures — the agents filter. */
     tests: z.array(AnalysedTestSchema),
   })

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -205,6 +205,18 @@ pull-request job contribute its own branch's failures to the history that judges
 case it exists for. A non-zero exit would stop the pipeline exactly where it should be producing its
 most useful output, and CI already knows the suite went red from the suite.
 
+**A history it cannot use does not stop it.** Cache eviction is an expected operating condition, and
+so is the truncated file a killed job used to leave behind: the command continues with an empty
+history, records `historySource: "unreadable"` on the document, and says in the log that every test
+now reads as new and `determinism` rests on within-run retries alone. Only a problem with the file's
+contents degrades — a permission error or a full disk still fails, because swallowing those would
+hide a real fault behind a warning. A run allowed to write history replaces the unusable file.
+
+`historyAvailable` says the signal is thin; `historySource` says whose problem that is. A cache that
+missed is Tuesday. A cache that was there and unreadable means something is writing the file wrongly
+— and the two produce identical output otherwise, right down to a pipeline that looks like it is
+working.
+
 When CI supplies no `GITHUB_RUN_ID`, the run's identity is a hash of the reports rather than
 anything drawn from the clock or the process. `mergeRun` keys idempotency on `runId`, so a local id
 that moved between invocations would append a second entry for every test and double the history —

--- a/docs/limitations-and-guardrails.md
+++ b/docs/limitations-and-guardrails.md
@@ -41,7 +41,9 @@ that the bug is a secret.
   timeline. If the evidence is not in the report, the diff, or the source, it does not exist.
 - **It cannot see history it was not given.** History lives in a CI cache. A cache miss (first run
   on a branch, eviction, expiry) means every test looks new, and the `determinism` axis degrades
-  to within-run retry evidence only.
+  to within-run retry evidence only. The context bundle says so in those words rather than leaving
+  the absence to be inferred — "no history" alone invites absence to be read as stability, which
+  turns every uncached run into a page of confident `deterministic`.
 - **It cannot detect flakiness on a single run.** Flakiness is a property of a distribution.
   One run with one failure carries almost no intermittency signal.
 - **It does not generalise beyond this repository.** Prompts, heuristics, and the dataset are
@@ -91,6 +93,12 @@ into a prompt.
   `main` job writes history; PR jobs read. Documented in ADR-0004.
 - **Cache eviction.** GitHub evicts caches after 7 days of no access and at a 10 GB repo cap.
   History is not durable storage.
+- **A history the pipeline cannot use is a warning, not a failure.** `flakemetry:analyze` continues
+  with an empty history and records `historySource: "unreadable"` in `analysis.json`, so the run
+  still produces output and the degradation is legible rather than inferred from a thin signal. Only
+  a problem with the file's _contents_ degrades; a permission error or a full disk still fails,
+  because swallowing those would hide a real fault behind a warning nobody reads. A run permitted to
+  write history replaces the unusable file, so the next one starts clean.
 - **Comment upsert relies on a marker.** If a user deletes the bot comment, the next run posts a
   fresh one. Harmless, occasionally confusing.
 - **Non-determinism in the eval gate.** The classifier's own eval is mildly flaky, which is why

--- a/scripts/analyze.ts
+++ b/scripts/analyze.ts
@@ -3,6 +3,8 @@ import { createHash } from 'node:crypto'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname } from 'node:path'
 import {
+  HistoryUnreadableError,
+  emptyHistory,
   normalisePlaywrightReport,
   normaliseVitestReport,
   parseTestRun,
@@ -217,7 +219,9 @@ export function summarise(analysis: Analysis): string {
     `${String(selectForTriage(analysis).length)} to triage`,
     analysis.historyAvailable
       ? `${String(analysis.historyDepth)} runs of history`
-      : 'no history — every test reads as new',
+      : analysis.historySource === 'unreadable'
+        ? 'history unreadable — every test reads as new'
+        : 'no history — every test reads as new',
   ].join(', ')
 }
 
@@ -325,11 +329,40 @@ export function main(argv: string[], deps: AnalyzeDeps = {}): number {
   }
 
   let history: History
+  let historySource: 'read' | 'missing' | 'unreadable'
   try {
     history = loadHistory(options.history)
+    historySource = historyDepth(history) > 0 ? 'read' : 'missing'
   } catch (error) {
-    console.error(`\n  ${(error as Error).message}\n`)
-    return 1
+    /**
+     * A history that cannot be used is not a reason to stop.
+     *
+     * Cache eviction is an expected operating condition, and so is the corrupt
+     * file a killed job used to leave behind. Failing here would turn a cache
+     * problem into a red pipeline on a run that has perfectly good reports to
+     * describe — and the *worse* outcome is the one this avoids in the other
+     * direction: reading a broken file as "no history yet" and producing a
+     * confident, thin analysis that says nothing went wrong.
+     *
+     * Only `HistoryUnreadableError` degrades. A permission error or a full disk
+     * is not a cache-shaped problem, and swallowing it would hide a real fault
+     * behind a warning nobody reads. That distinction is what `reason` on the
+     * error is for.
+     */
+    if (!(error instanceof HistoryUnreadableError)) {
+      console.error(`\n  ${(error as Error).message}\n`)
+      return 1
+    }
+    history = emptyHistory()
+    historySource = 'unreadable'
+    log('')
+    log(`  warning: ${options.history} could not be read (${error.reason}).`)
+    log('           Continuing without history: every test reads as new, and')
+    log('           determinism falls back to within-run retry evidence alone.')
+    if (options.writeHistory) {
+      log(`           It will be replaced by this run's history.`)
+    }
+    log('')
   }
 
   const scoring = {
@@ -345,7 +378,11 @@ export function main(argv: string[], deps: AnalyzeDeps = {}): number {
   const first = analyses[0]
   if (first === undefined) return 1
 
-  const analysis: Analysis = { ...first, tests: analyses.flatMap((a) => a.tests) }
+  const analysis: Analysis = {
+    ...first,
+    historySource,
+    tests: analyses.flatMap((a) => a.tests),
+  }
 
   write(options.out, `${JSON.stringify(analysis, null, 2)}\n`)
   log(`  wrote ${options.out}`)

--- a/tests/unit/analyze.test.ts
+++ b/tests/unit/analyze.test.ts
@@ -1,7 +1,13 @@
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
-import { emptyHistory, type AnalysedTest, type Analysis, type History } from '@sentra/contracts'
+import {
+  HistoryUnreadableError,
+  emptyHistory,
+  type AnalysedTest,
+  type Analysis,
+  type History,
+} from '@sentra/contracts'
 import { mergeRun } from '@sentra/flakemetry'
 import {
   duplicateIds,
@@ -460,20 +466,119 @@ describe('when it cannot do its job', () => {
   })
 
   /**
-   * Reported rather than swallowed. A history that cannot be read is either a
-   * cache-shaped problem or a bug, and #61 is where that distinction turns into
-   * a policy — this only has to not hide it.
+   * A permission error or a full disk is not a cache-shaped problem, and
+   * swallowing it would hide a real fault behind a warning nobody reads.
    */
-  it('fails on a history it cannot read, with the library’s own message', () => {
+  it('fails on a history error that is not about the file’s contents', () => {
     const { value, errors } = quiet(() =>
       run([], {
         loadHistory: () => {
-          throw new Error('h.json cannot be read as run history: the file is empty')
+          throw Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' })
         },
       }),
     )
     expect(value.code).toBe(1)
-    expect(errors).toContain('cannot be read as run history')
+    expect(errors).toContain('permission denied')
+  })
+})
+
+describe('a history that cannot be used', () => {
+  const unreadable = (reason: 'unparsable' | 'invalid' | 'version') => () => {
+    throw new HistoryUnreadableError('.flakemetry/history.json', reason, 'why')
+  }
+
+  /**
+   * Cache eviction is an expected operating condition, and so is the corrupt
+   * file a killed job used to leave behind. Failing here turns a cache problem
+   * into a red pipeline on a run with perfectly good reports to describe.
+   */
+  it('does not stop the run', () => {
+    const result = run([], { loadHistory: unreadable('unparsable') })
+    expect(result.code).toBe(0)
+    expect(analysisFrom(result).tests.length).toBeGreaterThan(0)
+  })
+
+  it('says so, in the log and in the document', () => {
+    const result = run([], { loadHistory: unreadable('invalid') })
+    expect(result.output).toContain('could not be read (invalid)')
+    expect(analysisFrom(result).historySource).toBe('unreadable')
+  })
+
+  /**
+   * The other direction is the worse one: reading a broken file as "no history
+   * yet" and producing a confident, thin analysis that says nothing went wrong.
+   */
+  it('is never confused with there being no history', () => {
+    expect(analysisFrom(run([], { loadHistory: unreadable('version') })).historySource).toBe(
+      'unreadable',
+    )
+    expect(analysisFrom(run([])).historySource).toBe('missing')
+  })
+
+  it('names the fallback rather than only the failure', () => {
+    const { output } = run([], { loadHistory: unreadable('unparsable') })
+    expect(output).toContain('every test reads as new')
+    expect(output).toContain('within-run retry evidence')
+  })
+
+  it('shows it in the summary line too, where it will actually be read', () => {
+    expect(run([], { loadHistory: unreadable('unparsable') }).output).toContain(
+      'history unreadable',
+    )
+  })
+
+  /** The next run on main repairs the cache rather than tripping over it again. */
+  it('is replaced when the run is allowed to write history', () => {
+    const result = run(['--write-history'], { loadHistory: unreadable('unparsable') })
+    expect(result.histories).toHaveLength(1)
+    expect(Object.keys(result.histories[0]?.history.tests ?? {}).length).toBeGreaterThan(0)
+    expect(result.output).toContain('replaced by this run')
+  })
+
+  it('says nothing about replacing it on a job that may not write', () => {
+    expect(run([], { loadHistory: unreadable('unparsable') }).output).not.toContain('replaced')
+  })
+})
+
+describe('running with no history at all', () => {
+  const result = run([])
+
+  it('produces a full analysis rather than a reduced one', () => {
+    expect(result.code).toBe(0)
+    expect(analysisFrom(result).tests.length).toBeGreaterThan(0)
+  })
+
+  /** A cache miss is Tuesday: seven idle days, or a first run on a new branch. */
+  it('marks every test as new, and the document as having read nothing', () => {
+    const analysis = analysisFrom(result)
+    expect(analysis).toMatchObject({
+      historyAvailable: false,
+      historyDepth: 0,
+      historySource: 'missing',
+    })
+    expect(analysis.tests.every((t) => t.signal.isNew)).toBe(true)
+  })
+
+  /**
+   * The evidence that survives a cache miss. A test that failed and passed
+   * inside one run alternated where the pass/fail sequence cannot show it, which
+   * is the whole of `determinism` when there is no sequence to read.
+   */
+  it('keeps the within-run retry evidence, which is all determinism has left', () => {
+    const analysis = analysisFrom(result)
+    const retried = analysis.tests.filter((t) => t.result.flakyWithinRun)
+    for (const test of retried) {
+      expect(test.signal.flakinessScore, test.result.testId).toBeGreaterThan(0)
+    }
+    // A one-run history scores zero without it, so the assertion above is only
+    // meaningful if the flag is what lifted them.
+    for (const test of analysis.tests.filter((t) => !t.result.flakyWithinRun)) {
+      expect(test.signal.flakinessScore, test.result.testId).toBe(0)
+    }
+  })
+
+  it('does not pretend the history was read', () => {
+    expect(result.output).toContain('no history')
   })
 })
 


### PR DESCRIPTION
Closes #61.

```
  read results.json (playwright)
  read results-unit.json (vitest)

  warning: .flakemetry/history.json could not be read (unparsable).
           Continuing without history: every test reads as new, and
           determinism falls back to within-run retry evidence alone.
           It will be replaced by this run's history.

  wrote analysis.json
  1773 tests, 0 failing, 0 newly flaky, 0 to triage, history unreadable — every test reads as new
  wrote .flakemetry/history.json — 1773 tests, 1 runs
```

Exit 0. Next run reads it clean.

## Why it degrades

Cache eviction is Tuesday — seven idle days, a first run on a new branch, a repository size cap — and so is the truncated file a killed job used to leave behind before writes became atomic. Failing on either turns a cache problem into a red pipeline on a run that has perfectly good reports to describe.

The other direction is the one worth naming, though, because it is the failure this project keeps hunting: reading a broken file as "no history yet" and producing a confident, thin analysis in which nothing went wrong. That is why the degradation is *stated* rather than merely survived.

## Only content problems degrade

A permission error or a full disk is not cache-shaped, and swallowing it would hide a real fault behind a warning nobody reads:

```ts
if (!(error instanceof HistoryUnreadableError)) {
  console.error(`\n  ${(error as Error).message}\n`)
  return 1
}
```

That distinction is exactly what `reason` on `HistoryUnreadableError` was added for in #57, and this is the first caller to use it. A `catch` that matched on message text would have lost it the first time somebody reworded an error.

## `historySource`

`historyAvailable` already said the signal was thin. This says whose problem that is:

| | |
|---|---|
| `read` | there was history and it was used |
| `missing` | no file — a cache miss, which is ordinary |
| `unreadable` | the file was there and could not be used — **something is writing it wrongly** |

Without the distinction those last two produce identical output, right down to a pipeline that looks like it is working. Optional on the schema, so documents written before it existed stay valid — and set by the CLI rather than by `analyse`, because `analyse` is handed a history and cannot tell an empty one from an absent one.

## The bundle names the fallback now

Before: `history available: no — the run had no history to read`
After: `history available: no — the run had no history to read, so determinism rests on this run's attempts alone`

`determinism` is normally decided across runs. With none, the evidence is the attempts inside this one — a retry that passed, or the absence of one. Saying "no history" and stopping there invites absence to be read as *stability*, which is the reading that turns every uncached run into a page of confident `deterministic`. That is the difference between a model reasoning from thin evidence and a model reasoning from evidence it believes is complete, and it decides how every cache-miss run gets classified.

Free to change today because no cassettes are committed; the rendered bundle is part of the cassette key.

## What a cache miss actually leaves

A test's entire history is one run, so every alternation score is 0 — **except** where a test failed and passed inside the run. That is the only alternation a single run can carry, and the test asserts both halves: retried tests score above zero, and every other test scores exactly zero, so the first assertion means something.

## Testing

1713 tests. Four mutations, all caught:

| Mutation | Caught by |
|---|---|
| Degrade on every history error, including `EACCES` | `fails on a history error that is not about the file's contents` |
| Report `unreadable` as `missing` | 3 tests |
| Keep failing the run on an unreadable history | 5 tests |
| Drop the fallback sentence from the bundle | 2 tests |

Also documented in `docs/limitations-and-guardrails.md` under operational limitations, and in `docs/architecture.md` beside the command's other decisions.
