### PR TITLE
docs(docs): M6 is done, and the criterion was read out of a job log

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <!-- status:start -->
 
 > **Project status: M3 — Triage agent & replay mode.**
-> 4 of 11 milestones complete.
+> 5 of 11 milestones complete.
 > Current exit criterion: the triage agent beats the baseline on joint accuracy by a margin that survives its confidence interval — or the finding that it does not is documented in the README. Either way, `npm run demo` runs the classifier end to end with no API key.
 >
 > Progress is tracked as [milestones](https://github.com/AKogut/ai-flaky-test-triage/milestones), not dates.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -102,10 +102,26 @@ catch.
 `analyze()` and the history file: EWMA flakiness scoring, streak tracking, atomic capped writes,
 and the CI cache strategy with `main`-only writes.
 
-**Status:** planned
+**Status:** done
 
 **Exit criterion:** history survives across CI runs on `main`, a cache miss degrades gracefully
 rather than crashing, and both behaviours have tests.
+
+**Met, and observed rather than argued.** ADR-0004 says GitHub's cache scoping across branches is
+subtle enough to need checking by observation, so all three clauses were read out of job logs:
+
+- A `main` run wrote `history-main-32115815984` with 1804 tests. The next `main` run restored it,
+  analysed against it, and saved 2 runs' worth — history surviving between two jobs that share
+  nothing else. ([run 32116732108](https://github.com/AKogut/ai-flaky-test-triage/actions/runs/32116732108))
+- A fresh branch restored `main`'s history through the `history-main-` fallback and did **not**
+  write. ([run 32116166714](https://github.com/AKogut/ai-flaky-test-triage/actions/runs/32116166714))
+- Before any history existed, a run missed the cache, said so, and produced a full analysis with
+  exit 0. ([run 32115147442](https://github.com/AKogut/ai-flaky-test-triage/actions/runs/32115147442))
+
+The observation earned its place: the first log showed the branch key was `history-183/merge-`,
+because `github.ref_name` is the merge ref on a pull request. Harmless while only `main` writes,
+and a silent trap the moment that is revisited. Fixed in the workflow, the ADR and a test that
+asserts one against the other.
 
 ## M7 — Root-cause & fix-suggestion agents
 

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -3,7 +3,7 @@
 <!-- status:start -->
 
 > **Project status: M3 — Triage agent & replay mode.**
-> 4 of 11 milestones complete.
+> 5 of 11 milestones complete.
 > Current exit criterion: the triage agent beats the baseline on joint accuracy by a margin that survives its confidence interval — or the finding that it does not is documented in the README. Either way, `npm run demo` runs the classifier end to end with no API key.
 >
 > Progress is tracked as [milestones](https://github.com/AKogut/ai-flaky-test-triage/milestones), not dates.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -5,7 +5,7 @@
 <!-- status:start -->
 
 > **Project status: M3 — Triage agent & replay mode.**
-> 4 of 11 milestones complete.
+> 5 of 11 milestones complete.
 > Current exit criterion: the triage agent beats the baseline on joint accuracy by a margin that survives its confidence interval — or the finding that it does not is documented in the README. Either way, `npm run demo` runs the classifier end to end with no API key.
 >
 > Progress is tracked as [milestones](https://github.com/AKogut/ai-flaky-test-triage/milestones), not dates.


### PR DESCRIPTION
M6 is done. This marks it, and records how that was established.

The exit criterion is *"history survives across CI runs on `main`, a cache miss degrades gracefully rather than crashing, and both behaviours have tests"*. ADR-0004 says in as many words that GitHub's cache scoping across branches is subtle enough to need checking by observation, so all three clauses were read out of job logs rather than argued from the workflow file.

**History survives between two `main` jobs that share nothing else:**

```
Cache hit for restore-key: history-main-32115815984
##[notice]history file: 680065 bytes, 1804 tests
  1831 tests, 2 failing, 3 newly flaky, 2 to triage, 1 runs of history
  wrote .flakemetry/history.json — 1831 tests, 2 runs
Cache saved with key: history-main-32116732108
```

**A fresh branch restores `main`'s history, and does not write:**

```
key: history-test/62-multi-run-fixture-sequences-32116166714
Cache hit for restore-key: history-main-32115815984
  history not written (pass --write-history; ADR-0004 confines that to main)
```

**And before any history existed, the miss path:**

```
Cache not found for input keys: …, history-main-
##[notice]history cache MISS — no key matched. Every test will read as new.
  1803 tests, 4 failing, 0 newly flaky, 4 to triage, no history — every test reads as new
```

Exit 0, full analysis, `analysis.json` uploaded.

## The observation earned its place

The very first of those logs showed the branch key as `history-183/merge-` — `github.ref_name` is the branch on a `push` and the **merge ref** on a `pull_request`. Harmless while ADR-0004's main-only rule holds, because no branch cache exists to match; a silent trap the moment that policy is revisited, which the ADR itself contemplates. Nothing would have errored.

Reading the documentation would not have found it. Running the job and reading its log did — which is the entire argument for the caveat the ADR wrote down.

## The milestone, in short

| | |
|---|---|
| #57 | `history.ts` — read, merge, atomic capped write |
| #58 | `analyze.ts` — alternation scoring, recency-weighted |
| #59 | `flakemetry:analyze` — reports plus history in, one document out |
| #61 | a cache that failed is a warning, not a red pipeline |
| #60 | the cache wired to a job that actually runs |
| #62 | the signal's shape asserted over twenty-five runs |

Three defects that only a run could find: a local run id that doubled the history on re-invocation, eighteen test identities shared by more than one test, and the merge-ref key. Plus one measurement that corrected a comment — the retained window costs 13.6 MB at the default cap, not the two megabytes nobody had checked.

Banners regenerate from `ROADMAP.md`; nothing here is hand-edited.
