### PR TITLE
feat(agents): every way the output got worse, said at the top

### DIFF
--- a/agents/report.test.ts
+++ b/agents/report.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { TriagedTest } from './pipeline.js'
 import {
   COMMENT_LIMIT,
+  DEGRADATIONS,
   TRUNCATION_NOTICE,
   escapeAgentText,
   fit,
@@ -208,6 +209,69 @@ describe('the footer', () => {
     expect(report).toContain('has not been scored yet')
     expect(report).toContain('unmeasured system')
   })
+})
+
+describe('the notices block', () => {
+  /**
+   * Silent degradation is the specific behaviour that turns a useful tool into a
+   * misleading one: the output looks the same, it is just quietly worse.
+   */
+  it('is absent entirely when the run was clean', () => {
+    expect(renderReport(input())).not.toContain('⚠️')
+  })
+
+  it('counts the unclassified, and says what that costs the counts above', () => {
+    const report = renderReport(
+      input({
+        triaged: [
+          row(),
+          row({ classification: undefined, unclassified: { reason: 'error', detail: 'boom' } }),
+        ],
+      }),
+    )
+    expect(report).toContain('1 test(s) went unclassified')
+    expect(report).toContain('not all of it')
+  })
+
+  it('names the budget when that is why rows are missing', () => {
+    const report = renderReport(
+      input({
+        triaged: [
+          row(),
+          row({ classification: undefined, unclassified: { reason: 'budget', detail: 'gone' } }),
+        ],
+      }),
+    )
+    expect(report).toContain('reached its token budget')
+  })
+
+  /** Passed in by the caller, which is the only thing that knows about credentials. */
+  it.each([
+    ['noKey', DEGRADATIONS.noKey, 'no credentials'],
+    ['noHistory', DEGRADATIONS.noHistory, 'reads as new'],
+    ['unreadableHistory', DEGRADATIONS.unreadableHistory, 'writing that file wrongly'],
+  ])('renders the %s notice', (_name, notice, phrase) => {
+    expect(renderReport(input({ notices: [notice] }))).toContain(phrase)
+  })
+
+  /**
+   * The truncation notice can only be known after the document is rendered, so
+   * it is added on a second pass rather than guessed at from a length.
+   */
+  it('adds itself when the report had to be cut', () => {
+    const many = Array.from({ length: 400 }, () => row())
+    const report = renderReport(input({ triaged: many }))
+    expect(report).toContain('truncated to fit GitHub')
+    expect(report.length).toBeLessThanOrEqual(COMMENT_LIMIT)
+  })
+
+  /** Every notice says what it means, not only what happened. */
+  it.each(Object.entries(DEGRADATIONS).filter(([, v]) => typeof v === 'string'))(
+    '%s explains the consequence',
+    (_name, notice) => {
+      expect(String(notice).length).toBeGreaterThan(80)
+    },
+  )
 })
 
 describe('fitting under GitHub’s comment limit', () => {

--- a/agents/report.ts
+++ b/agents/report.ts
@@ -56,6 +56,40 @@ const cell = (text: string, max = 120): string => {
   return flat.length <= max ? flat : `${flat.slice(0, max - 1)}…`
 }
 
+/**
+ * Every way this pipeline can produce partial output, and what each one costs
+ * the reader.
+ *
+ * Silent degradation is the specific behaviour that turns a useful tool into a
+ * misleading one: the output looks the same, it is just quietly worse. So each
+ * notice says not only what happened but what it means for the reliability of
+ * what follows — "no history" alone invites absence to be read as stability,
+ * which is exactly the misreading that costs the most.
+ *
+ * The block is absent entirely when the run was clean. A permanent banner is a
+ * banner people learn to skip, and then the one that mattered goes with it.
+ */
+export const DEGRADATIONS = {
+  noKey:
+    'The classifier did not run: no credentials were available to this job. Every failure below ' +
+    'is listed with the pipeline’s own signals and no verdict — nothing here has been classified.',
+  noHistory:
+    'The run had no history to read, so every test reads as new. `determinism` rests on this ' +
+    'run’s attempts alone, which is much weaker evidence than a sequence of runs.',
+  unreadableHistory:
+    'The run history existed and could not be read, so every test reads as new. That is a ' +
+    'stronger signal than a cache miss: something is writing that file wrongly.',
+  budget:
+    'The run reached its token budget. Tests it never reached are listed as unclassified rather ' +
+    'than omitted — a missing row would read as "nothing was wrong with this test".',
+  unclassified: (n: number): string =>
+    `${String(n)} test(s) went unclassified. Their rows say why. Read the counts above as covering ` +
+    'the rest of the run, not all of it.',
+  truncated:
+    'This report was truncated to fit GitHub’s comment limit. The full document is attached to ' +
+    'the workflow run as an artifact.',
+} as const
+
 export interface ReportInput {
   triaged: readonly TriagedTest[]
   commitSha: string
@@ -96,6 +130,35 @@ export function quadrantCounts(triaged: readonly TriagedTest[]): Record<string, 
 
 export function renderReport(input: ReportInput): string {
   const limit = input.limit ?? COMMENT_LIMIT
+
+  // Rendered once without the truncation notice to find out whether it is
+  // needed, then once more with it. Cheap, and the alternative is guessing at
+  // the length of a document that has not been written yet.
+  const first = assemble(input, [...(input.notices ?? []), ...derivedNotices(input)], limit)
+  if (!first.truncated) return first.text
+  return assemble(
+    input,
+    [...(input.notices ?? []), ...derivedNotices(input), DEGRADATIONS.truncated],
+    limit,
+  ).text
+}
+
+/** Degradations the report can see for itself, rather than being told about. */
+function derivedNotices(input: ReportInput): string[] {
+  const gaps = input.triaged.filter((r) => r.unclassified !== undefined).length
+  const notices: string[] = []
+  if (gaps > 0 && gaps < input.triaged.length) notices.push(DEGRADATIONS.unclassified(gaps))
+  if (input.triaged.some((r) => r.unclassified?.reason === 'budget')) {
+    notices.push(DEGRADATIONS.budget)
+  }
+  return notices
+}
+
+function assemble(
+  input: ReportInput,
+  notices: readonly string[],
+  limit: number,
+): { text: string; truncated: boolean } {
   const classified = input.triaged.filter((r) => r.classification !== undefined)
   const gaps = input.triaged.filter((r) => r.unclassified !== undefined)
 
@@ -107,7 +170,7 @@ export function renderReport(input: ReportInput): string {
     '',
     ...quadrantLines(input.triaged),
     ...gapLines(gaps),
-    ...(input.notices ?? []).map((n) => `> ⚠️ ${escapeAgentText(n)}`),
+    ...notices.map((n) => `> ⚠️ ${escapeAgentText(n)}`),
     '',
   ]
 
@@ -129,8 +192,9 @@ export function renderReport(input: ReportInput): string {
 
   const body = [...header, ...table, ...detailed, ...collapsed].join('\n')
   const footer = renderFooter(input)
+  const text = fit(body, footer, limit)
 
-  return fit(body, footer, limit)
+  return { text, truncated: text.includes(TRUNCATION_NOTICE) }
 }
 
 function quadrantLines(triaged: readonly TriagedTest[]): string[] {

--- a/agents/run.ts
+++ b/agents/run.ts
@@ -12,7 +12,7 @@ import { runContextFor } from './context.js'
 import { TokenBudget } from './model-client.js'
 import { hasWork } from './orchestrate.js'
 import { runPipeline, type PipelineDeps } from './pipeline.js'
-import { renderReport } from './report.js'
+import { DEGRADATIONS, renderReport } from './report.js'
 import { AnthropicTransport, type Transport } from './transport.js'
 
 /**
@@ -155,13 +155,12 @@ export async function main(argv: string[], deps: RunDeps = {}): Promise<number> 
   const countCassettes = deps.cassetteCount ?? ((): number => listCassettes().length)
   const credentials = credentialState(env, countCassettes())
 
+  // Every notice comes from one table, so the report and the command cannot
+  // describe the same degradation in two different sets of words.
   const notices: string[] = []
-  if (analysis.historySource === 'unreadable') {
-    notices.push('The run history could not be read, so every test reads as new.')
-  } else if (!analysis.historyAvailable) {
-    notices.push('The run had no history, so every test reads as new.')
-  }
-  if (credentials.notice !== undefined) notices.push(credentials.notice)
+  if (analysis.historySource === 'unreadable') notices.push(DEGRADATIONS.unreadableHistory)
+  else if (!analysis.historyAvailable) notices.push(DEGRADATIONS.noHistory)
+  if (!credentials.canRun) notices.push(credentials.notice ?? DEGRADATIONS.noKey)
 
   const triagePrompt = loadPrompt(CURRENT_PROMPT.triage)
 


### PR DESCRIPTION
Closes #74.

Silent degradation is the specific behaviour that turns a useful tool into a misleading one: **the output looks the same, it is just quietly worse.** So each notice says not only what happened but what it costs the reader.

```
> ⚠️ The run had no history to read, so every test reads as new. `determinism` rests on this
     run's attempts alone, which is much weaker evidence than a sequence of runs.
> ⚠️ 1 test(s) went unclassified. Their rows say why. Read the counts above as covering the
     rest of the run, not all of it.
```

"No history" alone invites absence to be read as *stability*, which is the misreading that costs the most.

## One table

`DEGRADATIONS` holds the wording. The command and the report used to describe the same degradation in two different sets of words, which is how a reader ends up unsure whether they are looking at two problems.

## Two the report works out for itself

How many tests went unclassified, and whether the budget is why. The other three — credentials, missing history, unreadable history — are only knowable by the caller that opened those things, so they are passed in.

## The truncation notice needed a second pass

Whether a document had to be cut cannot be known until it has been rendered. Guessing from a length would be a number that drifts the moment a section is added, so the report is assembled once to find out and once more to say so.

## Absent when clean

A permanent banner is one people learn to skip, and the one that mattered goes with it.

```ts
it('is absent entirely when the run was clean', () => {
  expect(renderReport(input())).not.toContain('⚠️')
})
```

Every notice is also asserted to be longer than 80 characters — not as a style rule, but because a notice that fits in a phrase has said what happened and not what it means.

1950 tests.