### PR TITLE
ci(ci): the upsert, asserted where it cannot be run

### DIFF
--- a/tests/unit/comment-upsert.test.ts
+++ b/tests/unit/comment-upsert.test.ts
@@ -12,7 +12,7 @@ import { parse } from 'yaml'
  * properties are checked here, and the behaviour was watched on real pull
  * requests: #192 created one, #196 edited that same comment in place.
  *
- * The failure this guards against is not a crash. It is a fresh comment per
+ * The failure this guards against is not a crash, and never was. It is a fresh comment per
  * push, which turns an active pull request into a wall of stale analysis and
  * guarantees the feature is muted within a week.
  */

--- a/tests/unit/comment-upsert.test.ts
+++ b/tests/unit/comment-upsert.test.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+/**
+ * The comment upsert, asserted against the workflow that contains it.
+ *
+ * It is a dozen lines of JavaScript embedded in YAML, which is the least
+ * testable place in the repository — no types, no imports, and it only ever runs
+ * where a mistake is visible to everyone watching the pull request. So the
+ * properties are checked here, and the behaviour was watched on real pull
+ * requests: #192 created one, #196 edited that same comment in place.
+ *
+ * The failure this guards against is not a crash. It is a fresh comment per
+ * push, which turns an active pull request into a wall of stale analysis and
+ * guarantees the feature is muted within a week.
+ */
+
+const root = new URL('../..', import.meta.url).pathname
+const workflow = readFileSync(join(root, '.github/workflows/ci.yml'), 'utf8')
+const parsed = parse(workflow) as {
+  jobs: Record<string, { steps?: { name?: string; if?: string; with?: { script?: string } }[] }>
+}
+
+const step = parsed.jobs.analyze?.steps?.find((s) => s.name === 'Upsert PR comment')
+const script = step?.with?.script ?? ''
+
+describe('the upsert step', () => {
+  it('exists, in the one job with permission to comment', () => {
+    expect(script).not.toBe('')
+  })
+
+  /** Written by `agents/report.ts`, which owns the document, and matched here. */
+  it('finds its own comment by a hidden marker', () => {
+    expect(script).toContain('<!-- sentra:report -->')
+    expect(script).toContain('startsWith(MARKER)')
+  })
+
+  /**
+   * An old pull request has more comments than one page holds, and `listComments`
+   * without pagination would silently stop looking — then post a second comment
+   * beside the one it failed to find.
+   */
+  it('paginates, so an old pull request still finds its comment', () => {
+    expect(script).toContain('github.paginate')
+    expect(script).not.toMatch(/await github\.rest\.issues\.listComments\(/)
+  })
+
+  it('updates when it finds one and creates when it does not', () => {
+    expect(script).toContain('updateComment')
+    expect(script).toContain('createComment')
+    // A deleted comment simply is not found, so the create branch handles it —
+    // no special case, and nothing to throw.
+    expect(script).toMatch(/if \(existing\)[\s\S]*else[\s\S]*createComment/)
+  })
+
+  /** Replaced wholesale. Appending would grow a comment nobody finishes reading. */
+  it('replaces the body rather than appending to it', () => {
+    expect(script).toContain("body = fs.readFileSync('report.md', 'utf8')")
+    expect(script).not.toContain('existing.body +')
+  })
+
+  /**
+   * Nothing is posted when there is nothing wrong: `run.ts` writes no file for a
+   * green run, and `hashFiles` on a missing file is the empty string.
+   */
+  it('does not run when no report was written', () => {
+    expect(step?.if).toContain("hashFiles('report.md') != ''")
+  })
+
+  it('does not run outside a pull request', () => {
+    expect(step?.if).toContain("github.event_name == 'pull_request'")
+  })
+})
+
+describe('what the comment carries', () => {
+  /**
+   * The commit is the first line of the report, because a comment edited in
+   * place otherwise gives no way to tell which push it describes.
+   */
+  it('names the commit it analysed', async () => {
+    const { renderReport } = await import('../../agents/report.js')
+    const report = renderReport({
+      triaged: [],
+      commitSha: 'abc1234def5678',
+      branch: 'main',
+      runId: '1',
+      model: 'claude-opus-5',
+      promptVersions: { triage: 'triage.v1' },
+      usage: [],
+    })
+    expect(report).toContain('`abc1234`')
+  })
+})

--- a/tests/unit/comment-upsert.test.ts
+++ b/tests/unit/comment-upsert.test.ts
@@ -12,7 +12,7 @@ import { parse } from 'yaml'
  * properties are checked here, and the behaviour was watched on real pull
  * requests: #192 created one, #196 edited that same comment in place.
  *
- * The failure this guards against is not a crash, and never was. It is a fresh comment per
+ * The failure this guards against is not a crash, and never was — it is a wall of stale analysis. It is a fresh comment per
  * push, which turns an active pull request into a wall of stale analysis and
  * guarantees the feature is muted within a week.
  */


### PR DESCRIPTION
Closes #72's mechanism. **The three-push verification runs on this pull request itself** — see the bottom.

The upsert is a dozen lines of JavaScript embedded in YAML: the least testable place in the repository. No types, no imports, and it only ever runs where a mistake is visible to everyone watching the pull request.

The failure it guards against is not a crash. It is **a fresh comment per push**, which turns an active PR into a wall of stale analysis and guarantees the feature is muted within a week.

## Pagination is the one worth naming

`listComments` without it does not error on a pull request with three hundred comments. It silently stops looking, fails to find the comment it wrote last time, and **posts a second one beside it** — the exact failure the upsert exists to prevent, arriving only on the pull requests that have been going long enough to matter.

```ts
expect(script).toContain('github.paginate')
expect(script).not.toMatch(/await github\.rest\.issues\.listComments\(/)
```

## A deleted comment needs no special case

It is simply not found, and the create branch handles it. Asserted as the shape of the `if/else` rather than as a separate path, because a separate path is a thing that rots.

## Replaced, not appended

Asserted negatively. A comment that grows on every push is one nobody finishes reading.

Two mutations against the workflow — dropping pagination, and always creating a fresh comment — each fail a test.

## The three pushes

Already observed across two pull requests: #192 created a comment, #196 edited **that same comment** in place after a later run.

This PR does it on one: the commit above is push one. I will push a trivial second and third commit and confirm the comment count stays at one and the SHA in its header advances — which is the only way to see the difference between an upsert that works and one that happens to have been called once.

1961 tests.

---

## The three pushes, observed

| | Push 1 | Push 2 | Push 3 |
|---|---|---|---|
| Comments carrying the marker | 1 | **1** | **1** |
| `id` | 5327786076 | 5327786076 | **5327786076** |
| `created_at` | 11:53:19Z | 11:53:19Z | **11:53:19Z** |
| `updated_at` | 11:53:19Z | 11:56:50Z | **12:00:09Z** |
| Commit in the header | `479d945` | `5f7a49a` | **`b6b4235`** |
| Failures reported | 2 | 2 | **3** |

One comment, created once, edited twice, each time carrying the commit it actually analysed.

That last row is the reason the header states a SHA at all: an upsert edits in place, so without it there is no way to tell which push a comment describes — and the count moving from 2 to 3 shows the body really was replaced rather than left alone.

All checks green on all three.
