### PR TITLE
test(flakemetry): assert the shape of the signal over twenty-five runs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,6 +119,19 @@ Three consequences, and they are the reason it is defined this way rather than a
   real definition existed, so recency weighting was the only thing that moved when they were
   rescored.
 
+One half-life of quiet leaves **0.37, not 0.5** — a test that alternated on all of its last ten runs
+and then passed ten times scores 0.37, and after forty quiet runs, 0.03. The weights halve, but the
+quiet runs are transitions too: they enter the denominator without entering the numerator, so the
+score falls faster than the weighting alone. Worth stating because "half-life 10" invites the other
+reading.
+
+The curve that makes the two axes worth having is a regression, not a flaky test. Ten passes then
+twelve failures scores `0 … 0, 0.13, 0.12, 0.10, … 0.04`: it **spikes** when the test breaks and
+then decays as it keeps failing, because a test that keeps failing has stopped alternating. Read on
+the run it broke, that looks flaky. Read across twenty-two runs, it is plainly a regression — and
+`consecutiveFailures` climbs to 12 while the score falls, which is the pair of numbers that says
+so.
+
 Skipped runs are dropped before scoring — a skip produced no evidence, and reading it as "did not
 fail" invents an alternation on both sides of it, so a quarantined test would score as the flakiest
 in the suite. A run that was flaky _within itself_ counts as a transition even in first position: it

--- a/flakemetry-lib/history.ts
+++ b/flakemetry-lib/history.ts
@@ -48,9 +48,16 @@ export const HISTORY_FILE = '.flakemetry/history.json'
  * merge, and it is bounded on both sides for a reason. It has to be several
  * times the scoring half-life, or the cap — not the decay — is what ends up
  * shaping the score. And it has to stay small enough that the file is not the
- * thing that breaks the cache: five hundred tests at fifty entries is about two
- * megabytes of JSON, which is inside the budget with room to spare and parses in
- * milliseconds.
+ * thing that breaks the cache.
+ *
+ * The size is measured rather than estimated, because the estimate was wrong by
+ * a factor of two. This repository's own unit suite — 1758 tests — reaches
+ * **13.6 MB** at fifty entries each, about 155 bytes per entry once the `testId`
+ * keys are counted. That is comfortably inside GitHub's budget and parses in
+ * milliseconds, but it is not the two megabytes this comment claimed before
+ * anybody ran the numbers. A suite an order of magnitude larger would want a
+ * lower cap, and the CI job warns past 25 MB so that arrives as a message rather
+ * than as a cache that silently stops persisting.
  *
  * Configurable per call, because a suite that runs on every push accumulates a
  * month of runs in a week.

--- a/flakemetry-lib/trajectory.test.ts
+++ b/flakemetry-lib/trajectory.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, it } from 'vitest'
+import {
+  emptyHistory,
+  type FlakySignal,
+  type History,
+  type TestResult,
+  type TestRun,
+} from '@sentra/contracts'
+import { DEFAULT_HALF_LIFE, analyse, historyDepth } from './analyze.js'
+import { mergeRun } from './history.js'
+
+/**
+ * The signal over a sequence of runs, rather than over one.
+ *
+ * Single-run tests miss the whole class of defect that matters here, and they
+ * miss it while looking thorough: a score that never decays, a streak that
+ * resets on the wrong event, a history that grows past its cap. Every one of
+ * those is correct on run one and wrong on run twenty.
+ *
+ * Each case drives `mergeRun` and `analyse` run by run — the same path
+ * `flakemetry:analyze` takes — and asserts the shape of the whole curve.
+ */
+
+const TEST_ID = 'tests/e2e/board.spec.ts›shows a row'
+const STATUS = { P: 'passed', F: 'failed', T: 'timedOut', S: 'skipped' } as const
+
+const result = (over: Partial<TestResult> = {}): TestResult => ({
+  testId: TEST_ID,
+  title: 'shows a row',
+  file: 'tests/e2e/board.spec.ts',
+  status: 'passed',
+  attempts: 1,
+  flakyWithinRun: false,
+  durationMs: 12,
+  annotations: [],
+  ...over,
+})
+
+const run = (over: Partial<TestRun> = {}): TestRun => ({
+  runId: 'run-1',
+  commitSha: 'abc1234',
+  branch: 'main',
+  startedAt: '2026-08-01T00:00:00.000Z',
+  durationMs: 100,
+  source: 'playwright',
+  results: [result()],
+  ...over,
+})
+
+/** Run `n`, a day after run `n - 1`. Built by addition so it stays valid past the 31st. */
+const day = (n: number): string =>
+  new Date(Date.UTC(2026, 7, 1) + (n - 1) * 86_400_000).toISOString()
+
+interface Step {
+  run: number
+  signal: FlakySignal
+  historyDepth: number
+  historyAvailable: boolean
+}
+
+/**
+ * Drive a whole sequence, one run at a time, and keep every signal along the way.
+ *
+ * `analyse` is handed the history as it stood before each run and the history is
+ * merged after — which is exactly what the CLI does, so a trajectory asserted
+ * here is a trajectory production would produce.
+ *
+ * `letters` may contain a `-` for a run this test did not appear in, which is
+ * how a newly-introduced test is expressed.
+ */
+function trajectory(letters: string, options: { cap?: number; halfLife?: number } = {}): Step[] {
+  let history: History = emptyHistory()
+  const steps: Step[] = []
+
+  ;[...letters].forEach((letter, index) => {
+    const number = index + 1
+    const results =
+      letter === '-'
+        ? [result({ testId: 'some other test' })]
+        : [result({ status: STATUS[letter as keyof typeof STATUS] })]
+    const current = run({ runId: `run-${String(number)}`, startedAt: day(number), results })
+
+    const analysis = analyse(current, history, {
+      analysedAt: day(number),
+      ...(options.cap === undefined ? {} : { cap: options.cap }),
+      ...(options.halfLife === undefined ? {} : { halfLife: options.halfLife }),
+    })
+    const signal = analysis.tests.find((t) => t.result.testId === TEST_ID)?.signal
+    if (signal !== undefined) {
+      steps.push({
+        run: number,
+        signal,
+        historyDepth: analysis.historyDepth,
+        historyAvailable: analysis.historyAvailable,
+      })
+    }
+
+    history = mergeRun(history, current, options.cap === undefined ? {} : { cap: options.cap })
+  })
+
+  return steps
+}
+
+const scores = (steps: Step[]): number[] => steps.map((s) => s.signal.flakinessScore)
+const last = (steps: Step[]): Step => {
+  const step = steps.at(-1)
+  if (step === undefined) throw new Error('no steps')
+  return step
+}
+
+// ---------------------------------------------------------------------------
+// The five shapes
+// ---------------------------------------------------------------------------
+
+describe('a test that always passes', () => {
+  const steps = trajectory('P'.repeat(25))
+
+  it('never scores above zero, however long it runs', () => {
+    expect(scores(steps).every((s) => s === 0)).toBe(true)
+  })
+
+  it('is new exactly once', () => {
+    expect(steps.filter((s) => s.signal.isNew)).toHaveLength(1)
+    expect(steps[0]?.signal.isNew).toBe(true)
+  })
+
+  it('keeps counting runs and keeps its first sighting', () => {
+    expect(last(steps).signal).toMatchObject({
+      totalRuns: 25,
+      firstSeenAt: day(1),
+      lastPassedAt: day(25),
+      consecutiveFailures: 0,
+    })
+  })
+})
+
+describe('a test that always fails', () => {
+  const steps = trajectory('F'.repeat(25))
+
+  /**
+   * The headline property of the whole scoring function, over a sequence rather
+   * than an assertion. A test that fails every run is broken, not flaky; scoring
+   * it high would put every genuine regression into the `intermittent` bucket.
+   */
+  it('scores zero on every single run', () => {
+    expect(scores(steps).every((s) => s === 0)).toBe(true)
+  })
+
+  it('never once reports a pass it did not have', () => {
+    expect(steps.every((s) => s.signal.lastPassedAt === null)).toBe(true)
+  })
+
+  it('grows the failure streak by exactly one per run', () => {
+    expect(steps.map((s) => s.signal.consecutiveFailures)).toEqual(
+      Array.from({ length: 25 }, (_, i) => i + 1),
+    )
+  })
+})
+
+describe('a test that alternates every run', () => {
+  const steps = trajectory('PF'.repeat(13))
+
+  it('reaches 1 on its second run and stays there', () => {
+    expect(scores(steps)[0]).toBe(0)
+    expect(
+      scores(steps)
+        .slice(1)
+        .every((s) => s === 1),
+    ).toBe(true)
+  })
+
+  /** The streak is about the tail, not the total. Alternating means it never builds one. */
+  it('never builds a streak longer than one', () => {
+    expect(Math.max(...steps.map((s) => s.signal.consecutiveFailures))).toBe(1)
+  })
+})
+
+describe('a test introduced part-way through', () => {
+  // Fifteen runs it is not in, then ten it is.
+  const steps = trajectory('-'.repeat(15) + 'PFPFPFPFPF')
+
+  it('appears only in the runs it ran in', () => {
+    expect(steps).toHaveLength(10)
+    expect(steps[0]?.run).toBe(16)
+  })
+
+  /**
+   * New to *itself*, not to the suite. The run had fifteen runs of history
+   * behind it, and `isNew` has to mean this test rather than this cache.
+   */
+  it('is new on its first run, against a history that was far from empty', () => {
+    expect(steps[0]?.signal.isNew).toBe(true)
+    expect(steps[0]?.historyAvailable).toBe(true)
+    expect(steps[0]?.historyDepth).toBe(15)
+  })
+
+  it('is never new again', () => {
+    expect(steps.slice(1).every((s) => !s.signal.isNew)).toBe(true)
+  })
+
+  it('dates itself from when it arrived, not from when the suite did', () => {
+    expect(last(steps).signal.firstSeenAt).toBe(day(16))
+    expect(last(steps).signal.totalRuns).toBe(10)
+  })
+})
+
+describe('a test that was flaky and recovered', () => {
+  const letters = 'PFPFPFPFPF' + 'P'.repeat(12)
+  const steps = trajectory(letters)
+
+  /**
+   * Hand-checked at the turning point and then every run after it. Ten runs of
+   * perfect alternation score 1; from the eleventh every run is a transition
+   * that did *not* change, so each one adds weight to the denominator and none
+   * to the numerator.
+   */
+  it('follows the documented curve, run by run', () => {
+    expect(scores(steps)).toEqual([
+      0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0.87, 0.77, 0.68, 0.61, 0.55, 0.49, 0.44, 0.4, 0.37, 0.33,
+      0.3,
+    ])
+  })
+
+  it('only ever falls once the alternation stops', () => {
+    const decaying = scores(steps).slice(10)
+    for (const [i, score] of decaying.entries()) {
+      if (i > 0) expect(score, `run ${String(i + 11)}`).toBeLessThan(decaying[i - 1] ?? 1)
+    }
+  })
+
+  /**
+   * One half-life of stable runs leaves 0.37, not 0.5. The weights halve, but
+   * the stable runs are transitions too — they enter the denominator without
+   * entering the numerator, so the score falls faster than the weighting alone.
+   * Worth pinning because "half-life 10" invites the other reading.
+   */
+  it('is down to roughly a third after one half-life of quiet, not to a half', () => {
+    const afterOneHalfLife = trajectory('PFPFPFPFPF' + 'P'.repeat(DEFAULT_HALF_LIFE))
+    expect(last(afterOneHalfLife).signal.flakinessScore).toBeCloseTo(0.37, 2)
+  })
+
+  it('is near zero after a month of quiet', () => {
+    const quiet = trajectory('PFPFPFPFPF' + 'P'.repeat(40))
+    expect(last(quiet).signal.flakinessScore).toBeLessThan(0.05)
+  })
+
+  it('forgets faster with a shorter half-life and slower with a longer one', () => {
+    const fast = last(trajectory(letters, { halfLife: 3 })).signal.flakinessScore
+    const slow = last(trajectory(letters, { halfLife: 30 })).signal.flakinessScore
+    expect(fast).toBeLessThan(slow)
+  })
+})
+
+describe('a regression that never recovers', () => {
+  const steps = trajectory('P'.repeat(10) + 'F'.repeat(12))
+
+  /**
+   * The shape that makes the two axes worth having. The score *spikes* when the
+   * test breaks and then decays as it keeps failing, because a test that keeps
+   * failing has stopped alternating. Read on run 11 alone this looks flaky; read
+   * over twenty-two runs it is plainly a regression, and the streak says so.
+   */
+  it('spikes when it breaks and then decays as it stays broken', () => {
+    expect(scores(steps)).toEqual([
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.13, 0.12, 0.1, 0.09, 0.08, 0.07, 0.07, 0.06, 0.05, 0.05, 0.04,
+      0.04,
+    ])
+  })
+
+  it('says what it is through the streak, which grows while the score falls', () => {
+    expect(last(steps).signal.consecutiveFailures).toBe(12)
+    expect(last(steps).signal.flakinessScore).toBeLessThan(0.05)
+  })
+
+  it('remembers the last time it worked', () => {
+    expect(last(steps).signal.lastPassedAt).toBe(day(10))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The retained window, over a sequence long enough for it to bite
+// ---------------------------------------------------------------------------
+
+describe('the cap, over twenty-five runs', () => {
+  const CAP = 5
+  const letters = 'PFPPFPFPPFPFPPFPFPPFPFPPF'
+  const steps = trajectory(letters, { cap: CAP })
+
+  it('never retains more than the cap', () => {
+    expect(steps.every((s) => s.signal.statusHistory.length <= CAP)).toBe(true)
+  })
+
+  /** Oldest first: the retained window is always the tail of what actually ran. */
+  it('evicts oldest first, so the window is the most recent runs at every step', () => {
+    for (const step of steps) {
+      expect(step.signal.statusHistory, `run ${String(step.run)}`).toBe(
+        letters.slice(0, step.run).slice(-CAP),
+      )
+    }
+  })
+
+  /**
+   * The reason the count is stored rather than derived. Read it off the entries
+   * and every test past the cap reports the cap for ever, and a year of history
+   * and a fortnight of it become the same number.
+   */
+  it('keeps counting runs long after it has stopped keeping them', () => {
+    expect(last(steps).signal.totalRuns).toBe(25)
+    expect(last(steps).signal.statusHistory).toHaveLength(CAP)
+  })
+
+  it('still dates the test from its first run, not from the oldest one retained', () => {
+    expect(last(steps).signal.firstSeenAt).toBe(day(1))
+  })
+
+  /** A capped window scores the window. Nothing outside it can be read, so nothing outside it counts. */
+  it('scores only what it retained', () => {
+    const capped = trajectory('F'.repeat(20) + 'PFPFP', { cap: CAP })
+    expect(last(capped).signal.flakinessScore).toBe(1)
+  })
+
+  /**
+   * Depth is what the scoring *could draw on*, so the cap bounds it: with one
+   * test and a window of five, five runs are all the file holds. It is the union
+   * across tests rather than any one test's window, so a real suite where tests
+   * come and go reports more than the cap — but it can never report runs that
+   * were evicted from every test at once, and claiming otherwise would overstate
+   * the evidence behind every score in the document.
+   */
+  it('reports what the file holds, which the cap bounds', () => {
+    expect(last(steps).historyDepth).toBe(CAP)
+    expect(last(steps).signal.totalRuns).toBe(25)
+  })
+
+  it('is the union across tests, not one test’s window', () => {
+    let history = emptyHistory()
+    for (const [index, ids] of [['a', 'b'], ['a'], ['b'], ['c']].entries()) {
+      history = mergeRun(
+        history,
+        run({
+          runId: `run-${String(index + 1)}`,
+          startedAt: day(index + 1),
+          results: ids.map((testId) => result({ testId })),
+        }),
+        { cap: 1 },
+      )
+    }
+    // Every test retains one entry; between them they name three distinct runs.
+    expect(historyDepth(history)).toBe(3)
+  })
+})


### PR DESCRIPTION
Closes #62, and completes M6.

Single-run tests miss the whole class of defect that matters here, and they miss it while looking thorough: a score that never decays, a streak that resets on the wrong event, a history that grows past its cap. Every one of those is correct on run one and wrong on run twenty.

Each case drives `mergeRun` and `analyse` **run by run** — the path the CLI takes — and asserts the whole curve rather than an endpoint.

## The two curves worth reading

**A test that was flaky and recovered.** Ten runs of perfect alternation, then twelve quiet ones:

```
0  1  1  1  1  1  1  1  1  1  1  0.87  0.77  0.68  0.61  0.55  0.49  0.44  0.40  0.37  0.33  0.30
```

One half-life of quiet leaves **0.37, not 0.5**, which is not what "half-life 10" suggests. The weights halve, but the quiet runs are transitions too — they enter the denominator without entering the numerator, so the score falls faster than the weighting alone. Pinned, because the other reading is the natural one.

**A regression that never recovers.** Ten passes, then twelve failures:

```
0  0  0  0  0  0  0  0  0  0  0.13  0.12  0.10  0.09  0.08  0.07  0.07  0.06  0.05  0.05  0.04  0.04
```

It **spikes** when the test breaks and then decays as it keeps failing — because a test that keeps failing has stopped alternating. Read on the run it broke, that looks flaky. Read across twenty-two runs it is plainly a regression, and `consecutiveFailures` climbing to 12 *while the score falls* is the pair of numbers that says so.

That is the whole argument for two axes, drawn as a curve.

## The five shapes

| | |
|---|---|
| always passes | 0 on all 25 runs; `isNew` exactly once |
| always fails | **0 on all 25 runs**; streak grows by exactly one per run; `lastPassedAt` never invented |
| alternates every run | reaches 1 on run 2 and stays; never builds a streak longer than 1 |
| introduced at run 16 | new to *itself*, against a history 15 runs deep — `isNew` true once, `historyAvailable` true, dated from run 16 |
| flaky then recovered | the curve above |

## The cap, asserted at every step

Not at the end. For all twenty-five runs the retained window equals the tail of what actually ran:

```ts
expect(step.signal.statusHistory).toBe(letters.slice(0, step.run).slice(-CAP))
```

`totalRuns` keeps climbing past the cap and `firstSeenAt` stays put — which is why both are stored rather than derived.

`historyDepth` turned out to be **bounded by the cap**, and my first expectation was wrong about it. It is the union of run ids across tests, so a real suite where tests come and go reports more than any one test's window — but it can never report runs evicted from every test at once, and claiming otherwise would overstate the evidence behind every score in the document. The test says that now, with a case that shows the union.

## Testing

1758 tests, 27 of them new. Six mutations against the library, all caught:

| Mutation | Caught by |
|---|---|
| Flatten the weights (no decay) | 5 tests |
| Reset the streak on any run | 2 tests |
| `totalRuns` reads the window | 2 tests |
| Remove the cap | 5 tests |
| Evict newest first | 3 tests |
| Score failures instead of alternations | 5 tests |

The decay numbers and the regression curve are documented in `docs/architecture.md` beside the score's definition, because "0.37 after one half-life" is the kind of thing a reader will otherwise recompute and mistrust.

---

## The evidence #60 was still owed

This branch's `Flakiness analysis` job is the case ADR-0004 says people get wrong — a fresh branch, restoring `main`'s history:

```
key: history-test/62-multi-run-fixture-sequences-32116166714
Cache hit for restore-key: history-main-32115815984
##[notice]history cache HIT via restore key: history-main-32115815984
##[notice]history file: 680065 bytes, 1804 tests

  1831 tests, 2 failing, 1 newly flaky, 2 to triage, 1 runs of history
  history not written (pass --write-history; ADR-0004 confines that to main)
```

([run 32116166714](https://github.com/AKogut/ai-flaky-test-triage/actions/runs/32116166714))

Every clause of the ADR, observed rather than reasoned about:

- the branch key is the **branch**, not the merge ref
- the exact key misses, and the lookup falls through to `history-main-`
- the pull-request job **does not write**
- the size is logged
- and `1 newly flaky` is the first real signal this pipeline has ever produced from history it actually restored

## One more thing the measurement corrected

The comment beside the cap claimed five hundred tests at fifty entries is about two megabytes. Measured against this repository's own unit suite — 1758 tests, driven to the full cap — it is **13.6 MB**, about 155 bytes an entry once the `testId` keys are counted. Roughly double the estimate.

The cap does not change: 13.6 MB is comfortably inside GitHub's budget and parses in milliseconds. But a number nobody ran is not a justification, so the comment now carries the measured figure and says what a suite an order of magnitude larger would need.
