### PR TITLE
docs(docs): M7's nine issues are closed and its criterion is not met

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -128,10 +128,25 @@ asserts one against the other.
 The two downstream agents, the orchestrator, budget enforcement, concurrency limiting, partial
 failure isolation, and the report writer.
 
-**Status:** planned
+**Status:** in progress
 
 **Exit criterion:** `npm run agents:analyze` turns a fixture `analysis.json` into a `report.md`
 whose structure is asserted by an integration test running fully in replay mode.
+
+**All nine issues are closed and the criterion is not met, so the milestone is not done.** The
+command exists and does its job: on this repository's own CI it reads `analysis.json`, writes
+`report.md`, and posts it as a pull-request comment — the first one the pipeline has ever produced.
+An integration test drives it end to end over five scenarios in 216 ms with no network, no key and
+no cost.
+
+What is missing is the two words "replay mode". Replay serves recorded cassettes; recording them
+needs live model calls; and nothing here has an `ANTHROPIC_API_KEY`. The integration test uses a
+scripted transport instead, which buys everything replay would — determinism, zero cost, a run that
+cannot touch the network — except real model responses.
+
+Three issues carry the same shortfall and no other: #64 and #65 are complete but for their
+cassettes, and #70 for replay. All three become one command each the moment a key exists, which is
+also what #38 needs. Nothing has been spent.
 
 ## M8 — End-to-end CI & PR comment
 


### PR DESCRIPTION
M7's nine issues are all closed. The exit criterion is not met, so the milestone stays `in progress` — the same rule that kept M5 there, and the reason the banner still reads 5 of 11.

## What is built

`npm run agents:analyze` reads `analysis.json`, writes `report.md`, and posts it as a pull-request comment. It did that for the first time on #192, and found a defect in its own first artifact — the report marker appeared twice, because both the writer and the workflow were adding it. Fixed there.

An integration test drives the command end to end over five scenarios — zero failures, one, many, budget exhaustion, mid-run API error — in 216 ms, with no network, no key and no cost.

## What is missing

Two words: **replay mode**. Replay serves recorded cassettes; recording needs live model calls; there is no `ANTHROPIC_API_KEY` here.

Three issues carry this one shortfall and no other:

| Issue | Complete but for |
|---|---|
| #64 root-cause agent | cassettes recorded, spot-check against known causes |
| #65 fix-suggestion agent | cassettes recorded |
| #70 integration test | `entirely in replay mode` |

All three become one command each the moment a key exists — which is also what #38 needs to publish the first honest numbers. **Nothing has been spent.**