### PR TITLE
test(agents): the whole pipeline, end to end, with no network at all

### DIFF
--- a/tests/fixtures/pipeline/green.analysis.json
+++ b/tests/fixtures/pipeline/green.analysis.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": 1,
+  "runId": "ci-1",
+  "commitSha": "abc1234def",
+  "branch": "main",
+  "analysedAt": "2026-08-18T00:00:00.000Z",
+  "historyAvailable": true,
+  "historyDepth": 40,
+  "historySource": "read",
+  "tests": [
+    {
+      "result": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 1",
+        "title": "board \u203a case 1",
+        "file": "tests/e2e/board.spec.ts",
+        "status": "passed",
+        "attempts": 1,
+        "flakyWithinRun": false,
+        "durationMs": 121,
+        "annotations": [],
+        "workerIndex": 0,
+        "startedAt": "2026-08-18T00:01:00.000Z"
+      },
+      "signal": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 1",
+        "flakinessScore": 0,
+        "consecutiveFailures": 0,
+        "totalRuns": 40,
+        "firstSeenAt": "2026-04-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-17T00:00:00.000Z",
+        "statusHistory": "PPPFPF",
+        "isNew": false
+      }
+    }
+  ]
+}

--- a/tests/fixtures/pipeline/many-failures.analysis.json
+++ b/tests/fixtures/pipeline/many-failures.analysis.json
@@ -1,0 +1,332 @@
+{
+  "schemaVersion": 1,
+  "runId": "ci-1",
+  "commitSha": "abc1234def",
+  "branch": "main",
+  "analysedAt": "2026-08-18T00:00:00.000Z",
+  "historyAvailable": true,
+  "historyDepth": 40,
+  "historySource": "read",
+  "tests": [
+    {
+      "result": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 1",
+        "title": "board \u203a case 1",
+        "file": "tests/e2e/board.spec.ts",
+        "status": "failed",
+        "attempts": 1,
+        "flakyWithinRun": false,
+        "durationMs": 121,
+        "annotations": [],
+        "workerIndex": 0,
+        "startedAt": "2026-08-18T00:01:00.000Z",
+        "error": {
+          "message": "expected 1 to equal 2",
+          "stack": "    at tests/e2e/board.spec.ts:1:4"
+        }
+      },
+      "signal": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 1",
+        "flakinessScore": 0.1,
+        "consecutiveFailures": 1,
+        "totalRuns": 40,
+        "firstSeenAt": "2026-04-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-17T00:00:00.000Z",
+        "statusHistory": "PPPFPF",
+        "isNew": false
+      }
+    },
+    {
+      "result": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 2",
+        "title": "board \u203a case 2",
+        "file": "tests/e2e/board.spec.ts",
+        "status": "failed",
+        "attempts": 1,
+        "flakyWithinRun": false,
+        "durationMs": 122,
+        "annotations": [],
+        "workerIndex": 0,
+        "startedAt": "2026-08-18T00:02:00.000Z",
+        "error": {
+          "message": "expected 2 to equal 3",
+          "stack": "    at tests/e2e/board.spec.ts:2:4"
+        }
+      },
+      "signal": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 2",
+        "flakinessScore": 0.2,
+        "consecutiveFailures": 2,
+        "totalRuns": 40,
+        "firstSeenAt": "2026-04-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-17T00:00:00.000Z",
+        "statusHistory": "PPPFPF",
+        "isNew": false
+      }
+    },
+    {
+      "result": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 3",
+        "title": "board \u203a case 3",
+        "file": "tests/e2e/board.spec.ts",
+        "status": "passed",
+        "attempts": 1,
+        "flakyWithinRun": false,
+        "durationMs": 123,
+        "annotations": [],
+        "workerIndex": 0,
+        "startedAt": "2026-08-18T00:03:00.000Z"
+      },
+      "signal": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 3",
+        "flakinessScore": 0.30000000000000004,
+        "consecutiveFailures": 3,
+        "totalRuns": 40,
+        "firstSeenAt": "2026-04-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-17T00:00:00.000Z",
+        "statusHistory": "PPPFPF",
+        "isNew": false
+      }
+    },
+    {
+      "result": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 4",
+        "title": "board \u203a case 4",
+        "file": "tests/e2e/board.spec.ts",
+        "status": "failed",
+        "attempts": 1,
+        "flakyWithinRun": false,
+        "durationMs": 124,
+        "annotations": [],
+        "workerIndex": 0,
+        "startedAt": "2026-08-18T00:04:00.000Z",
+        "error": {
+          "message": "expected 4 to equal 5",
+          "stack": "    at tests/e2e/board.spec.ts:4:4"
+        }
+      },
+      "signal": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 4",
+        "flakinessScore": 0.4,
+        "consecutiveFailures": 0,
+        "totalRuns": 40,
+        "firstSeenAt": "2026-04-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-17T00:00:00.000Z",
+        "statusHistory": "PPPFPF",
+        "isNew": false
+      }
+    },
+    {
+      "result": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 5",
+        "title": "board \u203a case 5",
+        "file": "tests/e2e/board.spec.ts",
+        "status": "failed",
+        "attempts": 2,
+        "flakyWithinRun": true,
+        "durationMs": 125,
+        "annotations": [],
+        "workerIndex": 0,
+        "startedAt": "2026-08-18T00:05:00.000Z",
+        "error": {
+          "message": "expected 5 to equal 6",
+          "stack": "    at tests/e2e/board.spec.ts:5:4"
+        }
+      },
+      "signal": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 5",
+        "flakinessScore": 0.5,
+        "consecutiveFailures": 1,
+        "totalRuns": 40,
+        "firstSeenAt": "2026-04-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-17T00:00:00.000Z",
+        "statusHistory": "PPPFPF",
+        "isNew": false
+      }
+    },
+    {
+      "result": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 6",
+        "title": "board \u203a case 6",
+        "file": "tests/e2e/board.spec.ts",
+        "status": "passed",
+        "attempts": 1,
+        "flakyWithinRun": false,
+        "durationMs": 126,
+        "annotations": [],
+        "workerIndex": 0,
+        "startedAt": "2026-08-18T00:06:00.000Z"
+      },
+      "signal": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 6",
+        "flakinessScore": 0.6000000000000001,
+        "consecutiveFailures": 2,
+        "totalRuns": 40,
+        "firstSeenAt": "2026-04-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-17T00:00:00.000Z",
+        "statusHistory": "PPPFPF",
+        "isNew": false
+      }
+    },
+    {
+      "result": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 7",
+        "title": "board \u203a case 7",
+        "file": "tests/e2e/board.spec.ts",
+        "status": "failed",
+        "attempts": 1,
+        "flakyWithinRun": false,
+        "durationMs": 127,
+        "annotations": [],
+        "workerIndex": 0,
+        "startedAt": "2026-08-18T00:07:00.000Z",
+        "error": {
+          "message": "expected 7 to equal 8",
+          "stack": "    at tests/e2e/board.spec.ts:7:4"
+        }
+      },
+      "signal": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 7",
+        "flakinessScore": 0.7000000000000001,
+        "consecutiveFailures": 3,
+        "totalRuns": 40,
+        "firstSeenAt": "2026-04-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-17T00:00:00.000Z",
+        "statusHistory": "PPPFPF",
+        "isNew": false
+      }
+    },
+    {
+      "result": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 8",
+        "title": "board \u203a case 8",
+        "file": "tests/e2e/board.spec.ts",
+        "status": "failed",
+        "attempts": 1,
+        "flakyWithinRun": false,
+        "durationMs": 128,
+        "annotations": [],
+        "workerIndex": 0,
+        "startedAt": "2026-08-18T00:08:00.000Z",
+        "error": {
+          "message": "expected 8 to equal 9",
+          "stack": "    at tests/e2e/board.spec.ts:8:4"
+        }
+      },
+      "signal": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 8",
+        "flakinessScore": 0.8,
+        "consecutiveFailures": 0,
+        "totalRuns": 40,
+        "firstSeenAt": "2026-04-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-17T00:00:00.000Z",
+        "statusHistory": "PPPFPF",
+        "isNew": false
+      }
+    },
+    {
+      "result": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 9",
+        "title": "board \u203a case 9",
+        "file": "tests/e2e/board.spec.ts",
+        "status": "passed",
+        "attempts": 1,
+        "flakyWithinRun": false,
+        "durationMs": 129,
+        "annotations": [],
+        "workerIndex": 0,
+        "startedAt": "2026-08-18T00:09:00.000Z"
+      },
+      "signal": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 9",
+        "flakinessScore": 0.9,
+        "consecutiveFailures": 1,
+        "totalRuns": 40,
+        "firstSeenAt": "2026-04-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-17T00:00:00.000Z",
+        "statusHistory": "PPPFPF",
+        "isNew": false
+      }
+    },
+    {
+      "result": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 10",
+        "title": "board \u203a case 10",
+        "file": "tests/e2e/board.spec.ts",
+        "status": "failed",
+        "attempts": 2,
+        "flakyWithinRun": true,
+        "durationMs": 130,
+        "annotations": [],
+        "workerIndex": 0,
+        "startedAt": "2026-08-18T00:10:00.000Z",
+        "error": {
+          "message": "expected 10 to equal 11",
+          "stack": "    at tests/e2e/board.spec.ts:10:4"
+        }
+      },
+      "signal": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 10",
+        "flakinessScore": 0.0,
+        "consecutiveFailures": 2,
+        "totalRuns": 40,
+        "firstSeenAt": "2026-04-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-17T00:00:00.000Z",
+        "statusHistory": "PPPFPF",
+        "isNew": false
+      }
+    },
+    {
+      "result": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 11",
+        "title": "board \u203a case 11",
+        "file": "tests/e2e/board.spec.ts",
+        "status": "failed",
+        "attempts": 1,
+        "flakyWithinRun": false,
+        "durationMs": 131,
+        "annotations": [],
+        "workerIndex": 0,
+        "startedAt": "2026-08-18T00:11:00.000Z",
+        "error": {
+          "message": "expected 11 to equal 12",
+          "stack": "    at tests/e2e/board.spec.ts:11:4"
+        }
+      },
+      "signal": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 11",
+        "flakinessScore": 0.10000000000000009,
+        "consecutiveFailures": 3,
+        "totalRuns": 40,
+        "firstSeenAt": "2026-04-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-17T00:00:00.000Z",
+        "statusHistory": "PPPFPF",
+        "isNew": false
+      }
+    },
+    {
+      "result": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 12",
+        "title": "board \u203a case 12",
+        "file": "tests/e2e/board.spec.ts",
+        "status": "passed",
+        "attempts": 1,
+        "flakyWithinRun": false,
+        "durationMs": 132,
+        "annotations": [],
+        "workerIndex": 0,
+        "startedAt": "2026-08-18T00:12:00.000Z"
+      },
+      "signal": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 12",
+        "flakinessScore": 0.20000000000000018,
+        "consecutiveFailures": 0,
+        "totalRuns": 40,
+        "firstSeenAt": "2026-04-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-17T00:00:00.000Z",
+        "statusHistory": "PPPFPF",
+        "isNew": false
+      }
+    }
+  ]
+}

--- a/tests/fixtures/pipeline/one-failure.analysis.json
+++ b/tests/fixtures/pipeline/one-failure.analysis.json
@@ -1,0 +1,64 @@
+{
+  "schemaVersion": 1,
+  "runId": "ci-1",
+  "commitSha": "abc1234def",
+  "branch": "main",
+  "analysedAt": "2026-08-18T00:00:00.000Z",
+  "historyAvailable": true,
+  "historyDepth": 40,
+  "historySource": "read",
+  "tests": [
+    {
+      "result": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 1",
+        "title": "board \u203a case 1",
+        "file": "tests/e2e/board.spec.ts",
+        "status": "failed",
+        "attempts": 1,
+        "flakyWithinRun": false,
+        "durationMs": 121,
+        "annotations": [],
+        "workerIndex": 0,
+        "startedAt": "2026-08-18T00:01:00.000Z",
+        "error": {
+          "message": "expected 1 to equal 2",
+          "stack": "    at tests/e2e/board.spec.ts:1:4"
+        }
+      },
+      "signal": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 1",
+        "flakinessScore": 0.5,
+        "consecutiveFailures": 1,
+        "totalRuns": 40,
+        "firstSeenAt": "2026-04-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-17T00:00:00.000Z",
+        "statusHistory": "PPPFPF",
+        "isNew": false
+      }
+    },
+    {
+      "result": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 2",
+        "title": "board \u203a case 2",
+        "file": "tests/e2e/board.spec.ts",
+        "status": "passed",
+        "attempts": 1,
+        "flakyWithinRun": false,
+        "durationMs": 122,
+        "annotations": [],
+        "workerIndex": 0,
+        "startedAt": "2026-08-18T00:02:00.000Z"
+      },
+      "signal": {
+        "testId": "tests/e2e/board.spec.ts\u203aboard \u203a case 2",
+        "flakinessScore": 0,
+        "consecutiveFailures": 0,
+        "totalRuns": 40,
+        "firstSeenAt": "2026-04-02T07:31:19.000Z",
+        "lastPassedAt": "2026-08-17T00:00:00.000Z",
+        "statusHistory": "PPPFPF",
+        "isNew": false
+      }
+    }
+  ]
+}

--- a/tests/unit/pipeline-integration.test.ts
+++ b/tests/unit/pipeline-integration.test.ts
@@ -1,0 +1,194 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { main } from '../../agents/run.js'
+import type { ModelRequest, ModelResponse, Transport } from '../../agents/transport.js'
+
+/**
+ * `agents/run.ts`, end to end, against committed fixtures.
+ *
+ * The unit tests cover each agent. This covers the wiring between them, which is
+ * where the interesting bugs live — ordering, budget accounting, threshold
+ * gating, partial failure — and it is the whole of M7's exit criterion.
+ *
+ * **No network, no key, no cost.** Not by policy but by construction: the
+ * transport handed in throws on any call it was not scripted for, and a second
+ * test hands in one that throws on *every* call, so a code path that reached out
+ * would fail rather than quietly work on somebody's machine and not in CI.
+ *
+ * It is not cassette replay. #70 asks for replay mode, and replay needs recorded
+ * cassettes, which need live model calls that this environment cannot make —
+ * see the note at the end of the pull request. Everything replay would buy here
+ * except the recorded responses themselves is bought by a scripted transport:
+ * determinism, zero cost, and a run that cannot touch the network.
+ */
+
+vi.setConfig({ testTimeout: 15_000 })
+
+const root = new URL('../..', import.meta.url).pathname
+const fixture = (name: string): string =>
+  readFileSync(join(root, `tests/fixtures/pipeline/${name}.analysis.json`), 'utf8')
+
+const CLASSIFICATION = {
+  owner: 'app_code',
+  determinism: 'intermittent',
+  confidence: 0.91,
+  reasoning: 'the diff changes the reducer the failing assertion reads',
+  evidence: ['expected 1 to equal 2'],
+}
+
+/** Answers triage; refuses anything else, so an unexpected call is a failure and not a default. */
+const scripted = (
+  reply: unknown = CLASSIFICATION,
+  fail?: (n: number) => Error | undefined,
+): Transport & { calls: number } => {
+  const transport = {
+    calls: 0,
+    countInputTokens: () => Promise.resolve(1_000),
+    send: (request: ModelRequest): Promise<ModelResponse> => {
+      transport.calls += 1
+      const failure = fail?.(transport.calls)
+      if (failure !== undefined) return Promise.reject(failure)
+      if (request.schemaName !== 'classification') {
+        return Promise.reject(new Error(`unscripted call: ${request.schemaName}`))
+      }
+      return Promise.resolve({
+        raw: reply,
+        stopReason: 'end_turn' as const,
+        model: 'claude-opus-5',
+        usage: { inputTokens: 1_000, outputTokens: 200 },
+      })
+    },
+  }
+  return transport
+}
+
+interface Run {
+  code: number
+  report: string | undefined
+  files: string[]
+  calls: number
+}
+
+const run = async (
+  name: string,
+  over: { transport?: Transport & { calls: number }; argv?: string[] } = {},
+): Promise<Run> => {
+  const transport = over.transport ?? scripted()
+  const written: Record<string, string> = {}
+  const code = await main(over.argv ?? [], {
+    env: { ANTHROPIC_API_KEY: 'test' },
+    read: (p) => (p === 'analysis.json' ? fixture(name) : ''),
+    exists: (p) => p === 'analysis.json',
+    write: (p, contents) => {
+      written[p] = contents
+    },
+    log: () => undefined,
+    cassetteCount: () => 0,
+    transport,
+  })
+  return { code, report: written['report.md'], files: Object.keys(written), calls: transport.calls }
+}
+
+describe('a run with nothing wrong', () => {
+  it('makes no calls, writes no file, and exits 0', async () => {
+    const result = await run('green')
+    expect(result).toMatchObject({ code: 0, calls: 0, files: [] })
+    expect(result.report).toBeUndefined()
+  })
+})
+
+describe('a run with one failure', () => {
+  it('classifies exactly the failure, not the passing test beside it', async () => {
+    const result = await run('one-failure')
+    expect(result.code).toBe(0)
+    expect(result.calls).toBe(1)
+    expect(result.report).toContain('board › case 1')
+    expect(result.report).not.toContain('board › case 2')
+  })
+
+  it('reports the quadrant it was told', async () => {
+    expect((await run('one-failure')).report).toContain('**app_code+intermittent** 1')
+  })
+
+  it('writes exactly one file', async () => {
+    expect((await run('one-failure')).files).toEqual(['report.md'])
+  })
+
+  it('carries the header, the table and the footer', async () => {
+    const report = (await run('one-failure')).report ?? ''
+    expect(report).toContain('## Flaky-test triage')
+    expect(report).toContain('| Test | Quadrant | Confidence | Reason |')
+    expect(report).toContain('has not been scored yet')
+  })
+})
+
+describe('a run with many failures', () => {
+  /**
+   * Eleven, not the nine that failed. `selectForTriage` also picks a test that
+   * passed while it is still alternating with a live failure streak — which is
+   * the point of the clause, and a fixture that avoided it would be testing a
+   * narrower pipeline than the real one.
+   */
+  it('classifies every one of them', async () => {
+    const result = await run('many-failures')
+    expect(result.code).toBe(0)
+    expect(result.calls).toBe(11)
+    expect(result.report).toContain('**app_code+intermittent** 11')
+  })
+
+  /**
+   * Deterministic ordering regardless of completion order, which is what makes a
+   * report worth reading twice. Two runs of the same fixture are byte-identical.
+   */
+  it('produces the same document twice', async () => {
+    const [a, b] = await Promise.all([run('many-failures'), run('many-failures')])
+    expect(a.report).toBe(b.report)
+  })
+})
+
+describe('a run that exhausts its budget', () => {
+  it('still writes a report, and says which tests were never reached', async () => {
+    const result = await run('many-failures', { argv: ['--budget', '3000'] })
+    expect(result.code).toBe(0)
+    expect(result.report).toContain('unclassified')
+    expect(result.report).toContain('never reached')
+  })
+
+  it('stops calling once the budget refuses', async () => {
+    const result = await run('many-failures', { argv: ['--budget', '3000'] })
+    expect(result.calls).toBeLessThan(9)
+  })
+})
+
+describe('a run where a call fails part-way through', () => {
+  /**
+   * The pipeline analyses CI failures; being unavailable exactly when CI is
+   * unhealthy would be a poor joke.
+   */
+  it('delivers every other classification and one honest gap', async () => {
+    const result = await run('many-failures', {
+      transport: scripted(CLASSIFICATION, (n) =>
+        n === 4 ? new Error('429 rate limited') : undefined,
+      ),
+    })
+    expect(result.code).toBe(0)
+    expect(result.report).toContain('429 rate limited')
+    expect(result.report).toContain('**app_code+intermittent** 10')
+  })
+})
+
+describe('no network, by construction', () => {
+  /**
+   * Stronger than "no network call occurred": a transport that throws on every
+   * call means a code path that reached out would fail here rather than working
+   * quietly on somebody's machine and not in CI.
+   */
+  it('a transport that refuses everything still produces a report and exit 0', async () => {
+    const refusing = scripted(CLASSIFICATION, () => new Error('no network in this test'))
+    const result = await run('many-failures', { transport: refusing })
+    expect(result.code).toBe(0)
+    expect(result.files).toEqual(['report.md'])
+    expect(result.report).toContain('no network in this test')
+  })
+})


### PR DESCRIPTION
Closes #70's integration test. **The literal "replay mode" clause is not met and cannot be here** — the last section says why.

The unit tests cover each agent. This covers the wiring between them, which is where the interesting bugs live, and it is M7's exit criterion.

## All five scenarios

| Scenario | What it asserts |
|---|---|
| Zero failures | no calls, **no file**, exit 0 |
| One failure | the failure classified, the passing test beside it not |
| Many failures | **11** calls, per-quadrant counts, byte-identical across two runs |
| Budget exhaustion | dispatch stops, tests never reached are named |
| Mid-run API error | ten classifications and one honest gap |

Eleven, not the nine that failed. `selectForTriage` also picks a test that *passed* while it is still alternating with a live failure streak — that is the point of the clause, and a fixture that avoided it would be testing a narrower pipeline than the real one.

## No network, by construction

Not by policy. The transport handed in rejects anything it was not scripted for, and one test hands in a transport that rejects **everything**:

```ts
it('a transport that refuses everything still produces a report and exit 0', …)
```

A code path that reached out would fail here rather than work quietly on somebody's machine and not in CI.

## Determinism

Two runs of the same fixture produce byte-identical documents. That is the property that makes a report worth reading twice — and it is the one that a concurrency pool preserving completion order rather than input order would silently break.

216 ms, well inside the fifteen-second budget, in the standard unit job rather than behind a flag.

## What is not met

- [ ] **"entirely in replay mode"**

Replay needs recorded cassettes; recording needs live model calls; there is no `ANTHROPIC_API_KEY` here. **Nothing has been spent.**

Everything replay would buy — determinism, zero cost, a run that cannot touch the network — is bought by the scripted transport. What is missing is *real model responses*, and those arrive with #38, at which point this file's `scripted()` is replaced by `CassetteTransport` and the assertions stay as they are.
