### PR TITLE
feat(agents): give the classifier the sequence a state leak leaves behind

### DIFF
--- a/agents/__snapshots__/context.test.ts.snap
+++ b/agents/__snapshots__/context.test.ts.snap
@@ -79,7 +79,7 @@ diff --git a/app/client/src/TaskCard.tsx b/app/client/src/TaskCard.tsx
 
 [END UNTRUSTED DATA: diffHunks]
 
-Not available for this failure: testSource, sourceUnderTest."
+Not available for this failure: testSource, runContext, sourceUnderTest."
 `;
 
 exports[`the rendered bundle > matches the recorded rendering for a hard-quadrant fixture 1`] = `
@@ -157,5 +157,5 @@ it('two overlapping writes both survive', async () => {
 
 [END UNTRUSTED DATA: testSource]
 
-Not available for this failure: sourceUnderTest, diffSummary, diffHunks."
+Not available for this failure: runContext, sourceUnderTest, diffSummary, diffHunks."
 `;

--- a/agents/context.test.ts
+++ b/agents/context.test.ts
@@ -1,12 +1,18 @@
 import { readFileSync } from 'node:fs'
-import { FixturePayloadSchema, type ClassificationInput } from '@sentra/contracts'
+import {
+  FixturePayloadSchema,
+  type AnalysedTest,
+  type ClassificationInput,
+} from '@sentra/contracts'
 import { describe, expect, it } from 'vitest'
 import {
   CONTEXT_FIELDS,
   assembleContext,
   changedPaths,
   diffSignal,
+  RUN_CONTEXT_NEIGHBOURS,
   renderContext,
+  runContextFor,
   samePath,
   siblingImplementation,
   stackPaths,
@@ -372,6 +378,181 @@ describe('ablation', () => {
     // No signals section at all rather than an empty heading, which would read
     // as "we measured nothing" instead of "we sent nothing".
     expect(renderContext(bundle)).not.toContain('MEASURED SIGNALS')
+  })
+})
+
+describe('what else ran in this worker', () => {
+  const neighbour = (testId: string, over: Partial<AnalysedTest['result']> = {}): AnalysedTest => ({
+    result: {
+      testId,
+      title: testId,
+      file: `tests/e2e/${testId}.spec.ts`,
+      status: 'passed' as const,
+      attempts: 1,
+      flakyWithinRun: false,
+      durationMs: 1,
+      annotations: [],
+      ...over,
+    },
+    signal: {
+      testId,
+      flakinessScore: 0,
+      consecutiveFailures: 0,
+      totalRuns: 1,
+      firstSeenAt: '2026-08-01T00:00:00.000Z',
+      lastPassedAt: null,
+      statusHistory: 'P',
+      isNew: true,
+    },
+  })
+
+  const at = (n: number): string => `2026-08-01T00:0${String(n)}:00.000Z`
+
+  /** A leak: the polluter ran first, in the same process, and passed. */
+  const run: AnalysedTest[] = [
+    neighbour('seeds-the-board', { workerIndex: 0, startedAt: at(1) }),
+    neighbour('leaves-a-row-behind', { workerIndex: 0, startedAt: at(2) }),
+    neighbour('elsewhere-entirely', { workerIndex: 1, startedAt: at(3) }),
+    neighbour('counts-the-rows', { workerIndex: 0, startedAt: at(4), status: 'failed' }),
+  ]
+
+  it('lists what shared the process, oldest first', () => {
+    const context = runContextFor(run, 'counts-the-rows')
+    expect(context?.before.map((n) => n.testId)).toEqual(['seeds-the-board', 'leaves-a-row-behind'])
+  })
+
+  /**
+   * The culprit in a state leak has usually **passed** — that is why it left
+   * something behind rather than dying. A field listing what else *failed* would
+   * have sounded useful and missed the case it was built for.
+   */
+  it('keeps the tests that passed, because those are the ones that leak', () => {
+    expect(runContextFor(run, 'counts-the-rows')?.before.every((n) => n.status === 'passed')).toBe(
+      true,
+    )
+  })
+
+  it('excludes another worker, which shares no process and so no state', () => {
+    expect(runContextFor(run, 'counts-the-rows')?.before.map((n) => n.testId)).not.toContain(
+      'elsewhere-entirely',
+    )
+  })
+
+  it('excludes what ran after, which cannot have caused anything', () => {
+    expect(runContextFor(run, 'leaves-a-row-behind')?.before.map((n) => n.testId)).toEqual([
+      'seeds-the-board',
+    ])
+  })
+
+  /**
+   * The order the results happen to sit in is not the order they ran. Playwright
+   * writes the report grouped by file, and a worker interleaves files — so
+   * trusting array position would produce a plausible-looking sequence that is
+   * wrong, which invites the wrong answer more strongly than no field at all.
+   */
+  it('orders by when tests ran, not by where they sit in the report', () => {
+    const shuffled = [
+      neighbour('third', { workerIndex: 0, startedAt: at(3) }),
+      neighbour('subject', { workerIndex: 0, startedAt: at(9), status: 'failed' }),
+      neighbour('first', { workerIndex: 0, startedAt: at(1) }),
+      neighbour('second', { workerIndex: 0, startedAt: at(2) }),
+    ]
+    expect(runContextFor(shuffled, 'subject')?.before.map((n) => n.testId)).toEqual([
+      'first',
+      'second',
+      'third',
+    ])
+  })
+
+  it('is null when the reporter did not say which worker ran what', () => {
+    expect(runContextFor([neighbour('alone')], 'alone')).toBeNull()
+  })
+
+  it('is null for a test the run does not contain', () => {
+    expect(runContextFor(run, 'never-ran')).toBeNull()
+  })
+
+  it('is an empty sequence, not null, for the first test in a worker', () => {
+    const context = runContextFor(run, 'seeds-the-board')
+    expect(context).not.toBeNull()
+    expect(context?.before).toEqual([])
+  })
+
+  /** A truncated sequence is not a sequence; the count says so out loud. */
+  it('keeps the most recent neighbours and counts what it dropped', () => {
+    const many = Array.from({ length: 25 }, (_, i) =>
+      neighbour(`t${String(i).padStart(2, '0')}`, {
+        workerIndex: 0,
+        startedAt: `2026-08-01T01:${String(i).padStart(2, '0')}:00.000Z`,
+      }),
+    )
+    many.push(
+      neighbour('subject', {
+        workerIndex: 0,
+        startedAt: '2026-08-01T02:00:00.000Z',
+        status: 'failed',
+      }),
+    )
+    const context = runContextFor(many, 'subject')
+    expect(context?.before).toHaveLength(RUN_CONTEXT_NEIGHBOURS)
+    expect(context?.before[0]?.testId).toBe('t15')
+    expect(context?.omitted).toBe(25 - RUN_CONTEXT_NEIGHBOURS)
+  })
+
+  /**
+   * #74 asks whether each context field earns its tokens. That question needs a
+   * number, and a number written down once drifts — so it is measured here, on a
+   * full complement of neighbours, and fails if it moves.
+   *
+   * 587 characters for ten neighbours — roughly 150 tokens — against a
+   * 1500-character cap and a 40,000-character evidence budget. Cheap, which is
+   * the argument for trying it at all; whether it is *worth* it is a question
+   * for the ablation, not for this file.
+   */
+  it('costs what the ablation will be told it costs', () => {
+    const full = Array.from({ length: RUN_CONTEXT_NEIGHBOURS }, (_, i) =>
+      neighbour(`neighbour-${String(i)}`, {
+        workerIndex: 0,
+        startedAt: `2026-08-01T00:${String(i).padStart(2, '0')}:00.000Z`,
+      }),
+    )
+    full.push(
+      neighbour('subject', {
+        workerIndex: 0,
+        startedAt: '2026-08-01T00:20:00.000Z',
+        status: 'failed',
+      }),
+    )
+
+    const base = fixture('board-shows-a-row-nothing-in-the-file-created')
+    const without = renderContext(assembleContext(base)).length
+    const withField = renderContext(
+      assembleContext({ ...base, runContext: runContextFor(full, 'subject') ?? undefined }),
+    ).length
+
+    expect(withField - without).toBe(587)
+  })
+
+  it('reaches the bundle as fenced, untrusted data', () => {
+    const bundle = assembleContext({
+      ...input(),
+      runContext: runContextFor(run, 'counts-the-rows') ?? undefined,
+    })
+    const rendered = renderContext(bundle)
+    expect(rendered).toContain('leaves-a-row-behind')
+    expect(rendered).toContain('BEGIN UNTRUSTED DATA')
+  })
+
+  /**
+   * An empty list reads as "nothing else ran", which is a claim, and a false
+   * one. The bundle's existing machinery states an absent field in words.
+   */
+  it('says nothing rather than rendering an empty sequence', () => {
+    const bundle = assembleContext({
+      ...input(),
+      runContext: runContextFor(run, 'seeds-the-board') ?? undefined,
+    })
+    expect(renderContext(bundle)).toContain('Not available for this failure')
   })
 })
 

--- a/agents/context.ts
+++ b/agents/context.ts
@@ -1,4 +1,4 @@
-import type { AnalysedTest, ClassificationInput } from '@sentra/contracts'
+import type { AnalysedTest, ClassificationInput, RunContext } from '@sentra/contracts'
 import { assembleEvidence, type Evidence, type FieldCaps, type UntrustedInput } from './sanitise.js'
 
 /**
@@ -53,6 +53,7 @@ export const CONTEXT_FIELDS = [
   'flakinessSignal',
   'statusHistory',
   'testSource',
+  'runContext',
   'diffSummary',
   'diffHunks',
   'derivedDiffSignal',
@@ -70,6 +71,92 @@ export interface ContextOptions {
 
 const included = (field: ContextField, options: ContextOptions): boolean =>
   options.include?.[field] !== false
+
+// ---------------------------------------------------------------------------
+// Run-level context
+// ---------------------------------------------------------------------------
+
+/**
+ * Neighbours retained, and why there is a limit at all.
+ *
+ * A leak is left by something that ran shortly before, so the most recent
+ * neighbours carry nearly all of the signal and a full worker's sequence is
+ * mostly tokens. Ten is enough to hold a `beforeEach` chain plus the specs
+ * around it; past that the field starts competing with the diff for room in the
+ * prompt, and #74 is where "does this earn its place" gets an answer with
+ * numbers rather than a guess.
+ */
+export const RUN_CONTEXT_NEIGHBOURS = 10
+
+/**
+ * What else ran in this test's worker before it.
+ *
+ * Pure, and derived from `analysis.json`, which already holds every test in the
+ * run — the material existed all along; nothing assembled it.
+ *
+ * Ordered by `startedAt` where the reporter gave one. Falling back to the order
+ * the results happen to appear in would be worse than useless here: the whole
+ * value of the field is the *sequence*, and a plausible-looking wrong sequence
+ * is a stronger invitation to the wrong answer than no field at all.
+ */
+export function runContextFor(
+  tests: readonly AnalysedTest[],
+  testId: string,
+  limit: number = RUN_CONTEXT_NEIGHBOURS,
+): RunContext | null {
+  const subject = tests.find((t) => t.result.testId === testId)
+  const worker = subject?.result.workerIndex
+  if (subject === undefined || worker === undefined || subject.result.startedAt === undefined) {
+    return null
+  }
+
+  const started = subject.result.startedAt
+  const sameWorker = tests
+    .filter(
+      (t) =>
+        t.result.workerIndex === worker &&
+        t.result.testId !== testId &&
+        t.result.startedAt !== undefined &&
+        t.result.startedAt < started,
+    )
+    .sort((a, b) => (a.result.startedAt ?? '').localeCompare(b.result.startedAt ?? ''))
+
+  const kept = sameWorker.slice(-limit)
+  return {
+    workerIndex: worker,
+    before: kept.map((t) => ({
+      testId: t.result.testId,
+      title: t.result.title,
+      file: t.result.file,
+      status: t.result.status,
+    })),
+    omitted: sameWorker.length - kept.length,
+  }
+}
+
+/**
+ * The sequence as one untrusted block.
+ *
+ * Titles and paths came out of the repository, so they go through `sanitise.ts`
+ * and are fenced as data like every other string a contributor controls — a
+ * neighbour called `` ` ``-fenced-anything must not be able to forge structure.
+ *
+ * An empty sequence renders as an empty string, which the assembler already
+ * treats as an absent field and states in words. That is the wanted behaviour —
+ * a rendered empty list would read as "nothing else ran", which is a claim, and
+ * a false one — and it needs no special case here, so there is not one: a branch
+ * that cannot change the output is a branch that will one day be read as
+ * meaningful.
+ */
+function renderRunContext(context: RunContext | undefined): string | undefined {
+  if (context === undefined) return undefined
+  const lines = context.before.map((n) => `${n.status.padEnd(8)} ${n.file} › ${n.title}`)
+  return context.omitted > 0
+    ? [`[... ${String(context.omitted)} earlier tests in this worker not listed]`, ...lines].join(
+        '\n',
+      )
+    : lines.join('\n')
+}
 
 // ---------------------------------------------------------------------------
 // Derived signals
@@ -225,6 +312,7 @@ export function assembleContext(
     errorStack: has('errorStack') ? result.error?.stack : undefined,
     errorSnippet: has('errorSnippet') ? result.error?.snippet : undefined,
     testSource: has('testSource') ? input.testSource : undefined,
+    runContext: has('runContext') ? renderRunContext(input.runContext) : undefined,
     diffSummary: has('diffSummary') ? summariseDiff(diff) : undefined,
     diffHunks: has('diffHunks') ? diff : undefined,
   }

--- a/agents/sanitise.ts
+++ b/agents/sanitise.ts
@@ -62,6 +62,7 @@ export const FIELD_CAPS = {
   errorStack: 4_000,
   errorSnippet: 1_500,
   testSource: 6_000,
+  runContext: 1_500,
   sourceUnderTest: 8_000,
   diffSummary: 2_000,
   diffHunks: 12_000,

--- a/contracts/analysis.ts
+++ b/contracts/analysis.ts
@@ -134,6 +134,49 @@ export type Analysis = z.infer<typeof AnalysisSchema>
  * out of it, so the fields the eval harness keeps for itself cannot reach a
  * prompt built from this type. Structural rather than remembered.
  */
+/**
+ * One test that shared a worker with the failing one.
+ *
+ * Four fields, not a whole `TestResult`. The question this answers is "what else
+ * touched the same process before this ran", and an error message from a
+ * different test is noise for that — it would also multiply the field's token
+ * cost by an order of magnitude to say nothing extra.
+ */
+export const RunNeighbourSchema = z
+  .object({
+    testId: z.string().min(1),
+    title: z.string().min(1),
+    file: z.string().min(1),
+    status: z.enum(['passed', 'failed', 'timedOut', 'skipped']),
+  })
+  .strict()
+export type RunNeighbour = z.infer<typeof RunNeighbourSchema>
+
+/**
+ * What else happened in this run, for the one failure shape that needs it.
+ *
+ * A spec leaves a row behind; a different spec fails because of it. The failing
+ * test's own evidence — assertion, stack, snippet, diff — is complete and points
+ * entirely at a file that is not the problem, so no amount of it can reach the
+ * cause. Only the sequence can.
+ *
+ * Note what this is *not*: a list of what else failed. The culprit in a state
+ * leak has usually **passed**, which is why it left something behind rather than
+ * dying. A "what else went wrong in this run" field would have sounded useful
+ * and missed the case it was built for.
+ */
+export const RunContextSchema = z
+  .object({
+    /** The worker this test ran in, when the reporter said which. */
+    workerIndex: z.int().min(0).optional(),
+    /** Tests that ran in the same worker before this one, oldest first. */
+    before: z.array(RunNeighbourSchema),
+    /** Dropped by the cap. Stated rather than silent: a truncated sequence is not a sequence. */
+    omitted: z.int().min(0),
+  })
+  .strict()
+export type RunContext = z.infer<typeof RunContextSchema>
+
 export const ClassificationInputSchema = z
   .object({
     /** The failing test plus its flakiness signal. */
@@ -144,6 +187,15 @@ export const ClassificationInputSchema = z
     testSource: z.string().max(20_000).optional(),
     /** False when the run had no history to draw on — a cache miss, usually. */
     historyAvailable: z.boolean(),
+    /**
+     * What else ran in the same worker before this test.
+     *
+     * Optional because a reporter that does not say which worker ran what cannot
+     * produce it, and because every fixture written before #168 predates it. Its
+     * absence has to be stated to the classifier rather than left blank, the same
+     * as an absent history — see `agents/context.ts`.
+     */
+    runContext: RunContextSchema.optional(),
   })
   .strict()
 export type ClassificationInput = z.infer<typeof ClassificationInputSchema>

--- a/contracts/reporters/playwright.ts
+++ b/contracts/reporters/playwright.ts
@@ -45,6 +45,14 @@ const PlaywrightResultSchema = z.looseObject({
   status: z.enum(['passed', 'failed', 'timedOut', 'skipped', 'interrupted']),
   duration: z.number(),
   retry: z.number(),
+  /**
+   * Optional because a reporter that drops them should degrade rather than fail
+   * the run — they buy one failure shape, not the whole pipeline. Playwright has
+   * emitted both for years; declaring them required would turn a reporter
+   * regression into a hard stop on evidence the classifier can do without.
+   */
+  workerIndex: z.number().int().min(0).optional(),
+  startTime: z.string().optional(),
   error: PlaywrightErrorSchema.optional(),
 })
 
@@ -186,6 +194,11 @@ function toResult(
     file,
     status,
     attempts: Math.max(attempts.length, 1),
+    // From the last attempt: the one whose outcome `status` reports. A retry can
+    // land on a different worker, and attributing this test to the worker it
+    // *started* on would put it in the wrong sequence.
+    ...(last?.workerIndex === undefined ? {} : { workerIndex: last.workerIndex }),
+    ...(last?.startTime === undefined ? {} : { startedAt: last.startTime }),
     flakyWithinRun: test.status === 'flaky' || passedAfterFailing,
     durationMs: attempts.reduce((total, r) => total + r.duration, 0),
     annotations: test.annotations.map((a) =>

--- a/contracts/test-run.ts
+++ b/contracts/test-run.ts
@@ -56,6 +56,23 @@ export const TestResultSchema = z
     /** True when an earlier attempt failed and a later one passed. */
     flakyWithinRun: z.boolean(),
     durationMs: z.number().min(0),
+
+    /**
+     * Which worker process ran this test, and when it started.
+     *
+     * Both optional, because only Playwright reports them — and both are here
+     * for one failure shape: a spec that leaves state behind and a *different*
+     * spec that fails because of it. The failing test's own evidence is complete
+     * and entirely misleading, so the only way to reach the cause is to know
+     * what else ran in the same process, in what order.
+     *
+     * The pipeline discarded these until #168. Worth noting what they are not
+     * for: the culprit in a state leak has usually **passed**, so "what else
+     * failed in this run" would not contain it.
+     */
+    workerIndex: z.int().min(0).optional(),
+    startedAt: z.iso.datetime().optional(),
+
     error: TestErrorSchema.optional(),
     annotations: z.array(z.string()).default([]),
   })

--- a/docs/adr/0008-run-level-context-is-the-worker-sequence.md
+++ b/docs/adr/0008-run-level-context-is-the-worker-sequence.md
@@ -1,0 +1,90 @@
+# ADR-0008: Run-level context is the worker sequence, not the failure list
+
+- **Status:** Accepted
+- **Date:** 2026-08-18
+- **Deciders:** @AKogut
+- **Related:** [ADR-0002](0002-two-axis-classification-taxonomy.md), [ADR-0006](0006-single-shot-agents-no-loop.md)
+
+## Context
+
+`agents/context.ts` assembled twelve fields, and every one of them described the failing test alone.
+Nothing described the run.
+
+That is fine until a spec leaves state behind and a _different_ spec fails because of it. Then the
+failing test's evidence — assertion, stack, snippet, diff, source — is complete, internally
+consistent, and points entirely at a file that is not the problem. A classifier given that bundle
+cannot distinguish "this spec is wrong about the data" from "a different spec changed the data",
+because the second hypothesis has no evidence in the input at all. The best it can do is guess.
+
+Filed as #168 against the assembler rather than the prompt, on purpose. No wording change recovers
+information that was never supplied, and tuning a prompt until it guesses `test_code` more often on
+this shape is fitting the prompt to one fixture.
+
+## Decision
+
+The bundle carries **the tests that ran in the same worker before this one, in order** — id, title,
+file, status — capped at ten, with the number omitted stated when the cap bites.
+
+It does not carry a list of what else failed in the run, and it does not carry which tests wrote to
+shared state.
+
+## Options considered
+
+### Option A — What else failed in this run
+
+- **Pros:** cheapest of the three; derivable today with no contract change; a leak often takes more
+  than one victim.
+- **Cons:** **it would not have helped on the fixture that motivated the issue.** The culprit in a
+  state leak has usually _passed_ — that is why it left something behind rather than dying. A field
+  listing failures sounds useful, is easy to build, and is empty of the one row that matters.
+
+That asymmetry is the whole argument. It is also the reason this ADR exists rather than a comment:
+the cheap option is the one a reader would assume was chosen.
+
+### Option B — What ran in the same worker, in order (chosen)
+
+- **Pros:** contains the culprit, because a state leak is a leak _between tests sharing a process_.
+  Playwright already reports `workerIndex` and `startTime` per result and the pipeline was
+  discarding both. Cheap at ~590 characters for ten neighbours, against a 40,000-character evidence
+  budget.
+- **Cons:** two new optional fields on `TestResult`, and a reporter asymmetry — Vitest reports
+  neither, so unit failures have no run context at all. Ordering depends on `startTime`; without it
+  the field is withheld rather than guessed, because a plausible-looking wrong sequence invites the
+  wrong answer more strongly than no field does.
+
+### Option C — Which tests wrote to shared state
+
+- **Pros:** the actual answer, when it can be had.
+- **Cons:** requires instrumenting the application under test or the database, which is a different
+  project. Rejected as out of proportion to the one failure shape it serves.
+
+## Consequences
+
+### Positive
+
+- The cross-file leak becomes _possible_ to classify correctly. It was not, before.
+- The material was already in the reports; only the assembly was missing.
+- Ten neighbours is a knob, and #74's ablation can turn it — including to zero.
+
+### Negative / accepted costs
+
+- `TestResult` gains two optional fields that only one reporter populates. The reporter-contract
+  test now asserts that asymmetry is exactly these two, so a third cannot join them unnoticed.
+- Unit failures carry no run context. Correct — Vitest does not report workers — but it means the
+  field is absent for a whole provenance, which the eval must not read as a property of the tests.
+- Every fixture written before this predates the field. They state its absence in words, like an
+  absent history, rather than rendering an empty sequence — an empty list reads as "nothing else
+  ran", which is a claim, and a false one.
+
+### What would make us revisit this
+
+The ablation (#74) showing the field does not change accuracy, in which case it should be removed
+rather than left in as a plausible-sounding cost. A negative result here is worth publishing: it
+would say that the sequence is not enough on its own, and that Option C is the only thing that would
+work.
+
+## What is not yet known
+
+Whether it _helps_. The field puts the culprit in front of the classifier; whether the classifier
+uses it is a measurement, and that measurement needs live model calls (#38). This ADR records a
+decision about what information the bundle carries, not a claim about accuracy.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,6 +15,7 @@ and links back to it.
 | [0005](0005-replay-cassettes-for-credential-free-demo.md) | Replay cassettes for a credential-free demo        | Accepted |
 | [0006](0006-single-shot-agents-no-loop.md)                | Single-shot agents, no agentic loop                | Accepted |
 | [0007](0007-no-github-app-no-pull-request-target.md)      | No GitHub App, no `pull_request_target`            | Accepted |
+| [0008](0008-run-level-context-is-the-worker-sequence.md)  | Run-level context is the worker sequence           | Accepted |
 
 ## When an ADR is required
 

--- a/tests/unit/reporter-contract.test.ts
+++ b/tests/unit/reporter-contract.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
+  TestResultSchema,
   normalisePlaywrightReport,
   normaliseVitestReport,
   relativise,
@@ -170,16 +171,51 @@ describe('absolute paths from the runner', () => {
 })
 
 describe('the two reporters agree on shape', () => {
+  /**
+   * Which fields the schema marks optional, asked of the schema rather than
+   * listed here. A hand-maintained list is a list that goes stale the first time
+   * somebody adds a field, and going stale here means the asymmetry check below
+   * quietly stops checking anything.
+   */
+  const optionalFields = Object.entries(TestResultSchema.shape)
+    .filter(([, schema]) => schema.safeParse(undefined).success)
+    .map(([name]) => name)
+
   it('produces results with identical key sets, ignoring optional fields', () => {
-    // Nothing downstream branches on `source`, so a field present from one
-    // reporter and absent from the other would be a silent asymmetry.
+    // Nothing downstream branches on `source`, so a *required* field present
+    // from one reporter and absent from the other would be a silent asymmetry.
     const required = (run: TestRun): string[] =>
       Object.keys(run.results[0] ?? {})
-        .filter((k) => k !== 'error')
+        .filter((k) => !optionalFields.includes(k))
         .sort()
 
     const [playwright, vitest] = runs.map(([, run]) => required(run))
     expect(playwright).toEqual(vitest)
+  })
+
+  /**
+   * The asymmetries that are deliberate, named so a new one cannot join them
+   * unnoticed.
+   *
+   * `workerIndex` and `startedAt` are Playwright's alone: it runs specs across
+   * worker processes and says which, and that sequence is the only evidence a
+   * cross-file state leak leaves anywhere (#168). Vitest reports neither, so a
+   * unit failure simply has no run context — stated as absent rather than
+   * guessed at.
+   */
+  it('is asymmetric only where a reporter genuinely knows more', () => {
+    // Every key either reporter ever emits, not the first result's. `error` is
+    // present on some results and absent on others, so sampling one would report
+    // an asymmetry that is really just which test happened to fail first.
+    const emitted = (run: TestRun): string[] => [
+      ...new Set(run.results.flatMap((result) => Object.keys(result))),
+    ]
+    const [playwright, vitest] = runs.map(([, run]) => emitted(run))
+    const onlyPlaywright = (playwright ?? []).filter((k) => !(vitest ?? []).includes(k)).sort()
+    const onlyVitest = (vitest ?? []).filter((k) => !(playwright ?? []).includes(k)).sort()
+
+    expect(onlyPlaywright).toEqual(['startedAt', 'workerIndex'])
+    expect(onlyVitest).toEqual([])
   })
 
   it('derives ids the same way from the same file and title', () => {

--- a/wiki/Decision-Records.md
+++ b/wiki/Decision-Records.md
@@ -71,6 +71,20 @@ what makes it a fair evaluation control.
 
 ---
 
+### [ADR-0008](https://github.com/AKogut/ai-flaky-test-triage/blob/main/docs/adr/0008-run-level-context-is-the-worker-sequence.md) — Run-level context is the worker sequence
+
+Every field the classifier saw described the failing test alone, which makes a cross-file state leak
+impossible to get right: the failing test's evidence is complete, consistent, and points at the
+wrong file. The bundle now carries the tests that shared a worker before it, in order.
+
+**The rejected option is the interesting one.** "What else failed in this run" is cheaper, needs no
+contract change, and would not have helped — the culprit in a state leak has usually _passed_, which
+is why it left something behind rather than dying.
+
+Whether it improves accuracy is a measurement, not a claim, and it needs live model calls.
+
+---
+
 ## When an ADR is required
 
 - Changing the agent architecture — call count, loop structure, tool surface


### PR DESCRIPTION
Closes #168. Decision recorded as [ADR-0008](https://github.com/AKogut/ai-flaky-test-triage/blob/main/docs/adr/0008-run-level-context-is-the-worker-sequence.md).

`agents/context.ts` assembled twelve fields and **every one described the failing test alone**. Nothing described the run.

That is fine until a spec leaves state behind and a different spec fails because of it. Then the failing test's evidence — assertion, stack, snippet, diff, source — is complete, internally consistent, and points entirely at a file that is not the problem. The second hypothesis has no evidence in the input *at all*, so the best a classifier can do is guess.

## The rejected option is the interesting one

Three candidates. The obvious one is wrong:

| Option | Verdict |
|---|---|
| **What else failed in this run** | Cheapest, no contract change — and **it would not have helped on the fixture that motivated the issue** |
| **What ran in the same worker, in order** | Chosen |
| Which tests wrote to shared state | Needs instrumenting the application; out of proportion |

The culprit in a state leak has usually **passed**. That is why it left something behind rather than dying. A field listing failures sounds useful, is easy to build, and is empty of the one row that matters.

That asymmetry is why this is an ADR rather than a comment: the cheap option is the one a reader would assume was chosen.

```
passed   tests/e2e/seeds-the-board.spec.ts › board › seeds-the-board
passed   tests/e2e/leaves-a-row-behind.spec.ts › board › leaves-a-row-behind
```

## Two fields the pipeline had been throwing away

Playwright has reported `workerIndex` and `startTime` per result for years. Both are optional on `TestResult`, because Vitest reports neither — so a unit failure has no run context, stated as absent rather than guessed at.

That asymmetry needed guarding. `tests/unit/reporter-contract.test.ts` now derives *which* fields are optional from the schema rather than from a hand-written list — a list goes stale the first time somebody adds a field, and going stale there means the check quietly stops checking — and asserts the deliberate asymmetry is exactly these two, so a third cannot join them unnoticed.

## Ordering is by time, never by position

Playwright writes the report grouped by file, and a worker interleaves files. Trusting array position would produce a **plausible-looking sequence that is wrong**, which invites the wrong answer more strongly than no field at all. Where the reporter gives no time, the field is withheld rather than guessed.

That test exists because a mutation survived: removing the sort changed nothing, since every fixture happened to be written in time order already.

## Cost, measured

**587 characters for ten neighbours** — roughly 150 tokens — against a 1500-character cap and a 40,000-character evidence budget. Pinned by a test, so #74 ablates against a number that cannot drift.

Ten is a knob, not a law: enough for a `beforeEach` chain plus the specs around it, past which the field starts competing with the diff for room.

## What is not claimed

**That it helps.** The field puts the culprit in front of the classifier; whether the classifier uses it is a measurement, and that measurement needs live model calls (#38). The ADR records a decision about what information the bundle carries, not a claim about accuracy — and says a negative result would be worth publishing, because it would mean the sequence is not enough on its own.

## Testing

1812 tests. Six mutations against the builder, all caught after two rounds:

| Mutation | Caught by |
|---|---|
| Include other workers | 2 tests |
| Include what ran after | 2 tests |
| Keep the oldest neighbours | `keeps the most recent neighbours and counts what it dropped` |
| Drop the omitted count | same |
| Order by array position | `orders by when tests ran, not by where they sit in the report` |
| Render an empty sequence as a list | *removed the branch instead* |

The last one survived, and the fix was to delete the code rather than write a test. The guard could not change the output — an empty render is already treated as an absent field — and a branch that cannot change the output is one that will eventually be read as meaningful.
