### PR TITLE
ci(ci): nothing waits on the analysis stages

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -315,6 +315,29 @@ The pipeline never fails the build because of its own problems. It degrades:
 | Malformed test report  | Zod error, pipeline step fails loudly — this one _should_ be noisy         |
 | Zero failures          | Skip the agent stage entirely, post nothing                                |
 
+### What the pipeline costs, in wall-clock
+
+Measured on run
+[32126433354](https://github.com/AKogut/ai-flaky-test-triage/actions/runs/32126433354), a full
+green pass on `main`:
+
+| Job                   | Duration  |
+| --------------------- | --------- |
+| Repository hygiene    | 18 s      |
+| Static analysis       | 48 s      |
+| Unit & contract tests | 37 s      |
+| E2E tests             | 65 s      |
+| Evaluation gate       | 18 s      |
+| Flakiness analysis    | 20 s      |
+| Agent triage          | 25 s      |
+| **Wall clock**        | **138 s** |
+
+The two analysis stages add 45 seconds of machine time and nothing to the critical path — they run
+after the suites, and nothing waits on them. That is the number to watch: the moment triage is on
+the path to a merge, somebody will want it switched off.
+
+Recorded here rather than left to be re-derived, so a regression is a diff rather than a memory.
+
 ## What is deliberately not here
 
 - **No agent loop.** Classification is a single decision with a fixed input. An agentic loop

--- a/tests/unit/history-cache.test.ts
+++ b/tests/unit/history-cache.test.ts
@@ -199,6 +199,44 @@ describe('the job that runs it', () => {
   })
 })
 
+describe('the analysis stages cannot fail the build', () => {
+  /**
+   * The property #71 exists to protect. A red X caused by the triage tool rather
+   * than by the tests would train everyone to ignore the check, which is the one
+   * outcome that makes the whole project useless.
+   *
+   * `continue-on-error` covers the job's own status. This covers the other half:
+   * nothing else may *depend* on them, because a required job that needs a
+   * failing one is blocked whatever that one's continue-on-error says.
+   */
+  it('no job waits on the analysis stages', () => {
+    const dependents = Object.entries(jobs).filter(([name, job]) => {
+      const needs = [job.needs ?? []].flat()
+      return name !== 'analyze' && (needs.includes('flakemetry') || needs.includes('analyze'))
+    })
+    expect(dependents.map(([name]) => name)).toEqual([])
+  })
+
+  it('both carry continue-on-error', () => {
+    for (const name of ['flakemetry', 'analyze']) {
+      expect(
+        (jobs[name] as { 'continue-on-error'?: boolean } | undefined)?.['continue-on-error'],
+        name,
+      ).toBe(true)
+    }
+  })
+
+  /**
+   * The agent job may wait on the flakemetry one — it consumes its artifact —
+   * but only under `always()`, or a flakemetry crash would silently skip triage
+   * rather than degrade it.
+   */
+  it('the agent job still runs when the stage before it failed', () => {
+    expect(jobs.analyze?.if).toContain('always()')
+    expect([jobs.analyze?.needs ?? []].flat()).toContain('flakemetry')
+  })
+})
+
 describe('what the job says out loud', () => {
   const reporting = steps('flakemetry').find((s) => s.name?.includes('cache returned'))?.run ?? ''
 


### PR DESCRIPTION
Closes #71.

The skeleton in `ci.yml` was written before the code existed, so its assumptions were untested. They have since been tested **by running** — across M6 and M7, on real pull requests:

| Assumption | Where it was exercised |
|---|---|
| Artifact names and download working directory | Flakiness analysis reading both reports, #183 |
| Cache restore keys across branches | a fresh branch restoring `main`'s history, #184 |
| `continue-on-error` × `always()` | Agent triage writing a report with no key, #192 |
| The comment upsert | one comment, edited in place across pushes, #192 → #196 |

## What was not asserted

The property the issue names as the one that matters: **the analysis stage must never fail the build.**

`continue-on-error` covers each job's own status. It does not cover the other half — a required job that `needs` a failing one is blocked whatever that one's `continue-on-error` says. So:

```ts
it('no job waits on the analysis stages', () => { … })
it('the agent job still runs when the stage before it failed', () => { … })
```

The second matters in the opposite direction: the agent job *may* wait on the flakemetry one, because it consumes its artifact — but only under `always()`, or a flakemetry crash would silently **skip** triage rather than degrade it.

## The number to watch

Measured on [run 32126433354](https://github.com/AKogut/ai-flaky-test-triage/actions/runs/32126433354), a full green pass on `main`:

| Job | Duration |
|---|---|
| Repository hygiene | 18 s |
| Static analysis | 48 s |
| Unit & contract tests | 37 s |
| E2E tests | 65 s |
| Evaluation gate | 18 s |
| Flakiness analysis | 20 s |
| Agent triage | 25 s |
| **Wall clock** | **138 s** |

The two analysis stages add 45 seconds of machine time and **nothing to the critical path**. Recorded in `docs/architecture.md` rather than left to be re-derived, so a regression is a diff rather than a memory — because the moment triage is on the path to a merge, somebody will want it switched off.

1953 tests.