### PR TITLE
ci(ci): run the history cache on a milestone that has shipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,14 +406,22 @@ jobs:
       # The exact key can never hit — it carries this run's id, and no earlier
       # run wrote it — so every restore is a restore-key match. That is the
       # point: it makes the lookup a prefix search, newest first.
+      #
+      # `head_ref || ref_name`, not `ref_name` alone. On a pull_request event
+      # `github.ref_name` is the *merge ref* — `183/merge` — so the branch-scoped
+      # key was a different string on every pull request and matched nothing.
+      # Harmless today, because ADR-0004 lets only main write and so no branch
+      # cache exists to match; a trap the moment that policy is revisited, which
+      # the ADR lists as a thing that could happen. Found by reading the job log
+      # the first time this job ever ran, which is what the ADR asked for.
       - name: Restore run history
         id: history
         uses: actions/cache/restore@v4
         with:
           path: .flakemetry/history.json
-          key: history-${{ github.ref_name }}-${{ github.run_id }}
+          key: history-${{ github.head_ref || github.ref_name }}-${{ github.run_id }}
           restore-keys: |
-            history-${{ github.ref_name }}-
+            history-${{ github.head_ref || github.ref_name }}-
             history-main-
 
       # Cache scoping across branches is subtle enough that ADR-0004 asks for it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       has-unit: ${{ steps.detect.outputs.has-unit }}
       has-e2e: ${{ steps.detect.outputs.has-e2e }}
       has-eval: ${{ steps.detect.outputs.has-eval }}
+      has-flakemetry: ${{ steps.detect.outputs.has-flakemetry }}
       has-agents: ${{ steps.detect.outputs.has-agents }}
     steps:
       - uses: actions/checkout@v7
@@ -55,6 +56,7 @@ jobs:
           flag has-unit   vitest.config.ts
           flag has-e2e    playwright.config.ts
           flag has-eval   eval/run-eval.ts
+          flag has-flakemetry scripts/analyze.ts
           flag has-agents agents/run.ts
 
       - name: Validate workflow and issue-template YAML
@@ -232,6 +234,18 @@ jobs:
           path: coverage/
           retention-days: 7
 
+      # The unit run is a data source, not only a gate: unit failures classify
+      # differently from browser failures, and a history built only from
+      # Playwright output would teach the classifier that every failure has a
+      # locator in it. `if: always()` because the runs worth analysing are the
+      # red ones.
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: unit-results
+          path: results-unit.json
+          retention-days: 14
+
   # ---------------------------------------------------------------------------
   # M5 — end-to-end. Deliberately does NOT retry: retries would erase the
   # intermittency signal the whole pipeline depends on.
@@ -359,11 +373,105 @@ jobs:
           retention-days: 30
 
   # ---------------------------------------------------------------------------
-  # M6/M7/M8 — flakiness analysis and agent triage. Never fails the build.
+  # M6 — the statistical half. Runs on every branch, writes history only on main.
+  # Never fails the build: it describes a run, and the runs worth describing are
+  # the ones where something went wrong.
+  # ---------------------------------------------------------------------------
+  flakemetry:
+    name: Flakiness analysis
+    needs: [hygiene, unit, e2e]
+    if: always() && needs.hygiene.outputs.has-flakemetry == 'true'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - run: npm ci
+
+      # Both reports, and neither is required: a job where one suite was skipped
+      # still has the other's failures worth recording.
+      - uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: test-results
+      - uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: unit-results
+
+      # ADR-0004: keyed cache with fallback to branch history, then to main's.
+      # The exact key can never hit — it carries this run's id, and no earlier
+      # run wrote it — so every restore is a restore-key match. That is the
+      # point: it makes the lookup a prefix search, newest first.
+      - name: Restore run history
+        id: history
+        uses: actions/cache/restore@v4
+        with:
+          path: .flakemetry/history.json
+          key: history-${{ github.ref_name }}-${{ github.run_id }}
+          restore-keys: |
+            history-${{ github.ref_name }}-
+            history-main-
+
+      # Cache scoping across branches is subtle enough that ADR-0004 asks for it
+      # to be verified by observation. This is the observation: which key
+      # answered, and how much history came back with it.
+      - name: Report what the cache returned
+        run: |
+          matched='${{ steps.history.outputs.cache-matched-key }}'
+          if [ -z "$matched" ]; then
+            echo "::notice::history cache MISS — no key matched. Every test will read as new."
+          else
+            echo "::notice::history cache HIT via restore key: $matched"
+          fi
+          if [ -f .flakemetry/history.json ]; then
+            bytes=$(wc -c < .flakemetry/history.json | tr -d ' ')
+            tests=$(node -e "try{console.log(Object.keys(JSON.parse(require('fs').readFileSync('.flakemetry/history.json','utf8')).tests).length)}catch{console.log('unreadable')}")
+            echo "::notice::history file: ${bytes} bytes, ${tests} tests"
+            # GitHub evicts at a 10 GB repository cap; a single entry this large
+            # means the retained window needs shrinking long before that.
+            if [ "$bytes" -gt 26214400 ]; then
+              echo "::warning::history is ${bytes} bytes — approaching a size where the cache stops persisting. Lower the per-test cap."
+            fi
+          else
+            echo "::notice::no history file restored"
+          fi
+
+      # `--write-history` only on main. ADR-0004 eliminates the lost-update race
+      # by having exactly one writer rather than by mitigating contention, and a
+      # pull-request job that wrote would feed its own branch's failures into the
+      # history that judges the next one.
+      - name: Analyse the run
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            npm run flakemetry:analyze -- --write-history
+          else
+            npm run flakemetry:analyze
+          fi
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: analysis
+          path: analysis.json
+          retention-days: 30
+
+      - name: Persist run history (main only — ADR-0004)
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: .flakemetry/history.json
+          key: history-main-${{ github.run_id }}
+
+  # ---------------------------------------------------------------------------
+  # M7/M8 — agent triage. Never fails the build.
   # ---------------------------------------------------------------------------
   analyze:
-    name: Flakiness analysis & triage
-    needs: [hygiene, e2e]
+    name: Agent triage
+    needs: [hygiene, flakemetry]
     if: always() && needs.hygiene.outputs.has-agents == 'true'
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -382,21 +490,12 @@ jobs:
       - run: npm ci
 
       - uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: test-results
-
-      # ADR-0004: keyed cache with fallback to main. Only the main-branch run writes.
-      - name: Restore run history
-        uses: actions/cache/restore@v4
+      - uses: actions/download-artifact@v4
         with:
-          path: .flakemetry/history.json
-          key: history-${{ github.ref_name }}-${{ github.run_id }}
-          restore-keys: |
-            history-${{ github.ref_name }}-
-            history-main-
-
-      - name: flakemetry analysis
-        run: npm run flakemetry:analyze
+          name: analysis
 
       - name: Agent triage
         env:
@@ -432,10 +531,3 @@ jobs:
             } else {
               await github.rest.issues.createComment({ owner, repo, issue_number, body });
             }
-
-      - name: Persist run history (main only — ADR-0004)
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v4
-        with:
-          path: .flakemetry/history.json
-          key: history-main-${{ github.run_id }}

--- a/docs/adr/0004-history-persistence-via-ci-cache.md
+++ b/docs/adr/0004-history-persistence-via-ci-cache.md
@@ -23,8 +23,17 @@ degrades exactly the signal the system depends on.
 
 History lives in `.flakemetry/history.json`, persisted with `actions/cache`:
 
-- Cache key: `history-${{ github.ref_name }}-${{ github.run_id }}`
-- Restore keys, in order: `history-${{ github.ref_name }}-`, then `history-main-`
+- Cache key: `history-${{ github.head_ref || github.ref_name }}-${{ github.run_id }}`
+- Restore keys, in order: `history-${{ github.head_ref || github.ref_name }}-`, then `history-main-`
+
+**`head_ref || ref_name`, not `ref_name` alone.** This ADR originally said `github.ref_name`, which
+is the branch on a `push` event and the _merge ref_ — `183/merge` — on a `pull_request`. The
+branch-scoped key was therefore a different string on every pull request and could match nothing.
+It is harmless while this ADR's main-only rule holds, because no branch cache exists to match and
+the lookup falls through to `history-main-` as intended; it becomes a silent trap the moment that
+policy is revisited, which the last section of this document contemplates. Corrected in #60, found
+by reading the job log the first time the job ever ran — which is the manual verification this ADR
+asked for, doing the job it was asked to do.
 
 **Only jobs running on `main` write the cache.** Pull-request jobs restore history read-only.
 Writes are atomic (temp file + rename) and merge-based rather than overwrite, so a partial or

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,8 @@
         "typescript": "^5.7.2",
         "typescript-eslint": "8.66.0",
         "vite": "^8.2.1",
-        "vitest": "4.1.10"
+        "vitest": "4.1.10",
+        "yaml": "2.9.0"
       },
       "engines": {
         "node": ">=22.13"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sentra",
   "version": "0.1.0",
   "private": true,
-  "description": "An AI triage layer for CI test failures \u2014 packaged as a pipeline step, not a service.",
+  "description": "An AI triage layer for CI test failures — packaged as a pipeline step, not a service.",
   "license": "MIT",
   "author": "Andrii Kohut",
   "repository": {
@@ -81,7 +81,8 @@
     "typescript": "^5.7.2",
     "typescript-eslint": "8.66.0",
     "vite": "^8.2.1",
-    "vitest": "4.1.10"
+    "vitest": "4.1.10",
+    "yaml": "2.9.0"
   },
   "lint-staged": {
     "*.{ts,tsx,js,mjs,cjs}": [

--- a/tests/unit/history-cache.test.ts
+++ b/tests/unit/history-cache.test.ts
@@ -70,7 +70,9 @@ describe('the restore keys', () => {
    * for in the first place.
    */
   it('uses a key no earlier run can have written', () => {
-    expect(restore[0]?.step.with?.key).toBe('history-${{ github.ref_name }}-${{ github.run_id }}')
+    expect(restore[0]?.step.with?.key).toBe(
+      'history-${{ github.head_ref || github.ref_name }}-${{ github.run_id }}',
+    )
   })
 
   it('falls back to this branch, then to main, in that order', () => {
@@ -79,14 +81,26 @@ describe('the restore keys', () => {
       .map((line) => line.trim())
       .filter((line) => line !== '')
 
-    expect(keys).toEqual(['history-${{ github.ref_name }}-', 'history-main-'])
+    expect(keys).toEqual(['history-${{ github.head_ref || github.ref_name }}-', 'history-main-'])
   })
 
   /** The ADR is the specification; drift between the two is the thing to catch. */
   it('matches the keys the ADR specifies', () => {
-    expect(adr).toContain('history-${{ github.ref_name }}-${{ github.run_id }}')
-    expect(adr).toContain('history-${{ github.ref_name }}-')
+    expect(adr).toContain('history-${{ github.head_ref || github.ref_name }}-${{ github.run_id }}')
+    expect(adr).toContain('history-${{ github.head_ref || github.ref_name }}-')
     expect(adr).toContain('history-main-')
+  })
+
+  /**
+   * `github.ref_name` is the branch on a push and the *merge ref* on a pull
+   * request — `183/merge`. Keying on it made the branch-scoped key a different
+   * string on every pull request, matching nothing. Harmless while only main
+   * writes; a trap the moment that is revisited.
+   */
+  it('keys on the branch, not on the merge ref a pull request runs from', () => {
+    const key = restore[0]?.step.with?.key ?? ''
+    expect(key).toContain('github.head_ref')
+    expect(adr).toContain('merge ref')
   })
 })
 

--- a/tests/unit/history-cache.test.ts
+++ b/tests/unit/history-cache.test.ts
@@ -1,0 +1,206 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+/**
+ * The history cache, checked against ADR-0004 rather than against a reviewer.
+ *
+ * Three of the ADR's guarantees live entirely in the workflow file, where no
+ * type checks them and no test runs them: the restore keys, the single writer,
+ * and the flag that makes a job a writer. Every one of them fails silently.
+ *
+ * A wrong restore key does not error — it produces a cache miss, and a cache
+ * miss is indistinguishable from a first run on a branch. A pull-request job
+ * that passed `--write-history` would not error either; it would quietly feed
+ * its own branch's failures into the history that judges the next one, and the
+ * only symptom would be a determinism signal that slowly stopped meaning
+ * anything.
+ *
+ * So the keys are asserted here against the ADR's own text, and the writer is
+ * asserted to be exactly one job on exactly one branch.
+ */
+
+const root = new URL('../..', import.meta.url).pathname
+const workflow = readFileSync(join(root, '.github/workflows/ci.yml'), 'utf8')
+const adr = readFileSync(join(root, 'docs/adr/0004-history-persistence-via-ci-cache.md'), 'utf8')
+
+interface Step {
+  name?: string
+  uses?: string
+  if?: string
+  run?: string
+  id?: string
+  with?: Record<string, string>
+}
+interface Job {
+  name?: string
+  needs?: string | string[]
+  if?: string
+  steps?: Step[]
+}
+
+const jobs = (parse(workflow) as { jobs: Record<string, Job> }).jobs
+const steps = (job: string): Step[] => jobs[job]?.steps ?? []
+const stepsUsing = (prefix: string): { job: string; step: Step }[] =>
+  Object.entries(jobs).flatMap(([job, definition]) =>
+    (definition.steps ?? [])
+      .filter((step) => step.uses?.startsWith(prefix) === true)
+      .map((step) => ({ job, step })),
+  )
+
+const HISTORY_PATH = '.flakemetry/history.json'
+
+describe('the restore keys', () => {
+  const restore = stepsUsing('actions/cache/restore@')
+
+  it('is exactly one step, so there is one place the lookup is defined', () => {
+    expect(restore).toHaveLength(1)
+    expect(restore[0]?.job).toBe('flakemetry')
+  })
+
+  it('restores the path the library reads', () => {
+    expect(restore[0]?.step.with?.path).toBe(HISTORY_PATH)
+  })
+
+  /**
+   * The exact key carries this run's id and can never hit — no earlier run wrote
+   * it. That is deliberate: it turns every lookup into a prefix search over the
+   * restore keys, newest first, which is the semantics the ADR chose `actions/cache`
+   * for in the first place.
+   */
+  it('uses a key no earlier run can have written', () => {
+    expect(restore[0]?.step.with?.key).toBe('history-${{ github.ref_name }}-${{ github.run_id }}')
+  })
+
+  it('falls back to this branch, then to main, in that order', () => {
+    const keys = (restore[0]?.step.with?.['restore-keys'] ?? '')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line !== '')
+
+    expect(keys).toEqual(['history-${{ github.ref_name }}-', 'history-main-'])
+  })
+
+  /** The ADR is the specification; drift between the two is the thing to catch. */
+  it('matches the keys the ADR specifies', () => {
+    expect(adr).toContain('history-${{ github.ref_name }}-${{ github.run_id }}')
+    expect(adr).toContain('history-${{ github.ref_name }}-')
+    expect(adr).toContain('history-main-')
+  })
+})
+
+describe('the single writer', () => {
+  const save = stepsUsing('actions/cache/save@')
+
+  /**
+   * ADR-0004 eliminates the lost-update race by having exactly one writer rather
+   * than by mitigating contention. A second save step anywhere would put the
+   * race back without changing a line of the reasoning that says there is none.
+   */
+  it('is one step, in one job', () => {
+    expect(save).toHaveLength(1)
+    expect(save[0]?.job).toBe('flakemetry')
+  })
+
+  it('runs only on main', () => {
+    expect(save[0]?.step.if).toBe("github.ref == 'refs/heads/main'")
+  })
+
+  it('saves under the key the restore keys fall back to', () => {
+    expect(save[0]?.step.with?.key).toBe('history-main-${{ github.run_id }}')
+    expect(save[0]?.step.with?.path).toBe(HISTORY_PATH)
+  })
+})
+
+describe('--write-history', () => {
+  const commands = Object.values(jobs)
+    .flatMap((job) => job.steps ?? [])
+    .map((step) => step.run ?? '')
+
+  /**
+   * The flag is what makes a job a writer, and a pull-request job that passed it
+   * would not error — it would feed its own branch's failures into the history
+   * that judges the next one, and the only symptom would be a determinism signal
+   * that slowly stopped meaning anything.
+   */
+  it('is passed only inside a branch guarded on main', () => {
+    const passing = commands.filter((run) => run.includes('--write-history'))
+    expect(passing).toHaveLength(1)
+
+    const command = passing[0] ?? ''
+    const guard = command.indexOf('refs/heads/main')
+    const flag = command.indexOf('--write-history')
+    expect(guard, 'the main guard must come before the flag it guards').toBeGreaterThan(-1)
+    expect(flag).toBeGreaterThan(guard)
+  })
+
+  it('has a branch that analyses without it, so pull requests still get a report', () => {
+    const command = commands.find((run) => run.includes('--write-history')) ?? ''
+    const withoutFlag = command
+      .split('\n')
+      .filter((line) => line.includes('flakemetry:analyze') && !line.includes('--write-history'))
+    expect(withoutFlag).toHaveLength(1)
+  })
+})
+
+describe('the job that runs it', () => {
+  it('does not wait for a milestone that has not shipped', () => {
+    // Gated on the command existing, not on the agents. Sharing a job with the
+    // triage agents is how the history cache sat unexercised through all of M6:
+    // `has-agents` looks for `agents/run.ts`, which lands in M7.
+    expect(jobs.flakemetry?.if).toContain('has-flakemetry')
+    expect(jobs.flakemetry?.if).not.toContain('has-agents')
+  })
+
+  /** The runs worth recording are the red ones. */
+  it('runs even when the suites failed', () => {
+    expect(jobs.flakemetry?.if).toContain('always()')
+    expect(jobs.flakemetry?.needs).toEqual(['hygiene', 'unit', 'e2e'])
+  })
+
+  it('reads both reports, and requires neither', () => {
+    const downloads = steps('flakemetry').filter((s) =>
+      s.uses?.startsWith('actions/download-artifact@'),
+    )
+    expect(downloads.map((s) => s.with?.name)).toEqual(['test-results', 'unit-results'])
+    for (const step of downloads) {
+      expect(step['continue-on-error' as keyof Step] ?? true).toBeTruthy()
+    }
+  })
+
+  /** Both halves of the pipeline's input have to survive the job that produced them. */
+  it('is given a unit report to read, because some job uploads one', () => {
+    const uploads = stepsUsing('actions/upload-artifact@').map(({ step }) => step.with?.name)
+    expect(uploads).toContain('unit-results')
+    expect(uploads).toContain('test-results')
+  })
+
+  it('publishes the document the agents read', () => {
+    const uploads = steps('flakemetry')
+      .filter((s) => s.uses?.startsWith('actions/upload-artifact@'))
+      .map((s) => s.with?.name)
+    expect(uploads).toEqual(['analysis'])
+    expect(steps('analyze').some((s) => s.with?.name === 'analysis')).toBe(true)
+  })
+})
+
+describe('what the job says out loud', () => {
+  const reporting = steps('flakemetry').find((s) => s.name?.includes('cache returned'))?.run ?? ''
+
+  /**
+   * ADR-0004 says cache scoping across branches is subtle enough to need
+   * verifying by observation. This is what makes the observation possible: a run
+   * that does not say which key answered cannot be checked afterwards.
+   */
+  it('names which restore key answered, or that none did', () => {
+    expect(reporting).toContain('cache-matched-key')
+    expect(reporting).toContain('MISS')
+    expect(reporting).toContain('HIT')
+  })
+
+  it('reports the size, so approaching the cap is visible before it bites', () => {
+    expect(reporting).toContain('bytes')
+    expect(reporting).toMatch(/::warning::/)
+  })
+})


### PR DESCRIPTION
Closes #60.

The cache steps were already written. They were sitting in a job gated on `agents/run.ts` — a file that lands in M7 — so the whole of M6 was built against a cache nobody had ever watched work.

That matters more than usual here, because ADR-0004 says in as many words that GitHub's scoping rules across branches are *"subtle enough to need a documented manual test at M6"*. A job that never runs cannot be observed.

## The split

| Job | Gate | Does |
|---|---|---|
| **Flakiness analysis** (new) | `scripts/analyze.ts` — exists | restore cache → analyse → upload `analysis.json` → save cache on `main` |
| **Agent triage** (was "Flakiness analysis & triage") | `agents/run.ts` — M7 | consumes `analysis.json` as an artifact |

The detection flags were built for exactly this incremental shipping; the history cache just wasn't given one.

The unit job now publishes `results-unit.json`. Nothing did — `test-results` carried only Playwright's report, so a history built from CI would have taught the classifier that every failure has a locator in it. Both downloads are `continue-on-error`, because a job where one suite was skipped still has the other's failures worth recording.

## One writer, guarded

```yaml
- name: Analyse the run
  run: |
    if [ "${{ github.ref }}" = "refs/heads/main" ]; then
      npm run flakemetry:analyze -- --write-history
    else
      npm run flakemetry:analyze
    fi
```

ADR-0004 eliminates the lost-update race by having exactly one writer rather than by mitigating contention. A pull-request job that passed the flag would not error — it would feed its own branch's failures into the history that judges the next one, and the only symptom would be a determinism signal that slowly stopped meaning anything.

## Why this is asserted rather than reviewed

Every failure mode here is silent:

- A wrong restore key does not error. It produces a cache miss — and a cache miss is indistinguishable from a first run on a branch.
- A second `cache/save` step anywhere puts the lost-update race back without changing a line of the reasoning that says there is none.
- `--write-history` on a PR job produces a perfectly normal-looking run.

`tests/unit/history-cache.test.ts` parses the workflow and checks the restore keys **against the ADR's own text**, that exactly one step saves, that it saves only on `main`, and that the flag appears exactly once and only *after* the guard. Five mutations against the workflow, all caught:

| Mutation | Caught by |
|---|---|
| Drop the `history-main-` fallback | `falls back to this branch, then to main, in that order` |
| Save the cache on every branch | `runs only on main` |
| Always pass `--write-history` | 2 tests |
| Gate the job on the agents again | `does not wait for a milestone that has not shipped` |
| Stop uploading the unit report | `is given a unit report to read, because some job uploads one` |

`yaml` moves from a transitive dependency to a declared one — a test that reads the workflow through a package nobody depends on is a test that disappears on the next dependency bump.

## The observation ADR-0004 asked for

The job logs which restore key answered, and how much came back:

```
::notice::history cache HIT via restore key: history-main-
::notice::history file: 41231 bytes, 1734 tests
```

with a `::warning::` past 25 MB, because GitHub evicts at a 10 GB repository cap and a single entry approaching that means the retained window needs shrinking long before it bites.

**On this PR the expected result is a MISS** — no run has ever saved a history, so there is nothing to restore. That is half the evidence: it exercises the degradation path end to end in CI for the first time, and #61's warning should appear in the job log.

The other half — a new branch restoring `main`'s history through the `history-main-` fallback — can only be observed *after* this merges and one `main` run has saved. I will link that run from the next PR in this milestone (#62), which is a fresh branch and therefore exactly the case the ADR flags as the one people get wrong.

1730 tests.

---

## Update: the observation found something

The first run of this job produced the evidence the criterion asked for, and a defect with it.

**The expected MISS, and #61's degradation path exercised in CI for the first time:**

```
Cache not found for input keys: history-183/merge-32115147442, history-183/merge-, history-main-
##[notice]history cache MISS — no key matched. Every test will read as new.
##[notice]no history file restored

  read results.json (playwright)
  read results-unit.json (vitest)
  wrote analysis.json
  1803 tests, 4 failing, 0 newly flaky, 4 to triage, no history — every test reads as new
```

Green job, `analysis.json` uploaded, both artifacts read. ([run 32115147442](https://github.com/AKogut/ai-flaky-test-triage/actions/runs/32115147442))

**And the defect, visible in the same three lines:**

```
key: history-183/merge-32115147442
```

`github.ref_name` is the branch on a `push` event and the **merge ref** on a `pull_request`. The branch-scoped key was a different string on every pull request and could match nothing.

It is harmless while ADR-0004's main-only rule holds — no branch cache exists to match, and the lookup falls through to `history-main-` exactly as intended. It becomes a silent trap the moment that policy is revisited, which the ADR's own final section contemplates. Nothing would have errored. The branch key would simply never have hit, and a cache miss is indistinguishable from a first run on a branch.

Fixed to `github.head_ref || github.ref_name` in the workflow, in ADR-0004, and in the test — all three, because the test asserts the workflow against the ADR's text and drift between them is the thing it exists to catch. Reverting the key fails three tests.

This is the entire argument for the ADR's caveat. Reading the documentation would not have found it; running the job and reading its log did.
