### PR TITLE
feat(agents): one file written, exit zero, and a report either way

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -527,8 +527,11 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            // The marker is written by agents/report.ts, which owns the document.
+            // Prepending a second one here put it in the comment twice — visible
+            // in the first report this pipeline ever posted.
             const MARKER = '<!-- sentra:report -->';
-            const body = MARKER + '\n' + fs.readFileSync('report.md', 'utf8');
+            const body = fs.readFileSync('report.md', 'utf8');
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
             const existing = (await github.paginate(

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ cat eval/report.md
 | `npm run test:e2e`           | M5        | Playwright — TaskFlow UI flows, one server per worker; emits results.json         |
 | `npm test`                   | M5        | Unit and E2E together                                                             |
 | `npm run flakemetry:analyze` | M6        | Test report + history → analysis.json                                             |
-| `npm run agents:analyze`     | M7 🚧     | analysis.json → report.md                                                         |
+| `npm run agents:analyze`     | M7        | analysis.json → report.md                                                         |
 | `npm run analyze`            | M8 🚧     | flakemetry and agents in sequence                                                 |
 | `npm run capture`            | M5        | Turn a real Playwright report into golden-dataset payloads                        |
 | `npm run eval`               | M2        | Golden-dataset evaluation → eval/report.md                                        |

--- a/agents/pipeline.ts
+++ b/agents/pipeline.ts
@@ -44,7 +44,7 @@ export interface TriagedTest {
    * distinct from an API error: one means the run was too big for its
    * allowance, the other means something broke.
    */
-  unclassified?: { reason: 'budget' | 'error' | 'not-dispatched'; detail: string }
+  unclassified?: { reason: 'budget' | 'error' | 'not-dispatched' | 'not-run'; detail: string }
 }
 
 export interface PipelineResult {

--- a/agents/report.test.ts
+++ b/agents/report.test.ts
@@ -115,8 +115,15 @@ describe('escaping what a model produced', () => {
 })
 
 describe('the document', () => {
-  it('opens with the marker the comment upsert looks for', () => {
-    expect(renderReport(input())).toMatch(/^<!-- sentra:report -->/)
+  /**
+   * Written here, and only here. The workflow's upsert step used to prepend its
+   * own copy, which put the marker in the comment twice — visible in the first
+   * report this pipeline ever posted publicly.
+   */
+  it('opens with the marker the comment upsert looks for, exactly once', () => {
+    const report = renderReport(input())
+    expect(report).toMatch(/^<!-- sentra:report -->/)
+    expect(report.split('<!-- sentra:report -->')).toHaveLength(2)
   })
 
   it('counts the quadrants it found', () => {

--- a/agents/report.ts
+++ b/agents/report.ts
@@ -151,6 +151,7 @@ function gapLines(gaps: readonly TriagedTest[]): string[] {
     budget: 'the run reached its token budget',
     error: 'the classifier call failed',
     'not-dispatched': 'never reached, because the budget ran out first',
+    'not-run': 'the classifier never ran — see the notice above',
   }
   return [
     `> **${String(gaps.length)} unclassified.** ` +

--- a/agents/run.test.ts
+++ b/agents/run.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it, vi } from 'vitest'
+import { credentialState, main, parseArgs } from './run.js'
+import type { ModelRequest, ModelResponse, Transport } from './transport.js'
+
+/**
+ * The one module in `agents/` that reads and writes, and it writes exactly one
+ * file.
+ *
+ * The behaviour worth pinning is the exit code. A run where every model call
+ * rate-limited still produced a correct report — one saying so — and failing the
+ * build there would fail it over the weather. A non-zero exit from this program
+ * means this program is broken, and nothing else.
+ */
+
+const CLASSIFICATION = {
+  owner: 'app_code',
+  determinism: 'intermittent',
+  confidence: 0.9,
+  reasoning: 'the diff changes the reducer the failing assertion reads',
+  evidence: ['expected 3 to equal 4'],
+}
+
+const analysis = (over: Record<string, unknown> = {}): string =>
+  JSON.stringify({
+    schemaVersion: 1,
+    runId: 'r',
+    commitSha: 'abc1234',
+    branch: 'main',
+    analysedAt: '2026-08-18T00:00:00.000Z',
+    historyAvailable: true,
+    historyDepth: 20,
+    tests: [
+      {
+        result: {
+          testId: 'tests/e2e/board.spec.ts›reorders',
+          title: 'board › reorders',
+          file: 'tests/e2e/board.spec.ts',
+          status: 'failed',
+          attempts: 1,
+          flakyWithinRun: false,
+          durationMs: 12,
+          annotations: [],
+          error: { message: 'expected 3 to equal 4' },
+        },
+        signal: {
+          testId: 'tests/e2e/board.spec.ts›reorders',
+          flakinessScore: 0.5,
+          consecutiveFailures: 1,
+          totalRuns: 20,
+          firstSeenAt: '2026-08-01T00:00:00.000Z',
+          lastPassedAt: null,
+          statusHistory: 'PF',
+          isNew: false,
+        },
+      },
+    ],
+    ...over,
+  })
+
+function stub(fail?: Error): Transport {
+  return {
+    countInputTokens: () => Promise.resolve(100),
+    send: (_request: ModelRequest): Promise<ModelResponse> =>
+      fail === undefined
+        ? Promise.resolve({
+            raw: CLASSIFICATION,
+            stopReason: 'end_turn',
+            model: 'claude-opus-5',
+            usage: { inputTokens: 100, outputTokens: 30 },
+          })
+        : Promise.reject(fail),
+  }
+}
+
+const run = async (
+  argv: string[] = [],
+  over: { files?: Record<string, string>; env?: NodeJS.ProcessEnv; transport?: Transport } = {},
+): Promise<{ code: number; written: Record<string, string>; output: string }> => {
+  const files = over.files ?? { 'analysis.json': analysis() }
+  const written: Record<string, string> = {}
+  const lines: string[] = []
+
+  const code = await main(argv, {
+    env: over.env ?? { ANTHROPIC_API_KEY: 'test' },
+    read: (p) => files[p] ?? '',
+    exists: (p) => p in files,
+    write: (p, contents) => {
+      written[p] = contents
+    },
+    log: (m) => lines.push(m),
+    cassetteCount: () => 0,
+    ...(over.transport === undefined ? {} : { transport: over.transport }),
+  })
+
+  return { code, written, output: lines.join('\n') }
+}
+
+describe('the arguments', () => {
+  it('defaults to the documented paths', () => {
+    expect(parseArgs([])).toMatchObject({ analysis: 'analysis.json', out: 'report.md' })
+  })
+
+  it('reads every flag it documents', () => {
+    expect(
+      parseArgs(['--analysis', 'a.json', '--out', 'r.md', '--budget', '500', '--concurrency', '2']),
+    ).toMatchObject({ analysis: 'a.json', out: 'r.md', budget: 500, concurrency: 2 })
+  })
+})
+
+describe('whether a classifier is available', () => {
+  /**
+   * Checked once, before any work. Without credentials every test would fail
+   * identically, and forty rows saying "no cassette for triage.v1" tell a reader
+   * nothing they could not have been told once, at the top.
+   */
+  it('is no when replay is in force and nothing is recorded', () => {
+    const state = credentialState({ SENTRA_REPLAY: '1' }, 0)
+    expect(state.canRun).toBe(false)
+    expect(state.notice).toContain('no cassettes are recorded')
+  })
+
+  it('is yes when replay has cassettes to serve', () => {
+    expect(credentialState({ SENTRA_REPLAY: '1' }, 12).canRun).toBe(true)
+  })
+
+  /**
+   * With nothing configured the repository defaults to replay, so the honest
+   * notice is about cassettes rather than about a key. Asserted because the
+   * tempting expectation is the other one.
+   */
+  it('falls back to replay, and says so, when nothing is configured at all', () => {
+    const state = credentialState({}, 0)
+    expect(state.canRun).toBe(false)
+    expect(state.notice).toContain('no cassettes are recorded')
+  })
+
+  it('names the missing key when a live run was asked for', () => {
+    const state = credentialState({ SENTRA_LIVE: '1' }, 0)
+    expect(state.canRun).toBe(false)
+    expect(state.notice).toContain('no ANTHROPIC_API_KEY')
+  })
+
+  it('is yes with either credential the SDK accepts', () => {
+    expect(credentialState({ ANTHROPIC_API_KEY: 'k' }, 0).canRun).toBe(true)
+    expect(credentialState({ ANTHROPIC_AUTH_TOKEN: 't' }, 0).canRun).toBe(true)
+  })
+})
+
+describe('a run with nothing to triage', () => {
+  /** A comment saying nothing went wrong, on every green PR, trains people to skip the one that matters. */
+  it('writes no file at all', async () => {
+    const green = JSON.parse(analysis()) as {
+      tests: {
+        result: { status: string }
+        signal: { flakinessScore: number; consecutiveFailures: number }
+      }[]
+    }
+    green.tests[0]!.result.status = 'passed'
+    green.tests[0]!.signal.flakinessScore = 0
+    green.tests[0]!.signal.consecutiveFailures = 0
+    const result = await run([], { files: { 'analysis.json': JSON.stringify(green) } })
+    expect(result.code).toBe(0)
+    expect(result.written).toEqual({})
+    expect(result.output).toContain('nothing to triage')
+  })
+})
+
+describe('a run with no classifier', () => {
+  it('still writes a report, and still exits 0', async () => {
+    const result = await run([], { env: {} })
+    expect(result.code).toBe(0)
+    expect(Object.keys(result.written)).toEqual(['report.md'])
+  })
+
+  /** Its own reason: a header saying "the call failed" about a call that never happened misleads. */
+  it('says the classifier never ran, not that it failed', async () => {
+    const report = (await run([], { env: { SENTRA_LIVE: '1' } })).written['report.md'] ?? ''
+    expect(report).toContain('the classifier never ran')
+    expect(report).toContain('no ANTHROPIC_API_KEY')
+    expect(report).not.toContain('the classifier call failed')
+  })
+})
+
+describe('a run that works', () => {
+  it('writes exactly one file', async () => {
+    const result = await run([], { transport: stub() })
+    expect(Object.keys(result.written)).toEqual(['report.md'])
+    expect(result.code).toBe(0)
+  })
+
+  it('classifies and reports', async () => {
+    const report = (await run([], { transport: stub() })).written['report.md'] ?? ''
+    expect(report).toContain('app_code+intermittent')
+    expect(report).toContain('board › reorders')
+  })
+
+  /**
+   * The exit code that matters. A run where every call rate-limited still
+   * produced a correct report, and failing the build there fails it over the
+   * weather.
+   */
+  it('exits 0 even when every model call failed', async () => {
+    const result = await run([], { transport: stub(new Error('429 rate limited')) })
+    expect(result.code).toBe(0)
+    expect(result.written['report.md']).toContain('429 rate limited')
+  })
+
+  it('carries the missing-history notice into the report', async () => {
+    const result = await run([], {
+      files: { 'analysis.json': analysis({ historyAvailable: false, historyDepth: 0 }) },
+      transport: stub(),
+    })
+    expect(result.written['report.md']).toContain('no history')
+  })
+})
+
+describe('when it cannot do its job', () => {
+  const quiet = async <T>(body: () => Promise<T>): Promise<{ value: T; errors: string }> => {
+    const errors: string[] = []
+    const spy = vi.spyOn(console, 'error').mockImplementation((m: unknown) => {
+      errors.push(String(m))
+    })
+    try {
+      return { value: await body(), errors: errors.join('\n') }
+    } finally {
+      spy.mockRestore()
+    }
+  }
+
+  it('fails when there is no analysis to read', async () => {
+    const { value, errors } = await quiet(() => run([], { files: {} }))
+    expect(value.code).toBe(1)
+    expect(errors).toContain('flakemetry:analyze')
+  })
+
+  it('fails when the analysis is not one', async () => {
+    const { value, errors } = await quiet(() =>
+      run([], { files: { 'analysis.json': '{"schemaVersion":1}' } }),
+    )
+    expect(value.code).toBe(1)
+    expect(errors).toContain('not a valid analysis')
+  })
+})

--- a/agents/run.ts
+++ b/agents/run.ts
@@ -1,0 +1,267 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import {
+  parseAnalysis,
+  type AnalysedTest,
+  type Analysis,
+  type ClassificationInput,
+} from '@sentra/contracts'
+import { CURRENT_PROMPT, loadPrompt } from '@sentra/prompts'
+import { CassetteTransport, listCassettes, resolveMode } from './cassettes.js'
+import { runContextFor } from './context.js'
+import { TokenBudget } from './model-client.js'
+import { hasWork } from './orchestrate.js'
+import { runPipeline, type PipelineDeps } from './pipeline.js'
+import { renderReport } from './report.js'
+import { AnthropicTransport, type Transport } from './transport.js'
+
+/**
+ * `npm run agents:analyze` — `analysis.json` in, `report.md` out.
+ *
+ * The one module in `agents/` that reads and writes, and it writes exactly one
+ * file. That is a guardrail rather than a coincidence: `docs/limitations-and-guardrails.md`
+ * promises the pipeline never modifies the working tree, and #69 asserts the
+ * whole-run version of that claim.
+ *
+ * **It exits 0 whenever the pipeline itself worked**, whatever the classifier
+ * managed. A run where every model call rate-limited still produced a correct
+ * report — one that says every test went unclassified and why — and exiting
+ * non-zero there would fail a build over the weather. A non-zero exit here means
+ * this program is broken, and nothing else.
+ *
+ * **A run with nothing to triage writes nothing at all.** Not an empty report: a
+ * comment saying nothing went wrong, posted on every green pull request, is
+ * noise that trains people to skip the one that matters.
+ */
+
+const ANALYSIS = 'analysis.json'
+const REPORT = 'report.md'
+
+/** A generous default. The point is a ceiling, not a tight one. */
+const DEFAULT_BUDGET = 200_000
+
+export interface RunDeps {
+  env?: NodeJS.ProcessEnv
+  read?: (path: string) => string
+  write?: (path: string, contents: string) => void
+  exists?: (path: string) => boolean
+  log?: (message: string) => void
+  transport?: Transport
+  /** Injected so a test can drive a whole run without a clock or a network. */
+  cassetteCount?: () => number
+}
+
+export interface RunOptions {
+  analysis: string
+  out: string
+  budget: number
+  concurrency?: number
+}
+
+export function parseArgs(argv: string[]): RunOptions {
+  let analysis = ANALYSIS
+  let out = REPORT
+  let budget = DEFAULT_BUDGET
+  let concurrency: number | undefined
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i]
+    const value = argv[i + 1]
+    if (value === undefined) continue
+    if (flag === '--analysis') analysis = value
+    else if (flag === '--out') out = value
+    else if (flag === '--budget') budget = Number(value)
+    else if (flag === '--concurrency') concurrency = Number(value)
+    else continue
+    i += 1
+  }
+
+  return { analysis, out, budget, ...(concurrency === undefined ? {} : { concurrency }) }
+}
+
+/**
+ * Whether this run can call a model at all, and what to say if not.
+ *
+ * Checked before any work rather than discovered one call at a time. Without
+ * credentials and without cassettes every test would fail identically, and forty
+ * rows saying "no cassette for triage.v1" tell a reader nothing they could not
+ * have been told once, at the top.
+ */
+export function credentialState(
+  env: NodeJS.ProcessEnv,
+  cassettes: number,
+): { canRun: boolean; notice?: string } {
+  const mode = resolveMode(env)
+  const hasKey = (env.ANTHROPIC_API_KEY ?? '') !== '' || (env.ANTHROPIC_AUTH_TOKEN ?? '') !== ''
+
+  if (mode === 'replay') {
+    return cassettes > 0
+      ? { canRun: true }
+      : {
+          canRun: false,
+          notice:
+            'The classifier did not run: replay mode is in force and no cassettes are recorded. ' +
+            'The failures below are listed with the pipeline’s own signals and no verdicts.',
+        }
+  }
+
+  // `ant auth login` leaves no environment variable, so an absent key is not
+  // proof of absent credentials — but in CI it is the only evidence there is.
+  return hasKey
+    ? { canRun: true }
+    : {
+        canRun: false,
+        notice:
+          'The classifier did not run: no ANTHROPIC_API_KEY is configured for this job. ' +
+          'The failures below are listed with the pipeline’s own signals and no verdicts.',
+      }
+}
+
+export async function main(argv: string[], deps: RunDeps = {}): Promise<number> {
+  const options = parseArgs(argv)
+  const env = deps.env ?? process.env
+  const read = deps.read ?? ((p: string) => readFileSync(p, 'utf8'))
+  const exists = deps.exists ?? ((p: string) => existsSync(p))
+  const log =
+    deps.log ??
+    ((m: string) => {
+      console.log(m)
+    })
+  const write =
+    deps.write ??
+    ((p: string, contents: string) => {
+      mkdirSync(dirname(p) === '' ? '.' : dirname(p), { recursive: true })
+      writeFileSync(p, contents)
+    })
+
+  if (!exists(options.analysis)) {
+    console.error(`\n  ${options.analysis} does not exist. Run npm run flakemetry:analyze first.\n`)
+    return 1
+  }
+
+  let analysis: Analysis
+  try {
+    analysis = parseAnalysis(JSON.parse(read(options.analysis)), options.analysis)
+  } catch (error) {
+    console.error(`\n  ${(error as Error).message}\n`)
+    return 1
+  }
+
+  if (!hasWork(analysis)) {
+    log('  nothing to triage — no report written')
+    return 0
+  }
+
+  const countCassettes = deps.cassetteCount ?? ((): number => listCassettes().length)
+  const credentials = credentialState(env, countCassettes())
+
+  const notices: string[] = []
+  if (analysis.historySource === 'unreadable') {
+    notices.push('The run history could not be read, so every test reads as new.')
+  } else if (!analysis.historyAvailable) {
+    notices.push('The run had no history, so every test reads as new.')
+  }
+  if (credentials.notice !== undefined) notices.push(credentials.notice)
+
+  const triagePrompt = loadPrompt(CURRENT_PROMPT.triage)
+
+  return await renderAndWrite()
+
+  async function renderAndWrite(): Promise<number> {
+    // Without credentials there is nothing to await, and a report is still owed.
+    if (!credentials.canRun) {
+      write(
+        options.out,
+        renderReport({
+          triaged: analysis.tests
+            .filter((t) => hasWork({ ...analysis, tests: [t] }))
+            .map((test) => ({
+              test,
+              unclassified: {
+                // Its own reason, not `error`. No call was made, and a header
+                // that says "the classifier call failed" about a call that never
+                // happened sends a reader looking for an outage.
+                reason: 'not-run' as const,
+                detail: 'no classifier was available for this run',
+              },
+            })),
+          commitSha: analysis.commitSha,
+          branch: analysis.branch,
+          runId: analysis.runId,
+          model: 'none — the classifier did not run',
+          promptVersions: { triage: triagePrompt.version },
+          usage: [],
+          notices,
+        }),
+      )
+      log(`  wrote ${options.out} (degraded: ${String(notices.length)} notice(s))`)
+      return 0
+    }
+
+    // Awaited, not fired and forgotten. A report written after the process has
+    // decided to exit is a report nobody gets — and the exit code would say the
+    // run succeeded either way, which is the worst of both.
+    await dispatch()
+    return 0
+  }
+
+  async function dispatch(): Promise<void> {
+    const inner = deps.transport ?? new AnthropicTransport({ allowModelFallback: true })
+    const transport =
+      deps.transport === undefined
+        ? new CassetteTransport(inner, { mode: resolveMode(env) })
+        : inner
+
+    const pipelineDeps: PipelineDeps = {
+      triage: {
+        transport,
+        system: triagePrompt.system,
+        promptVersion: triagePrompt.version,
+      },
+      // Root cause and fix suggestion stay off until a calibration exists — see
+      // shouldInvestigate. A threshold nobody measured is a guess with a decimal.
+      threshold: null,
+      budget: new TokenBudget(options.budget),
+      inputFor: (test): ClassificationInput => inputFor(test),
+      ...(options.concurrency === undefined ? {} : { concurrency: options.concurrency }),
+    }
+
+    const result = await runPipeline(analysis, pipelineDeps)
+
+    write(
+      options.out,
+      renderReport({
+        triaged: result.triaged,
+        commitSha: analysis.commitSha,
+        branch: analysis.branch,
+        runId: analysis.runId,
+        model: result.telemetry[0]?.model ?? 'unknown',
+        promptVersions: { triage: triagePrompt.version },
+        usage: result.telemetry.map((t) => ({
+          model: t.model,
+          inputTokens: t.inputTokens,
+          outputTokens: t.outputTokens,
+        })),
+        notices,
+      }),
+    )
+    log(
+      `  wrote ${options.out} (${String(result.triaged.length)} tests, degraded: ${String(result.degraded)})`,
+    )
+  }
+
+  function inputFor(test: AnalysedTest): ClassificationInput {
+    const source = join(process.cwd(), test.result.file)
+    const runContext = runContextFor(analysis.tests, test.result.testId)
+    return {
+      subject: test,
+      historyAvailable: analysis.historyAvailable,
+      ...(runContext === null ? {} : { runContext }),
+      ...(exists(source) ? { testSource: read(source) } : {}),
+    }
+  }
+}
+
+if (process.argv[1]?.endsWith('run.ts') === true) {
+  process.exitCode = await main(process.argv.slice(2))
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sentra",
   "version": "0.1.0",
   "private": true,
-  "description": "An AI triage layer for CI test failures — packaged as a pipeline step, not a service.",
+  "description": "An AI triage layer for CI test failures \u2014 packaged as a pipeline step, not a service.",
   "license": "MIT",
   "author": "Andrii Kohut",
   "repository": {
@@ -23,7 +23,7 @@
     "eval"
   ],
   "scripts": {
-    "agents:analyze": "node scripts/pending.mjs agents:analyze",
+    "agents:analyze": "tsx agents/run.ts",
     "analyze": "node scripts/pending.mjs analyze",
     "build": "npm run build --workspace @sentra/taskflow-client",
     "capture": "tsx scripts/capture.ts",

--- a/scripts/script-manifest.json
+++ b/scripts/script-manifest.json
@@ -62,7 +62,7 @@
       "description": "analysis.json \u2192 report.md",
       "milestone": "M7",
       "issue": 66,
-      "status": "pending"
+      "status": "shipped"
     },
     {
       "name": "analyze",


### PR DESCRIPTION
Closes #67. `agents/run.ts` is the CLI #66 deferred, and it lands here because **this is the issue that can honestly handle the case where nothing works**.

## The exit code

It exits 0 whenever the pipeline itself worked, whatever the classifier managed. A run where every model call rate-limited still produced a correct report — one saying every test went unclassified and why — and exiting non-zero there would fail a build over the weather.

A non-zero exit from this program means **this program is broken**, and nothing else.

## Credentials are checked once, at the top

Without them every test would fail identically, and forty rows saying "no cassette for triage.v1" tell a reader nothing they could not have been told once.

With nothing configured the repository defaults to **replay**, so the honest notice is about cassettes rather than about a key. That is the opposite of what one expects, which is exactly why there is a test named for it:

```ts
it('falls back to replay, and says so, when nothing is configured at all', …)
it('names the missing key when a live run was asked for', …)
```

## A run with no classifier gets its own reason

`error` would put *"the classifier call failed"* in the header about a call that never happened, and send a reader looking for an outage. So `not-run` exists, and reads:

```
> **1 unclassified.** 1 — the classifier never ran — see the notice above.

> ⚠️ The run had no history, so every test reads as new.
> ⚠️ The classifier did not run: replay mode is in force and no cassettes are recorded.
```

Run for real against a locally generated `analysis.json`: exit 0, one file, both degradations named.

## Awaited, not fired and forgotten

The first version returned before the pipeline finished. A report written after the process has decided to exit is a report nobody gets — and the exit code would say the run succeeded either way, which is the worst of both.

## What this changes in CI

`agents/run.ts` existing flips `has-agents`, so the **Agent triage** job starts running on every pull request instead of skipping. Without a key it writes a degraded report and passes — which is the behaviour the tests here pin, and which you should see on this PR's checks for the first time.

## Still off

Root cause and fix suggestion do not run: `shouldInvestigate` refuses without a calibrated threshold, and none exists until #38. Today the command produces classifications and no hypotheses — the correct amount of confident prose about verdicts nobody has measured.

1906 tests, 16 of them new.
